### PR TITLE
Oracle NUMBER as incrementing column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <commons-io.version>2.4</commons-io.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <hsqldb.version>2.3.3</hsqldb.version>
     </properties>
 
     <repositories>
@@ -131,6 +132,13 @@
             <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>${hsqldb.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
+++ b/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
@@ -59,10 +59,6 @@ public class EmbeddedHSQLDB
     }
   }
 
-  public String getName() {
-    return name;
-  }
-
   private String getRawName() {
     return NAME_PREFIX + name;
   }
@@ -75,11 +71,7 @@ public class EmbeddedHSQLDB
   private String getShutdownUrl() {
     return PROTOCOL + getRawName() + ";shutdown=true";
   }
-
-  public Connection getConnection() {
-    return conn;
-  }
-
+  
   /**
    * Shorthand for creating a table
    * @param name name of the table

--- a/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
+++ b/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
@@ -55,7 +55,7 @@ public class EmbeddedHSQLDB
     try {
       conn = DriverManager.getConnection(getUrl());
     } catch (SQLException e) {
-      throw new RuntimeException("Couldn't get Oracle database connection", e);
+      throw new RuntimeException("Couldn't get HSqlDb database connection in Oracle compatibility mode.", e);
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
+++ b/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.sql.*;
 
 /**
- * Embedded HSqlDb server useful for testing against a real JDBC database.
+ * Embedded HSQLDB server useful for testing against a real JDBC database.
  */
 public class EmbeddedHSQLDB
 {
@@ -55,7 +55,18 @@ public class EmbeddedHSQLDB
     try {
       conn = DriverManager.getConnection(getUrl());
     } catch (SQLException e) {
-      throw new RuntimeException("Couldn't get HSqlDb database connection in Oracle compatibility mode.", e);
+      throw new RuntimeException("Couldn't get HSQLDB database connection in Oracle compatibility mode.", e);
+    }
+  }
+
+  /**
+   * Forces the registration of the JDBC driver into {@link DriverManager}.
+   */
+  public static void loadDriver() {
+    try {
+      Class.forName("org.hsqldb.jdbc.JDBCDriver");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Unable to load the HSQLDB JDBC driver.");
     }
   }
 
@@ -71,7 +82,7 @@ public class EmbeddedHSQLDB
   private String getShutdownUrl() {
     return PROTOCOL + getRawName() + ";shutdown=true";
   }
