### PR TITLE
CC-243: use Long for nanos in offset map rather than Integer

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/TimestampIncrementingOffset.java
@@ -54,7 +54,7 @@ public class TimestampIncrementingOffset {
     }
     if (timestampOffset != null) {
       map.put(TIMESTAMP_FIELD, timestampOffset.getTime());
-      map.put(TIMESTAMP_NANOS_FIELD, timestampOffset.getNanos());
+      map.put(TIMESTAMP_NANOS_FIELD, (long) timestampOffset.getNanos());
     }
     return map;
   }
@@ -69,9 +69,9 @@ public class TimestampIncrementingOffset {
     Timestamp ts = null;
     if (millis != null) {
       ts = new Timestamp(millis);
-      Integer nanos = (Integer) map.get(TIMESTAMP_NANOS_FIELD);
+      Long nanos = (Long) map.get(TIMESTAMP_NANOS_FIELD);
       if (nanos != null) {
-        ts.setNanos(nanos);
+        ts.setNanos(nanos.intValue());
       }
     }
     return new TimestampIncrementingOffset(ts, incr);


### PR DESCRIPTION
if JSON converter is in use we can get a Long back even if an Integer is used at storage time