### PR TITLE
CC-69: support nanoseconds precision for timestamp-based offset tracking

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceTask.java
@@ -45,9 +45,6 @@ public class JdbcSourceTask extends SourceTask {
 
   private static final Logger log = LoggerFactory.getLogger(JdbcSourceTask.class);
 
-  static final String INCREMENTING_FIELD = "incrementing";
-  static final String TIMESTAMP_FIELD = "timestamp";
-
   private Time time;
   private JdbcSourceTaskConfig config;
   private Connection db;
@@ -146,10 +143,6 @@ public class JdbcSourceTask extends SourceTask {
           throw new ConnectException("Unexpected query mode: " + queryMode);
       }
       Map<String, Object> offset = offsets == null ? null : offsets.get(partition);
-      Long incrementingOffset = offset == null ? null :
-                              (Long) offset.get(INCREMENTING_FIELD);
-      Long timestampOffset = offset == null ? null :
-                             (Long) offset.get(TIMESTAMP_FIELD);
 
       String topicPrefix = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
 
@@ -157,14 +150,13 @@ public class JdbcSourceTask extends SourceTask {
         tableQueue.add(new BulkTableQuerier(queryMode, tableOrQuery, topicPrefix));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, null, null, incrementingColumn, incrementingOffset, timestampDelayInterval));
