### PR TITLE
Add check for NOT NULL columns on target tables when specified as increasing or timestamp column for offsets.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnectorConfig.java
@@ -64,12 +64,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String INCREASING_COLUMN_NAME_CONFIG = "increasing.column.name";
   private static final String INCREASING_COLUMN_NAME_DOC =
       "The name of the strictly increasing column to use to detect new rows. Any empty value "
-      + "indicates the column should be autodetected by looking for an auto-incrementing column.";
+      + "indicates the column should be autodetected by looking for an auto-incrementing column. "
+      + "This column may not be nullable.";
   public static final String INCREASING_COLUMN_NAME_DEFAULT = "";
 
   public static final String TIMESTAMP_COLUMN_NAME_CONFIG = "timestamp.column.name";
   private static final String TIMESTAMP_COLUMN_NAME_DOC =
-      "The name of the timestamp column to use to detect new or modified rows.";
+      "The name of the timestamp column to use to detect new or modified rows. This column may "
+      + "not be nullable.";
   public static final String TIMESTAMP_COLUMN_NAME_DEFAULT = "";
 
   public static final String TABLE_POLL_INTERVAL_MS_CONFIG = "table.poll.interval.ms";

--- a/src/main/java/io/confluent/connect/jdbc/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcUtils.java
@@ -55,6 +55,7 @@ public class JdbcUtils {
   private static final int GET_TABLES_NAME_COLUMN = 3;
 
   private static final int GET_COLUMNS_COLUMN_NAME = 4;
+  private static final int GET_COLUMNS_IS_NULLABLE = 18;
   private static final int GET_COLUMNS_IS_AUTOINCREMENT = 23;
 
 
@@ -145,6 +146,21 @@ public class JdbcUtils {
       stmt.close();
     }
     return (matches == 1 ? result : null);
+  }
+
+  public static boolean isColumnNullable(Connection conn, String table, String column)
+      throws SQLException {
+    ResultSet rs = conn.getMetaData().getColumns(null, null, table, column);
+    if (rs.getMetaData().getColumnCount() > GET_COLUMNS_IS_NULLABLE) {
+      // Should only be one match
+      if (!rs.next()) {
+        return false;
+      }
+      String val = rs.getString(GET_COLUMNS_IS_NULLABLE);
+      return rs.getString(GET_COLUMNS_IS_NULLABLE).equals("YES");
+    }
+
+    return false;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskUpdateTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.jdbc;
 
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Test;
@@ -75,9 +76,36 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     assertRecordsTopic(records, TOPIC_PREFIX + SINGLE_TABLE_NAME);
   }
 
+  @Test(expected = ConnectException.class)
+  public void testIncreasingInvalidColumn() throws Exception {
+    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+
+    PowerMock.replayAll();
+
+    // Increasing column must be NOT NULL
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT");
+
+    startTask(null, "id", null);
+
+    PowerMock.verifyAll();
+  }
+
+  @Test(expected = ConnectException.class)
+  public void testTimestampInvalidColumn() throws Exception {
+    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+
+    PowerMock.replayAll();
+
+    // Timestamp column must be NOT NULL
+    db.createTable(SINGLE_TABLE_NAME, "modified", "TIMESTAMP");
+
+    startTask("modified", null, null);
+
+    PowerMock.verifyAll();
+  }
+
   @Test
   public void testManualIncreasing() throws Exception {
-
     expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();

--- a/src/test/java/io/confluent/connect/jdbc/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcUtilsTest.java
@@ -25,7 +25,9 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class JdbcUtilsTest {
 
@@ -83,5 +85,20 @@ public class JdbcUtilsTest {
                    "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY",
                    "bar", "INTEGER");
     assertEquals("id", JdbcUtils.getAutoincrementColumn(db.getConnection(), "mixed"));
+  }
+
+  @Test
+  public void testIsColumnNullable() throws Exception {
+    db.createTable("test", "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY", "bar", "INTEGER");
+    assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), "test", "id"));
+    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), "test", "bar"));
+
+    // Derby does not seem to allow null
+    db.createTable("tstest", "ts", "TIMESTAMP NOT NULL", "tsdefault", "TIMESTAMP",
+                   "tsnull", "TIMESTAMP DEFAULT NULL");
+    assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), "tstest", "ts"));
+    // The default for TIMESTAMP columns can vary between databases, but for Derby it is nullable
+    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), "tstest", "tsdefault"));
+    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), "tstest", "tsnull"));
   }
 }


### PR DESCRIPTION


Because this is checked before making any queries, this is only checked for
table-based copying. Custom queries would either require specifying a
table.column format for the check, which wouldn't guarantee it even matched up
with the query, or require parsing or executing the query to perform the
validation before normal polling could start.