-  
+
   /**
    * Shorthand for creating a table
    * @param name name of the table

--- a/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
+++ b/src/test/java/io/confluent/connect/jdbc/EmbeddedHSQLDB.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
+import java.sql.*;
+
+/**
+ * Embedded HSqlDb server useful for testing against a real JDBC database.
+ */
+public class EmbeddedHSQLDB
+{
+
+  private static final Logger log = LoggerFactory.getLogger(EmbeddedHSQLDB.class);
+
+  // Try to avoid conflicting with other files since databases are created in the current
+  // directory. This also makes it easier to clean up if something goes wrong
+  private static final String NAME_PREFIX = "__test_database_";
+  private static final String PROTOCOL = "jdbc:hsqldb:mem:";
+
+  private String name;
+  private Connection conn;
+
+  public EmbeddedHSQLDB() {
+    this("default");
+  }
+
+  public EmbeddedHSQLDB(final String name) {
+    this.name = name;
+    // Make sure any existing on-disk data is cleared.
+    try {
+      dropDatabase();
+    } catch (IOException e) {
+      // Ignore
+    }
+    // And initialize by creating a connection
+    try {
+      conn = DriverManager.getConnection(getUrl());
+    } catch (SQLException e) {
+      throw new RuntimeException("Couldn't get Oracle database connection", e);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  private String getRawName() {
+    return NAME_PREFIX + name;
+  }
+
+  public String getUrl() {
+    String url = PROTOCOL + getRawName() + ";sql.syntax_ora=true";
+    return url;
+  }
+
+  private String getShutdownUrl() {
+    return PROTOCOL + getRawName() + ";shutdown=true";
+  }
+
+  public Connection getConnection() {
+    return conn;
+  }
+
+  /**
+   * Shorthand for creating a table
+   * @param name name of the table
+   * @param fields list of field names followed by specs specifications, e.g. "user-id",
+   *               "INT NOT NULL", "username", "VARCHAR(20)". May include other settings like
+   *               "PRIMARY KEY user_id"
+   */
+  public void createTable(String name, String... fields) throws SQLException {
+    if (fields.length == 0) {
+      throw new IllegalArgumentException("Must specify at least one column when creating a table");
+    }
+    if (fields.length % 2 != 0) {
+      throw new IllegalArgumentException("Must specify files in pairs of name followed by "
+                                         + "column spec");
+    }
+
+    StringBuilder statement = new StringBuilder();
+    statement.append("CREATE TABLE ");
+    statement.append(quoteCaseSensitive(name));
+    statement.append(" (");
+    for (int i = 0; i < fields.length; i += 2) {
+      if (i > 0) {
+        statement.append(", ");
+      }
+      statement.append(quoteCaseSensitive(fields[i]));
+      statement.append(" ");
+      statement.append(fields[i + 1]);
+    }
+    statement.append(")");
+
+    Statement stmt = conn.createStatement();
+    String statementStr = statement.toString();
+    log.debug("Creating table {} in {} with statement {}", name, this.name, statementStr);
+    stmt.execute(statementStr);
+  }
+
+  /**
+   * Drop a table.
+   * @param name
+   */
+  public void dropTable(String name) throws SQLException {
+    Statement stmt = conn.createStatement();
+    stmt.execute("DROP TABLE \"" + name + "\"");
+  }
+
+  public void close() throws SQLException {
+    conn.close();
+
+    // Derby requires more than just closing the connection to clear out the embedded data
+    try {
+      DriverManager.getConnection(getShutdownUrl());
+    } catch (SQLException se) {
+      // Clean shutdown always throws this exception
+      if (((se.getErrorCode() == 45000)
+          && ("08006".equals(se.getSQLState())))) {
+        // Note that for single database shutdown, the expected
+        // SQL state is "08006", and the error code is 45000.
+      } else {
+        throw se;
+      }
+    }
+  }
+
+  /**
+   * Drops the database by deleting it's files from disk. This assumes the working directory
+   * isn't changing so the database files can be found relative to the current working directory.
+   */
+  public void dropDatabase() throws IOException {
+    log.debug("Dropping database {} by removing directory {}", name);
+    //do nothing
+  }
+
+  /**
+   * Shorthand for creating a statement and executing a query.
+   * @param stmt the statement to execute
+   * @throws SQLException
+   */
+  public void execute(String stmt) throws SQLException {
+    conn.createStatement().execute(stmt);
+  }
+
+  /**
+   * Insert a row into a table.
+   *
+   * @param table the table to insert the record into
+   * @param columns list of column names followed by values
+   * @throws IllegalArgumentException
+   * @throws SQLException
+   */
+  public void insert(String table, Object... columns)
+      throws IllegalArgumentException, SQLException {
+    if (columns.length % 2 != 0) {
+      throw new IllegalArgumentException("Must specify values to insert as pairs of column name "
+                                         + "followed by values");
+    }
+
+    StringBuilder builder = new StringBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(quoteCaseSensitive(table));
+    builder.append(" (");
+    for (int i = 0; i < columns.length; i += 2) {
+      if (i > 0) {
+        builder.append(", ");
+      }
+      builder.append(quoteCaseSensitive(columns[i].toString()));
+    }
+    builder.append(") VALUES(");
+    for (int i = 1; i < columns.length; i += 2) {
+      if (i > 1) {
+        builder.append(", ");
+      }
+      builder.append(formatLiteral(columns[i]));
+    }
+    builder.append(")");
+    execute(builder.toString());
+  }
+
+  /**
+   * Delete rows matching a condition from a table
+   * @param table the table to remove rows from
+   * @param where the condition rows must match; be careful to correctly quote/escape any
+   *              strings, table names, or literal
+   * @throws SQLException
+   */
+  public void delete(String table, String where) throws SQLException {
+    StringBuilder builder = new StringBuilder();
+    builder.append("DELETE FROM ");
+    builder.append(quoteCaseSensitive(table));
+    if (where != null) {
+      builder.append(" WHERE ");
+      builder.append(where);
+    }
+    execute(builder.toString());
+  }
+
+  public void delete(String table, Condition where) throws SQLException {
+    delete(table, where.toString());
+  }
+
+
+  private static String quoteCaseSensitive(String name) {
+    return "\"" + name + "\"";
+  }
+
+  private static String formatLiteral(Object value) throws SQLException {
+    if (value == null) {
+      return "NULL";
+    } else if (value instanceof CharSequence) {
+      return "'" + value + "'";
+    } else if (value instanceof Blob) {
+      Blob blob = ((Blob) value);
+      byte[] blobData = blob.getBytes(1, (int) blob.length());
+      return "CAST(X'" + DatatypeConverter.printHexBinary(blobData) + "' AS BLOB)";
+    } else if (value instanceof byte[]) {
+      return "X'" + DatatypeConverter.printHexBinary((byte[]) value) + "'";
+    } else {
+      return value.toString();
+    }
+  }
+
+
+  public static class CaseSensitive {
+
+    private String name;
+
+    public CaseSensitive(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return quoteCaseSensitive(name);
+    }
+  }
+
+  public static class TableName extends CaseSensitive {
+
+    public TableName(String name) {
+      super(name);
+    }
+  }
+
+  public static class ColumnName extends CaseSensitive {
+
+    public ColumnName(String name) {
+      super(name);
+    }
+  }
+
+  /**
+   * Base class for WHERE clause conditions
+   */
+  public static class Condition {
+
+  }
+
+  public static class EqualsCondition extends Condition {
+
+    private Object left, right;
+
+    public EqualsCondition(Object left, Object right) {
+      this.left = left;
+      this.right = right;
+    }
+
+    @Override
+    public String toString() {
+      return left.toString() + " = " + right.toString();
+    }
+  }
+
+  // Literal value that should be used directly without any additional formatting.
+  public static class Literal {
+    String value;
+
+    public Literal(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskConversionOracleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskConversionOracleTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc;
+
+import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.sql.rowset.serial.SerialBlob;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// Tests conversion of Oracle specific data types, namely {@code NUMBER}.
+public class JdbcSourceTaskConversionOracleTest extends JdbcSourceTaskTestOracleBase {
+
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    task.start(singleTableConfig());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    task.stop();
+    super.tearDown();
+  }
+
+  @Test
+  public void testLong() throws Exception {
+    typeConversion("NUMBER(1,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(2,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(4,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(8,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(16,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(32,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(38,0)", false, 1, Schema.INT64_SCHEMA, 1l);
+  }
+
+  @Test
+  public void testNullableLong() throws Exception {
+    typeConversion("NUMBER(38,0)", true, 1, Schema.OPTIONAL_INT64_SCHEMA, 1l);
+    typeConversion("NUMBER(38,0)", true, null, Schema.OPTIONAL_INT64_SCHEMA, null);
+  }
+
+  // Derby has an XML type, but the JDBC driver doesn't implement any of the type bindings,
+
+  private void typeConversion(String sqlType, boolean nullable,
+                              Object sqlValue, Schema convertedSchema,
+                              Object convertedValue) throws Exception {
+    try
+    {
+      String sqlColumnSpec = sqlType;
+      if (!nullable)
+      {
+        sqlColumnSpec += " NOT NULL";
+      }
+      db.createTable(SINGLE_TABLE_NAME, "id", sqlColumnSpec);
+      db.insert(SINGLE_TABLE_NAME, "id", sqlValue);
+      List<SourceRecord> records = task.poll();
+      validateRecords(records, convertedSchema, convertedValue);
+    } finally
+    {
+      db.dropTable(SINGLE_TABLE_NAME);
+    }
+  }
+
+  /**
+   * Validates schema and type of returned record data. Assumes single-field values since this is
+   * only used for validating type information.
+   */
+  private void validateRecords(List<SourceRecord> records, Schema expectedFieldSchema,
+                               Object expectedValue) {
+    // Validate # of records and object type
+    assertEquals(1, records.size());
+    Object objValue = records.get(0).value();
+    assertTrue(objValue instanceof Struct);
+    Struct value = (Struct) objValue;
+
+    // Validate schema
+    Schema schema = value.schema();
+    assertEquals(Type.STRUCT, schema.type());
+    List<Field> fields = schema.fields();
+
+    assertEquals(1, fields.size());
+
+    Schema fieldSchema = fields.get(0).schema();
+    assertEquals(expectedFieldSchema, fieldSchema);
+    if (expectedValue instanceof byte[]) {
+      assertTrue(value.get(fields.get(0)) instanceof byte[]);
+      assertEquals(ByteBuffer.wrap((byte[])expectedValue),
+                   ByteBuffer.wrap((byte[])value.get(fields.get(0))));
+    } else {
+      assertEquals(expectedValue, value.get(fields.get(0)));
+    }
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskConversionOracleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskConversionOracleTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.sql.rowset.serial.SerialBlob;
@@ -37,6 +38,16 @@ import static org.junit.Assert.assertTrue;
 
 // Tests conversion of Oracle specific data types, namely {@code NUMBER}.
 public class JdbcSourceTaskConversionOracleTest extends JdbcSourceTaskTestOracleBase {
+
+  //forces the registration of the HSQLDB into java.sql.DriverManager
+  //when running these tests as part of the whole test suite, the first time
+  //DriverManager.getConnection("jdbc:hsqldb:mem") is called it complains with
+  //"No suitable driver found for jdbc:hsqldb:mem"
+  @BeforeClass
+  public static void loadDriver()
+  {
+    EmbeddedHSQLDB.loadDriver();
+  }
 
   @Before
   public void setup() throws Exception {

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskTestOracleBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceTaskTestOracleBase.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc;
+
+import io.confluent.common.utils.MockTime;
+import io.confluent.common.utils.Time;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.powermock.api.easymock.PowerMock;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for Oracle specific data type conversion tests.
+ */
+public class JdbcSourceTaskTestOracleBase
+{
+
+  protected static String SINGLE_TABLE_NAME = "test";
+  protected static Map<String, Object> SINGLE_TABLE_PARTITION = new HashMap<>();
+
+  static {
+    SINGLE_TABLE_PARTITION.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME);
+  }
+
+  protected static EmbeddedDerby.TableName SINGLE_TABLE
+      = new EmbeddedDerby.TableName(SINGLE_TABLE_NAME);
+
+  protected static final String TOPIC_PREFIX = "test-";
+
+  protected Time time;
+  protected SourceTaskContext taskContext;
+  protected JdbcSourceTask task;
+  protected EmbeddedHSQLDB db;
+
+  @Before
+  public void setup() throws Exception {
+    time = new MockTime();
+    task = new JdbcSourceTask(time);
+    taskContext = PowerMock.createMock(SourceTaskContext.class);
+    db = new EmbeddedHSQLDB();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    db.close();
+    db.dropDatabase();
+  }
+
+  protected Map<String, String> singleTableConfig() {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcSourceTaskConfig.TABLES_CONFIG, SINGLE_TABLE_NAME);
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
+    props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, TOPIC_PREFIX);
+    return props;
+  }
+  protected void initializeTask() {
+    task.initialize(taskContext);
+  }
+
+}


### PR DESCRIPTION
The implementation uses the scale of the NUMBER column to determine whether to create an `INT64_SCHEMA` or a `BYTES` schema.

In order to be able to have unit tests that are independent of a running Oracle instance, I made use of the HSQLDB in memory database using the Oracle compatibility mode.
As a result I had to create a second `EmbeddedHSQLDB` next to the existing `EmbeddedDerby` and an extra `JdbcSourceTaskTestOracleBase` that copies `JdbcSourceTaskTestBase`.

There is definitely room for refactoring like: 
* introducing a base class/interface for the embedded database classes,
* this way we could have one base `JdbcSourceTaskTestBase` class where every implementing class (i.e. `JdbcSourceTaskXXXTest`) can then define which database to use,
* lastly, the 2 big switch cases in `DataConverter` should be replaced by the use of polymorphism.

I did not want to attack these refactorings in this PR. Because I first wanted to have feedback about the provided implementation.

*Note*: this PR is created from the `v2.0.0.` tag.