+            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset, timestampDelayInterval));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, timestampOffset, null, null, timestampDelayInterval));
+            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset, timestampDelayInterval));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, timestampOffset,
-            incrementingColumn, incrementingOffset, timestampDelayInterval));
+            queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn, offset, timestampDelayInterval));
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
@@ -1,0 +1,86 @@
+package io.confluent.connect.jdbc;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TimestampIncrementingOffset {
+  private Long incrementingOffset;
+  private Timestamp timestampOffset;
+
+  public TimestampIncrementingOffset() {}
+
+  public TimestampIncrementingOffset(Timestamp ts, Long id) {
+    this.timestampOffset = ts;
+    this.incrementingOffset = id;
+  }
+
+  public long getIncrementingOffset() {
+    return incrementingOffset == null ? -1 : incrementingOffset;
+  }
+
+  public void setIncrementingOffset(Long incrementingOffset) {
+    if (incrementingOffset != null && incrementingOffset < -1)
+      throw new IllegalArgumentException("incrementingOffset must be -1 or non-negative");
+    this.incrementingOffset = incrementingOffset;
+  }
+
+  public Timestamp getTimestampOffset() {
+    return timestampOffset == null ? new Timestamp(0) : timestampOffset;
+  }
+
+  public void setTimestampOffset(Timestamp timestampOffset) {
+    this.timestampOffset = timestampOffset;
+  }
+
+  private static final String INCREMENTING_FIELD = "incrementing";
+  private static final String TIMESTAMP_MILLIS_FIELD = "timestamp_millis";
+  private static final String TIMESTAMP_NANOS_FIELD = "timestamp_nanos";
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> map = new HashMap<>();
+    if (incrementingOffset != null)
+      map.put(INCREMENTING_FIELD, incrementingOffset);
+    if (timestampOffset != null) {
+      map.put(TIMESTAMP_MILLIS_FIELD, timestampOffset.getTime());
+      map.put(TIMESTAMP_NANOS_FIELD, timestampOffset.getNanos());
+    }
+    return map;
+  }
+
+  public static TimestampIncrementingOffset fromMap(Map<String, ?> map) {
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset();
+    if (map == null || map.isEmpty())
+      return offset;
+    Object incr = map.get(INCREMENTING_FIELD);
+    if (incr != null)
+      offset.setIncrementingOffset((Long)incr);
+    Object millis = map.get(TIMESTAMP_MILLIS_FIELD);
+    if (millis != null) {
+      Timestamp ts = new Timestamp((Long)millis);
+      ts.setNanos((Integer)map.get(TIMESTAMP_NANOS_FIELD));
+      offset.setTimestampOffset(ts);
+    }
+    return offset;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    TimestampIncrementingOffset that = (TimestampIncrementingOffset) o;
+
+    if (incrementingOffset != null ? !incrementingOffset.equals(that.incrementingOffset) : that.incrementingOffset != null)
+      return false;
+    return timestampOffset != null ? timestampOffset.equals(that.timestampOffset) : that.timestampOffset == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = incrementingOffset != null ? incrementingOffset.hashCode() : 0;
+    result = 31 * result + (timestampOffset != null ? timestampOffset.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package io.confluent.connect.jdbc;
 
 import java.sql.Timestamp;
@@ -54,11 +70,11 @@ public class TimestampIncrementingOffset {
       return offset;
     Object incr = map.get(INCREMENTING_FIELD);
     if (incr != null)
-      offset.setIncrementingOffset((Long)incr);
+      offset.setIncrementingOffset((Long) incr);
     Object millis = map.get(TIMESTAMP_MILLIS_FIELD);
     if (millis != null) {
-      Timestamp ts = new Timestamp((Long)millis);
-      ts.setNanos((Integer)map.get(TIMESTAMP_NANOS_FIELD));
+      Timestamp ts = new Timestamp((Long) millis);
+      ts.setNanos((Integer) map.get(TIMESTAMP_NANOS_FIELD));
       offset.setTimestampOffset(ts);
     }
     return offset;

--- a/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
@@ -21,63 +21,56 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TimestampIncrementingOffset {
-  private Long incrementingOffset;
-  private Timestamp timestampOffset;
+  private static final String INCREMENTING_FIELD = "incrementing";
+  private static final String TIMESTAMP_FIELD = "timestamp";
+  private static final String TIMESTAMP_NANOS_FIELD = "timestamp_nanos";
 
-  public TimestampIncrementingOffset() {}
+  private final Long incrementingOffset;
+  private final Timestamp timestampOffset;
 
-  public TimestampIncrementingOffset(Timestamp ts, Long id) {
-    this.timestampOffset = ts;
-    this.incrementingOffset = id;
+  public TimestampIncrementingOffset() {
+    this.timestampOffset = null;
+    this.incrementingOffset = null;
+  }
+
+  public TimestampIncrementingOffset(Timestamp timestampOffset, Long incrementingOffset) {
+    this.timestampOffset = timestampOffset;
+    this.incrementingOffset = incrementingOffset;
   }
 
   public long getIncrementingOffset() {
     return incrementingOffset == null ? -1 : incrementingOffset;
   }
 
-  public void setIncrementingOffset(Long incrementingOffset) {
-    if (incrementingOffset != null && incrementingOffset < -1)
-      throw new IllegalArgumentException("incrementingOffset must be -1 or non-negative");
-    this.incrementingOffset = incrementingOffset;
-  }
-
   public Timestamp getTimestampOffset() {
     return timestampOffset == null ? new Timestamp(0) : timestampOffset;
   }
-
-  public void setTimestampOffset(Timestamp timestampOffset) {
-    this.timestampOffset = timestampOffset;
-  }
-
-  private static final String INCREMENTING_FIELD = "incrementing";
-  private static final String TIMESTAMP_MILLIS_FIELD = "timestamp_millis";
-  private static final String TIMESTAMP_NANOS_FIELD = "timestamp_nanos";
 
   public Map<String, Object> toMap() {
     Map<String, Object> map = new HashMap<>();
     if (incrementingOffset != null)
       map.put(INCREMENTING_FIELD, incrementingOffset);
     if (timestampOffset != null) {
-      map.put(TIMESTAMP_MILLIS_FIELD, timestampOffset.getTime());
+      map.put(TIMESTAMP_FIELD, timestampOffset.getTime());
       map.put(TIMESTAMP_NANOS_FIELD, timestampOffset.getNanos());
     }
     return map;
   }
 
   public static TimestampIncrementingOffset fromMap(Map<String, ?> map) {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset();
     if (map == null || map.isEmpty())
-      return offset;
-    Object incr = map.get(INCREMENTING_FIELD);
-    if (incr != null)
-      offset.setIncrementingOffset((Long) incr);
-    Object millis = map.get(TIMESTAMP_MILLIS_FIELD);
+      return new TimestampIncrementingOffset();
+
+    Long incr = (Long) map.get(INCREMENTING_FIELD);
+    Long millis = (Long) map.get(TIMESTAMP_FIELD);
+    Timestamp ts = null;
     if (millis != null) {
-      Timestamp ts = new Timestamp((Long) millis);
-      ts.setNanos((Integer) map.get(TIMESTAMP_NANOS_FIELD));
-      offset.setTimestampOffset(ts);
+      ts = new Timestamp(millis);
+      Integer nanos = (Integer) map.get(TIMESTAMP_NANOS_FIELD);
+      if (nanos != null)
+          ts.setNanos(nanos);
     }
-    return offset;
+    return new TimestampIncrementingOffset(ts, incr);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
@@ -28,11 +28,12 @@ public class TimestampIncrementingOffset {
   private final Long incrementingOffset;
   private final Timestamp timestampOffset;
 
-  public TimestampIncrementingOffset() {
-    this.timestampOffset = null;
-    this.incrementingOffset = null;
-  }
-
+  /**
+   * @param timestampOffset the timestamp offset.
+   *                        If null, {@link #getTimestampOffset()} will return {@code new Timestamp(0)}.
+   * @param incrementingOffset the incrementing offset.
+   *                           If null, {@link #getIncrementingOffset()} will return -1.
+   */
   public TimestampIncrementingOffset(Timestamp timestampOffset, Long incrementingOffset) {
     this.timestampOffset = timestampOffset;
     this.incrementingOffset = incrementingOffset;
@@ -47,7 +48,7 @@ public class TimestampIncrementingOffset {
   }
 
   public Map<String, Object> toMap() {
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new HashMap<>(3);
     if (incrementingOffset != null)
       map.put(INCREMENTING_FIELD, incrementingOffset);
     if (timestampOffset != null) {
@@ -59,7 +60,7 @@ public class TimestampIncrementingOffset {
 
   public static TimestampIncrementingOffset fromMap(Map<String, ?> map) {
     if (map == null || map.isEmpty())
-      return new TimestampIncrementingOffset();
+      return new TimestampIncrementingOffset(null, null);
 
     Long incr = (Long) map.get(INCREMENTING_FIELD);
     Long millis = (Long) map.get(TIMESTAMP_FIELD);

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskUpdateTest.java
@@ -240,11 +240,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testManualIncrementingRestoreOffset() throws Exception {
-    Map<String, Object> offset = new HashMap<>();
-    offset.put(JdbcSourceTask.INCREMENTING_FIELD, 1L);
-
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
     expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
-            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset));
+            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
 
@@ -264,10 +262,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testAutoincrementRestoreOffset() throws Exception {
-    Map<String, Object> offset = new HashMap<>();
-    offset.put(JdbcSourceTask.INCREMENTING_FIELD, 1L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
     expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
-            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset));
+            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
 
@@ -290,10 +287,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampRestoreOffset() throws Exception {
-    Map<String, Object> offset = new HashMap<>();
-    offset.put(JdbcSourceTask.TIMESTAMP_FIELD, 10L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
     expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
-            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset));
+            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
 
@@ -316,11 +312,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampAndIncrementingRestoreOffset() throws Exception {
-    Map<String, Object> offset = new HashMap<>();
-    offset.put(JdbcSourceTask.TIMESTAMP_FIELD, 10L);
-    offset.put(JdbcSourceTask.INCREMENTING_FIELD, 3L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
     expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
-            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset));
+            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
 
@@ -518,12 +512,14 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
           extracted = (T) (Long) rawTimestamp.getTime();
           break;
         }
-        case INCREMENTING_OFFSET:
-          extracted = (T)(record.sourceOffset()).get(JdbcSourceTask.INCREMENTING_FIELD);
+        case INCREMENTING_OFFSET: {
+          TimestampIncrementingOffset offset = TimestampIncrementingOffset.fromMap(record.sourceOffset());
+          extracted = (T) (Long) offset.getIncrementingOffset();
           break;
+        }
         case TIMESTAMP_OFFSET: {
-          java.util.Date rawTimestamp
-              = (java.util.Date) record.sourceOffset().get(JdbcSourceTask.TIMESTAMP_FIELD);
+          TimestampIncrementingOffset offset = TimestampIncrementingOffset.fromMap(record.sourceOffset());
+          Timestamp rawTimestamp = offset.getTimestampOffset();
           extracted = (T) (Long) rawTimestamp.getTime();
           break;
         }
@@ -556,8 +552,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
       Object incrementing = ((Struct)record.value()).get("id");
       long incrementingValue = incrementing instanceof Integer ? (long)(Integer)incrementing
                                                            : (Long)incrementing;
-      long offsetValue = (Long)(record.sourceOffset())
-          .get(JdbcSourceTask.INCREMENTING_FIELD);
+      long offsetValue = TimestampIncrementingOffset.fromMap(record.sourceOffset()).getIncrementingOffset();
       assertEquals(incrementingValue, offsetValue);
     }
   }
@@ -565,9 +560,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   private void assertTimestampOffsets(List<SourceRecord> records) {
     // Should use timestamps as offsets
     for(SourceRecord record : records) {
-      long timestampValue = ((java.util.Date) ((Struct)record.value()).get("modified")).getTime();
-      long offsetValue = (Long)(record.sourceOffset()
-          .get(JdbcSourceTask.TIMESTAMP_FIELD));
+      Timestamp timestampValue = (Timestamp) ((Struct)record.value()).get("modified");
+      Timestamp offsetValue = TimestampIncrementingOffset.fromMap(record.sourceOffset()).getTimestampOffset();
       assertEquals(timestampValue, offsetValue);
     }
   }

--- a/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class TimestampIncrementingOffsetTest {
@@ -86,34 +85,6 @@ public class TimestampIncrementingOffsetTest {
     assertEquals(zero, incOnly.getTimestampOffset());
     assertEquals(ts, tsInc.getTimestampOffset());
     assertEquals(nanos, nanosOffset.getTimestampOffset());
-  }
-
-  @Test
-  public void testSetTimestampOffset() {
-    assertNotEquals(unset, tsOnly);
-    assertEquals(ts, tsOnly.getTimestampOffset());
-    tsOnly.setTimestampOffset(null);
-    assertNotNull(tsOnly.getTimestampOffset());
-    assertEquals(new Timestamp(0), tsOnly.getTimestampOffset());
-    assertEquals(unset, tsOnly);
-    tsInc.setTimestampOffset(null);
-    assertNotNull(tsInc.getTimestampOffset());
-    assertEquals(new Timestamp(0), tsInc.getTimestampOffset());
-    assertEquals(incOnly, tsInc);
-  }
-
-  @Test
-  public void testSetIncrementingOffset() {
-    assertNotEquals(unset, incOnly);
-    assertEquals(id, incOnly.getIncrementingOffset());
-    incOnly.setIncrementingOffset(null);
-    assertNotNull(incOnly.getIncrementingOffset());
-    assertEquals(-1, incOnly.getIncrementingOffset());
-    assertEquals(unset, incOnly);
-    tsInc.setIncrementingOffset(null);
-    assertNotNull(tsInc.getIncrementingOffset());
-    assertEquals(-1, tsInc.getIncrementingOffset());
-    assertEquals(tsOnly, tsInc);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
@@ -1,0 +1,133 @@
+package io.confluent.connect.jdbc;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TimestampIncrementingOffsetTest {
+  private TimestampIncrementingOffset unset;
+  private TimestampIncrementingOffset tsOnly;
+  private TimestampIncrementingOffset incOnly;
+  private TimestampIncrementingOffset tsInc;
+  private TimestampIncrementingOffset nanosOffset;
+  private Timestamp ts;
+  private Timestamp nanos;
+  private long id;
+
+  @Before
+  public void setUp() {
+    ts = new Timestamp(100L);
+    id = 1000L;
+    unset = new TimestampIncrementingOffset();
+    tsOnly = new TimestampIncrementingOffset(ts, null);
+    incOnly = new TimestampIncrementingOffset(null, id);
+    tsInc = new TimestampIncrementingOffset(ts, id);
+
+    long millis = System.currentTimeMillis();
+    nanos = new Timestamp(millis);
+    nanos.setNanos((int)(millis % 1000) * 1000000 + 123456);
+    assertEquals(millis, nanos.getTime());
+    nanosOffset = new TimestampIncrementingOffset(nanos, null);
+  }
+
+  @Test
+  public void testDefaults() {
+    assertEquals(-1, unset.getIncrementingOffset());
+    assertNotNull(unset.getTimestampOffset());
+    assertEquals(0, unset.getTimestampOffset().getTime());
+    assertEquals(0, unset.getTimestampOffset().getNanos());
+  }
+
+  @Test
+  public void testToMap() {
+    assertEquals(0, unset.toMap().size());
+    assertEquals(2, tsOnly.toMap().size());
+    assertEquals(1, incOnly.toMap().size());
+    assertEquals(3, tsInc.toMap().size());
+    assertEquals(2, nanosOffset.toMap().size());
+  }
+
+  @Test
+  public void testGetIncrementingOffset() {
+    assertEquals(-1, unset.getIncrementingOffset());
+    assertEquals(-1, tsOnly.getIncrementingOffset());
+    assertEquals(id, incOnly.getIncrementingOffset());
+    assertEquals(id, tsInc.getIncrementingOffset());
+    assertEquals(-1, nanosOffset.getIncrementingOffset());
+  }
+
+  @Test
+  public void testGetTimestampOffset() {
+    assertNotNull(unset.getTimestampOffset());
+    Timestamp zero = new Timestamp(0);
+    assertEquals(zero, unset.getTimestampOffset());
+    assertEquals(ts, tsOnly.getTimestampOffset());
+    assertEquals(zero, incOnly.getTimestampOffset());
+    assertEquals(ts, tsInc.getTimestampOffset());
+    assertEquals(nanos, nanosOffset.getTimestampOffset());
+  }
+
+  @Test
+  public void testSetTimestampOffset() {
+    assertNotEquals(unset, tsOnly);
+    assertEquals(ts, tsOnly.getTimestampOffset());
+    tsOnly.setTimestampOffset(null);
+    assertNotNull(tsOnly.getTimestampOffset());
+    assertEquals(new Timestamp(0), tsOnly.getTimestampOffset());
+    assertEquals(unset, tsOnly);
+    tsInc.setTimestampOffset(null);
+    assertNotNull(tsInc.getTimestampOffset());
+    assertEquals(new Timestamp(0), tsInc.getTimestampOffset());
+    assertEquals(incOnly, tsInc);
+  }
+
+  @Test
+  public void testSetIncrementingOffset() {
+    assertNotEquals(unset, incOnly);
+    assertEquals(id, incOnly.getIncrementingOffset());
+    incOnly.setIncrementingOffset(null);
+    assertNotNull(incOnly.getIncrementingOffset());
+    assertEquals(-1, incOnly.getIncrementingOffset());
+    assertEquals(unset, incOnly);
+    tsInc.setIncrementingOffset(null);
+    assertNotNull(tsInc.getIncrementingOffset());
+    assertEquals(-1, tsInc.getIncrementingOffset());
+    assertEquals(tsOnly, tsInc);
+  }
+
+  @Test
+  public void testFromMap() {
+    assertEquals(unset, TimestampIncrementingOffset.fromMap(unset.toMap()));
+    assertEquals(tsOnly, TimestampIncrementingOffset.fromMap(tsOnly.toMap()));
+    assertEquals(incOnly, TimestampIncrementingOffset.fromMap(incOnly.toMap()));
+    assertEquals(tsInc, TimestampIncrementingOffset.fromMap(tsInc.toMap()));
+    assertEquals(nanosOffset, TimestampIncrementingOffset.fromMap(nanosOffset.toMap()));
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(nanosOffset, nanosOffset);
+    assertEquals(new TimestampIncrementingOffset(), new TimestampIncrementingOffset());
+    assertEquals(new TimestampIncrementingOffset(), new TimestampIncrementingOffset(null, null));
+    assertEquals(unset, new TimestampIncrementingOffset());
+    assertEquals(unset, new TimestampIncrementingOffset(null, null));
+
+    TimestampIncrementingOffset x = new TimestampIncrementingOffset(null, id);
+    assertEquals(x, incOnly);
+
+    x = new TimestampIncrementingOffset(ts, null);
+    assertEquals(x, tsOnly);
+
+    x = new TimestampIncrementingOffset(ts, id);
+    assertEquals(x, tsInc);
+
+    x = new TimestampIncrementingOffset(nanos, null);
+    assertEquals(x, nanosOffset);
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
@@ -25,24 +25,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class TimestampIncrementingOffsetTest {
-  private TimestampIncrementingOffset unset;
-  private TimestampIncrementingOffset tsOnly;
-  private TimestampIncrementingOffset incOnly;
-  private TimestampIncrementingOffset tsInc;
-  private TimestampIncrementingOffset nanosOffset;
-  private Timestamp ts;
+  private final Timestamp ts = new Timestamp(100L);
+  private final long id = 1000L;
+  private final TimestampIncrementingOffset unset = new TimestampIncrementingOffset(null, null);
+  private final TimestampIncrementingOffset tsOnly = new TimestampIncrementingOffset(ts, null);
+  private final TimestampIncrementingOffset incOnly = new TimestampIncrementingOffset(null, id);
+  private final TimestampIncrementingOffset tsInc = new TimestampIncrementingOffset(ts, id);
   private Timestamp nanos;
-  private long id;
+  private TimestampIncrementingOffset nanosOffset;
 
   @Before
   public void setUp() {
-    ts = new Timestamp(100L);
-    id = 1000L;
-    unset = new TimestampIncrementingOffset();
-    tsOnly = new TimestampIncrementingOffset(ts, null);
-    incOnly = new TimestampIncrementingOffset(null, id);
-    tsInc = new TimestampIncrementingOffset(ts, id);
-
     long millis = System.currentTimeMillis();
     nanos = new Timestamp(millis);
     nanos.setNanos((int)(millis % 1000) * 1000000 + 123456);
@@ -99,9 +92,7 @@ public class TimestampIncrementingOffsetTest {
   @Test
   public void testEquals() {
     assertEquals(nanosOffset, nanosOffset);
-    assertEquals(new TimestampIncrementingOffset(), new TimestampIncrementingOffset());
-    assertEquals(new TimestampIncrementingOffset(), new TimestampIncrementingOffset(null, null));
-    assertEquals(unset, new TimestampIncrementingOffset());
+    assertEquals(new TimestampIncrementingOffset(null, null), new TimestampIncrementingOffset(null, null));
     assertEquals(unset, new TimestampIncrementingOffset(null, null));
 
     TimestampIncrementingOffset x = new TimestampIncrementingOffset(null, id);

--- a/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/TimestampIncrementingOffsetTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package io.confluent.connect.jdbc;
 
 import org.junit.Before;


### PR DESCRIPTION
Originally, I ran into an issue where PostgreSQL timestamps have microsecond precision, but the offsets were stored with millisecond precision. Consequently, several records would _always_ be extracted on every poll because the extra microseconds of precision caused those records to _always_ be "newer" than the stored offset.

The logic to save and restore nanosecond precision on a `java.sql.Timestamp` was non-trivial, so I thought it would be good to abstract the offsets into its own class `TimestampIncrementingOffset`. Wrote some tests for it too.

Open to comments and suggestions.
Thanks!