### PR TITLE
CC-227: merge in JDBC Sink 

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -24,7 +24,7 @@
 
   <!-- header -->
   <module name="RegexpHeader">
-    <property name="header" value="/\*\*\nCopyright .* Confluent Inc."/>
+    <property name="header" value="/\*\nCopyright .* Confluent Inc."/>
   </module>
 
   <module name="TreeWalker">

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
         <powermock.version>1.6.2</powermock.version>
         <derby.version>10.11.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
+        <sqlite.version>3.8.11.2</sqlite.version>
+        <mockito.version>1.10.19</mockito.version>
+        <licenses.version>3.1.0-SNAPSHOT</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
@@ -76,11 +79,11 @@
             <version>${kafka.version}</version>
         </dependency>
 
-        <!-- JDBC drivers, only included in runtime so they get packaged -->
+         <!-- JDBC drivers, only included in runtime so they get packaged -->
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.8.11.2</version>
+            <version>${sqlite.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -90,6 +93,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>${sqlite.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -124,6 +133,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -164,6 +178,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
+                    <!-- FIXME: because of impossible to reset PowerMock.mockStatic(DriverManager.class) -->
+                    <reuseForks>false</reuseForks>
                     <argLine>-Djava.awt.headless=true</argLine>
                 </configuration>
             </plugin>
@@ -211,6 +227,106 @@
                                 <descriptor>src/assembly/standalone.xml</descriptor>
                             </descriptors>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>licenses-package</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>create-licenses</id>
+                                <configuration>
+                                    <mainClass>io.confluent.licenses.LicenseFinder</mainClass>
+                                    <arguments>
+                                        <!-- Note use of development instead of package so we pick up all dependencies. -->
+                                        <argument>-i ${project.build.directory}/${project.build.finalName}-package/share/java/kafka-connect-jdbc</argument>
+                                        <argument>-o ${project.basedir}/licenses</argument>
+                                        <argument>-f</argument>
+                                        <argument>-h ${project.build.directory}/${project.build.finalName}-package/share/doc/kafka-connect-jdbc/licenses.html</argument>
+                                        <argument>-l ${project.build.directory}/${project.build.finalName}-package/share/doc/kafka-connect-jdbc/licenses</argument>
+                                        <argument>-n ${project.build.directory}/${project.build.finalName}-package/share/doc/kafka-connect-jdbc/notices</argument>
+                                        <argument>-t ${project.name}</argument>
+                                        <argument>-x licenses-${licenses.version}.jar</argument>
+                                    </arguments>
+                                </configuration>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <includeProjectDependencies>true</includeProjectDependencies>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <executableDependency>
+                                <groupId>io.confluent</groupId>
+                                <artifactId>licenses</artifactId>
+                            </executableDependency>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.confluent</groupId>
+                                <artifactId>licenses</artifactId>
+                                <version>${licenses.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>licenses-source</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>create-licenses</id>
+                                <configuration>
+                                    <mainClass>io.confluent.licenses.LicenseFinder</mainClass>
+                                    <arguments>
+                                        <!-- Note use of development instead of package so we pick up all dependencies. -->
+                                        <argument>-i ${project.build.directory}/${project.build.finalName}-development/share/java/kafka-connect-jdbc</argument>
+                                        <argument>-o ${project.basedir}/licenses</argument>
+                                        <argument>-f</argument>
+                                        <argument>-h ${project.basedir}/licenses.html</argument>
+                                        <argument>-l ${project.basedir}/licenses</argument>
+                                        <argument>-n ${project.basedir}/notices</argument>
+                                        <argument>-t ${project.name}</argument>
+                                        <argument>-x licenses-${licenses.version}.jar</argument>
+                                    </arguments>
+                                </configuration>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <includeProjectDependencies>true</includeProjectDependencies>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <executableDependency>
+                                <groupId>io.confluent</groupId>
+                                <artifactId>licenses</artifactId>
+                            </executableDependency>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.confluent</groupId>
+                                <artifactId>licenses</artifactId>
+                                <version>${licenses.version}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <powermock.version>1.6.2</powermock.version>
         <derby.version>10.11.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
-        <sqlite.version>3.8.11.2</sqlite.version>
         <mockito.version>1.10.19</mockito.version>
         <licenses.version>3.1.0-SNAPSHOT</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -83,7 +82,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>${sqlite.version}</version>
+            <version>3.8.11.2</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -93,12 +92,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>${sqlite.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc;
+
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.JdbcSinkTask;
+
+public final class JdbcSinkConnector extends SinkConnector {
+  private static final Logger log = LoggerFactory.getLogger(JdbcSinkConnector.class);
+
+  private Map<String, String> configProps;
+
+  public Class<? extends Task> taskClass() {
+    return JdbcSinkTask.class;
+  }
+
+  @Override
+  public List<Map<String, String>> taskConfigs(int maxTasks) {
+    log.info("Setting task configurations for {} workers.", maxTasks);
+    final List<Map<String, String>> configs = new ArrayList<>(maxTasks);
+    for (int i = 0; i < maxTasks; ++i) {
+      configs.add(configProps);
+    }
+    return configs;
+  }
+
+  @Override
+  public void start(Map<String, String> props) {
+    configProps = props;
+  }
+
+  @Override
+  public void stop() {
+  }
+
+  @Override
+  public ConfigDef config() {
+    return JdbcSinkConfig.CONFIG_DEF;
+  }
+
+  @Override
+  public Config validate(Map<String, String> connectorConfigs) {
+    // TODO cross-fields validation here: pkFields against the pkMode
+    return super.validate(connectorConfigs);
+  }
+
+  @Override
+  public String version() {
+    // TODO switch away to whatever connector-jdbc is doing
+    return getClass().getPackage().getImplementationVersion();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -36,6 +36,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import io.confluent.connect.jdbc.source.JdbcSourceTask;
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+import io.confluent.connect.jdbc.source.TableMonitorThread;
 import io.confluent.connect.jdbc.util.StringUtils;
 import io.confluent.connect.jdbc.util.Version;
 
@@ -154,6 +158,6 @@ public class JdbcSourceConnector extends SourceConnector {
 
   @Override
   public ConfigDef config() {
-    return JdbcSourceConnectorConfig.config;
+    return JdbcSourceConnectorConfig.CONFIG_DEF;
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.dialect.DbDialect;
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
+
+public class BufferedRecords {
+  private static final Logger log = LoggerFactory.getLogger(BufferedRecords.class);
+
+  private final String tableName;
+  private final JdbcSinkConfig config;
+  private final DbDialect dbDialect;
+  private final DbStructure dbStructure;
+  private final Connection connection;
+
+  private List<SinkRecord> records = new ArrayList<>();
+  private SchemaPair currentSchemaPair;
+  private FieldsMetadata fieldsMetadata;
+  private PreparedStatement preparedStatement;
+  private PreparedStatementBinder preparedStatementBinder;
+
+  public BufferedRecords(JdbcSinkConfig config, String tableName, DbDialect dbDialect, DbStructure dbStructure, Connection connection) {
+    this.tableName = tableName;
+    this.config = config;
+    this.dbDialect = dbDialect;
+    this.dbStructure = dbStructure;
+    this.connection = connection;
+  }
+
+  public List<SinkRecord> add(SinkRecord record) throws SQLException {
+    final SchemaPair schemaPair = new SchemaPair(record.keySchema(), record.valueSchema());
+
+    if (currentSchemaPair == null) {
+      currentSchemaPair = schemaPair;
+      // re-initialize everything that depends on the record schema
+      fieldsMetadata = FieldsMetadata.extract(tableName, config.pkMode, config.pkFields, currentSchemaPair);
+      dbStructure.createOrAmendIfNecessary(config, connection, tableName, fieldsMetadata);
+      final String insertSql = getInsertSql();
+      log.debug("insertion sql:{}", config.insertMode, insertSql);
+      preparedStatement = connection.prepareStatement(insertSql);
+      preparedStatementBinder = new PreparedStatementBinder(preparedStatement, config.pkMode, schemaPair, fieldsMetadata);
+    }
+
+    final List<SinkRecord> flushed;
+    if (currentSchemaPair.equals(schemaPair)) {
+      // Continue with current batch state
+      records.add(record);
+      if (records.size() >= config.batchSize) {
+        flushed = flush();
+      } else {
+        flushed = Collections.emptyList();
+      }
+    } else {
+      // Each batch needs to have the same SchemaPair, so get the buffered records out, reset state and re-attempt the add
+      flushed = flush();
+      currentSchemaPair = null;
+      flushed.addAll(add(record));
+    }
+    return flushed;
+  }
+
+  public List<SinkRecord> flush() throws SQLException {
+    if (records.isEmpty()) {
+      return new ArrayList<>();
+    }
+    for (SinkRecord record : records) {
+      preparedStatementBinder.bindRecord(record);
+    }
+    int totalUpdateCount = 0;
+    for (int updateCount : preparedStatement.executeBatch()) {
+      totalUpdateCount += updateCount;
+    }
+    if (totalUpdateCount != records.size()) {
+      switch (config.insertMode) {
+        case INSERT:
+          throw new ConnectException(String.format("Update count (%d) did not sum up to total number of records inserted (%d)",
+                                                   totalUpdateCount, records.size()));
+        case UPSERT:
+          log.trace("Upserted records:{} resulting in in totalUpdateCount:{}", records.size(), totalUpdateCount);
+      }
+    }
+
+    final List<SinkRecord> flushedRecords = records;
+    records = new ArrayList<>();
+    return flushedRecords;
+  }
+
+  private String getInsertSql() {
+    switch (config.insertMode) {
+      case INSERT:
+        return dbDialect.getInsert(tableName, fieldsMetadata.keyFieldNames, fieldsMetadata.nonKeyFieldNames);
+      case UPSERT:
+        if (fieldsMetadata.keyFieldNames.isEmpty()) {
+          throw new ConnectException(String.format(
+              "Write to table '%s' in UPSERT mode requires key field names to be known, check the primary key configuration", tableName
+          ));
+        }
+        return dbDialect.getUpsertQuery(tableName, fieldsMetadata.keyFieldNames, fieldsMetadata.nonKeyFieldNames);
+      default:
+        throw new ConnectException("Invalid insert mode");
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbMetadataQueries.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbMetadataQueries.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
+
+public abstract class DbMetadataQueries {
+  private static final Logger log = LoggerFactory.getLogger(DbMetadataQueries.class);
+
+  public static boolean tableExists(final Connection connection, final String tableName) throws SQLException {
+    final String catalog = connection.getCatalog();
+
+    final DatabaseMetaData meta = connection.getMetaData();
+
+    final String product = meta.getDatabaseProductName();
+    final String schema = getSchema(connection, product);
+
+    log.info("Checking table:{} exists for product:{} schema:{} catalog:", tableName, product, schema, catalog);
+
+    try (ResultSet rs = meta.getTables(catalog, schema, tableName, new String[]{"TABLE"})) {
+      final boolean exists = rs.next();
+      log.info("product:{} schema:{} catalog:{} -- table:{} is {}", product, schema, catalog, tableName, exists ? "present" : "absent");
+      return exists;
+    }
+  }
+
+  public static Map<String, DbTable> allTables(final Connection connection) throws SQLException {
+    final Map<String, DbTable> tables = new HashMap<>();
+    final String catalog = connection.getCatalog();
+    final DatabaseMetaData dbMetadata = connection.getMetaData();
+    final ResultSet tablesRs = dbMetadata.getTables(catalog, null, null, new String[]{"TABLE"});
+    while (tablesRs.next()) {
+      final String tableName = tablesRs.getString("TABLE_NAME");
+      final List<DbTableColumn> columns = DbMetadataQueries.columns(connection, tableName);
+      tables.put(tableName, new DbTable(tableName, columns));
+    }
+    return tables;
+  }
+
+  public static DbTable table(final Connection connection, final String tableName) throws SQLException {
+    return new DbTable(tableName, columns(connection, tableName));
+  }
+
+  public static List<DbTableColumn> columns(final Connection connection, final String tableName) throws SQLException {
+    final DatabaseMetaData dbMetaData = connection.getMetaData();
+    final String product = dbMetaData.getDatabaseProductName();
+    final String catalog = connection.getCatalog();
+
+    final String schema = getSchema(connection, product);
+    final String tableNameForQuery = product.equalsIgnoreCase("oracle") ? tableName.toUpperCase() : tableName;
+
+    log.info("Querying column metadata for product:{} schema:{} catalog:{} table:{}", product, schema, catalog, tableNameForQuery);
+
+    final Set<String> pkColumns = new HashSet<>();
+    try (final ResultSet primaryKeysResultSet = dbMetaData.getPrimaryKeys(catalog, schema, tableNameForQuery)) {
+      while (primaryKeysResultSet.next()) {
+        final String colName = primaryKeysResultSet.getString("COLUMN_NAME");
+        pkColumns.add(colName);
+      }
+    }
+
+    final List<DbTableColumn> columns = new ArrayList<>();
+    try (final ResultSet columnsResultSet = dbMetaData.getColumns(catalog, schema, tableNameForQuery, null)) {
+      while (columnsResultSet.next()) {
+        final String colName = columnsResultSet.getString("COLUMN_NAME");
+        final int sqlType = columnsResultSet.getInt("DATA_TYPE");
+        final boolean isPk = pkColumns.contains(colName);
+        final boolean isNullable = !isPk // SQLite can report PK's as nullable
+                                   && Objects.equals("YES", columnsResultSet.getString("IS_NULLABLE"));
+        columns.add(new DbTableColumn(colName, isPk, isNullable, sqlType));
+      }
+    }
+    return columns;
+  }
+
+  private static String getSchema(final Connection connection, final String product) throws SQLException {
+    if (product.equalsIgnoreCase("oracle")) {
+      // Use SQL to retrieve the database name for Oracle, apparently the JDBC API doesn't work as expected
+      try (
+          Statement statement = connection.createStatement();
+          ResultSet rs = statement.executeQuery("select sys_context('userenv','current_schema') x from dual")
+      ) {
+        if (rs.next()) {
+          return rs.getString("x").toUpperCase();
+        } else {
+          throw new SQLException("Failed to determine Oracle schema");
+        }
+      }
+    } else if (product.toLowerCase().startsWith("postgre")) {
+      return connection.getSchema();
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.confluent.connect.jdbc.sink.dialect.DbDialect;
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.sink.metadata.TableMetadataLoadingCache;
+
+public class DbStructure {
+  private final static Logger log = LoggerFactory.getLogger(DbStructure.class);
+
+  private final TableMetadataLoadingCache tableMetadataLoadingCache = new TableMetadataLoadingCache();
+
+  private final DbDialect dbDialect;
+
+  public DbStructure(DbDialect dbDialect) {
+    this.dbDialect = dbDialect;
+  }
+
+  /**
+   * @return whether a DDL operation was performed
+   * @throws SQLException if a DDL operation was deemed necessary but failed
+   */
+  public boolean createOrAmendIfNecessary(
+      final JdbcSinkConfig config,
+      final Connection connection,
+      final String tableName,
+      final FieldsMetadata fieldsMetadata
+  ) throws SQLException {
+    if (tableMetadataLoadingCache.get(connection, tableName) == null) {
+      try {
+        create(config, connection, tableName, fieldsMetadata);
+      } catch (SQLException sqle) {
+        log.warn("Create failed, will attempt amend if table already exists", sqle);
+        if (DbMetadataQueries.tableExists(connection, tableName)) {
+          tableMetadataLoadingCache.refresh(connection, tableName);
+        } else {
+          throw sqle;
+        }
+      }
+    }
+    return amendIfNecessary(config, connection, tableName, fieldsMetadata, config.maxRetries);
+  }
+
+  /**
+   * @throws SQLException if CREATE failed
+   */
+  void create(
+      final JdbcSinkConfig config,
+      final Connection connection,
+      final String tableName,
+      final FieldsMetadata fieldsMetadata
+  ) throws SQLException {
+    if (!config.autoCreate) {
+      throw new ConnectException(String.format("Table %s is missing and auto-creation is disabled", tableName));
+    }
+    final String sql = dbDialect.getCreateQuery(tableName, fieldsMetadata.allFields.values());
+    log.info("Creating table:{} with SQL: {}", tableName, sql);
+    try (Statement statement = connection.createStatement()) {
+      statement.executeUpdate(sql);
+      connection.commit();
+    }
+    tableMetadataLoadingCache.refresh(connection, tableName);
+  }
+
+  /**
+   * @return whether an ALTER was successfully performed
+   * @throws SQLException if ALTER was deemed necessary but failed
+   */
+  boolean amendIfNecessary(
+      final JdbcSinkConfig config,
+      final Connection connection,
+      final String tableName,
+      final FieldsMetadata fieldsMetadata,
+      final int maxRetries
+  ) throws SQLException {
+    // NOTE:
+    //   The table might have extra columns defined (hopefully with default values), which is not a case we check for here.
+    //   We also don't check if the data types for columns that do line-up are compatible.
+
+    final DbTable tableMetadata = tableMetadataLoadingCache.get(connection, tableName);
+    final Map<String, DbTableColumn> dbColumns = tableMetadata.columns;
+
+// FIXME: SQLite JDBC driver seems to not always return the PK column names?
+//    if (!tableMetadata.getPrimaryKeyColumnNames().equals(fieldsMetadata.keyFieldNames)) {
+//      throw new ConnectException(String.format(
+//          "Table %s has different primary key columns - database (%s), desired (%s)",
+//          tableName, tableMetadata.getPrimaryKeyColumnNames(), fieldsMetadata.keyFieldNames
+//      ));
+//    }
+
+    final Set<SinkRecordField> missingFields = missingFields(fieldsMetadata.allFields.values(), dbColumns.keySet());
+
+    if (missingFields.isEmpty()) {
+      return false;
+    }
+
+    if (!config.autoEvolve) {
+      throw new ConnectException(String.format("Table %s is missing fields (%s) and auto-evolution is disabled", tableName, missingFields));
+    }
+
+    final List<String> amendTableQueries = dbDialect.getAlterTable(tableName, missingFields);
+    log.info("Amending table to add missing fields:{} maxRetries:{} with SQL: {}", missingFields, maxRetries, amendTableQueries);
+    try (Statement statement = connection.createStatement()) {
+      for (String amendTableQuery : amendTableQueries) {
+        statement.executeUpdate(amendTableQuery);
+      }
+      connection.commit();
+    } catch (SQLException sqle) {
+      if (maxRetries <= 0) {
+        throw new ConnectException(
+            String.format("Failed to amend table '%s' to add missing fields: %s", tableName, missingFields),
+            sqle
+        );
+      }
+      log.warn("Amend failed, re-attempting", sqle);
+      tableMetadataLoadingCache.refresh(connection, tableName);
+      // Perhaps there was a race with other tasks to add the columns
+      return amendIfNecessary(
+          config,
+          connection,
+          tableName,
+          fieldsMetadata,
+          maxRetries - 1
+      );
+    }
+
+    tableMetadataLoadingCache.refresh(connection, tableName);
+    return true;
+  }
+
+  Set<SinkRecordField> missingFields(Collection<SinkRecordField> fields, Set<String> dbColumnNames) {
+    final Set<SinkRecordField> missingFields = new HashSet<>();
+    for (SinkRecordField field : fields) {
+      if (!dbColumnNames.contains(field.name)) {
+        missingFields.add(field);
+      }
+    }
+    return missingFields;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.dialect.DbDialect;
+
+public class JdbcDbWriter {
+  private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
+
+  private final Map<String, JdbcSinkConfig> contextualConfigCache = new HashMap<>();
+
+  private final JdbcSinkConfig config;
+  private final DbDialect dbDialect;
+  private final DbStructure dbStructure;
+
+  Connection connection;
+
+  JdbcDbWriter(final JdbcSinkConfig config) {
+    this.config = config;
+    dbDialect = DbDialect.fromConnectionString(config.connectionUrl);
+    dbStructure = new DbStructure(dbDialect);
+  }
+
+  void write(final Collection<SinkRecord> records) throws SQLException {
+    initConnection();
+
+    final Map<String, BufferedRecords> bufferByTable = new HashMap<>();
+    for (SinkRecord record : records) {
+      final String table = destinationTable(record.topic());
+      BufferedRecords buffer = bufferByTable.get(table);
+      if (buffer == null) {
+        buffer = new BufferedRecords(cachedContextualConfig(table), table, dbDialect, dbStructure, connection);
+        bufferByTable.put(table, buffer);
+      }
+      buffer.add(record);
+    }
+    for (BufferedRecords buffer : bufferByTable.values()) {
+      buffer.flush();
+    }
+    connection.commit();
+  }
+
+  void initConnection() throws SQLException {
+    if (connection == null) {
+      connection = newConnection();
+    } else if (!connection.isValid(3000)) {
+      log.info("The database connection is invalid. Reconnecting...");
+      closeQuietly();
+      connection = newConnection();
+    }
+    connection.setAutoCommit(false);
+  }
+
+  Connection newConnection() throws SQLException {
+    return DriverManager.getConnection(config.connectionUrl, config.connectionUser, config.connectionPassword);
+  }
+
+  void closeQuietly() {
+    try {
+      connection.close();
+    } catch (SQLException sqle) {
+      log.warn("Ignoring error closing connection", sqle);
+    }
+  }
+
+  JdbcSinkConfig cachedContextualConfig(String context) {
+    JdbcSinkConfig contextualConfig = contextualConfigCache.get(context);
+    if (contextualConfig == null) {
+      contextualConfig = config.contextualConfig(context);
+      contextualConfigCache.put(context, contextualConfig);
+    }
+    return contextualConfig;
+  }
+
+  String destinationTable(String topic) {
+    final String tableNameFormat = cachedContextualConfig(topic).tableNameFormat.trim();
+    final String tableName = tableNameFormat.replace("${topic}", topic);
+    if (tableName.isEmpty()) {
+      throw new ConnectException(String.format("Destination table name for topic '%s' is empty using the format string '%s'", topic, tableNameFormat));
+    }
+    return tableName;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class JdbcSinkConfig extends AbstractConfig {
+
+  public enum InsertMode {
+    INSERT,
+    UPSERT;
+  }
+
+  public enum PrimaryKeyMode {
+    NONE,
+    KAFKA,
+    RECORD_KEY,
+    RECORD_VALUE;
+  }
+
+  private static final String TABLE_OVERRIDABLE_DOC = "\nThis config is overridable at the table-level by using a '$table.' prefix.";
+  private static final String TOPIC_OVERRIDABLE_DOC = "\nThis config is overridable at the topic-level by using a '$topic.' prefix.";
+
+  public static final String CONNECTION_URL = "connection.url";
+  private static final String CONNECTION_URL_DOC = "JDBC connection URL."
+                                                   + "\nThe protocol portion will be used for determining the SQL dialect to be used.";
+
+  public static final String CONNECTION_USER = "connection.user";
+  private static final String CONNECTION_USER_DOC = "JDBC connection user.";
+
+  public static final String CONNECTION_PASSWORD = "connection.password";
+  private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
+
+  public static final String TABLE_NAME_FORMAT = "table.name.format";
+  private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
+  private static final String TABLE_NAME_FORMAT_DOC =
+      "A format string for the destination table name, which may contain '${topic}' as a placeholder for the originating topic name."
+      + "\nFor example, \"kafka_${topic}\" for the topic 'orders' will map to the table name 'kafka_orders'." + TOPIC_OVERRIDABLE_DOC;
+
+  public static final String MAX_RETRIES = "max.retries";
+  private static final int MAX_RETRIES_DEFAULT = 10;
+  private static final String MAX_RETRIES_DOC = "The maximum number of times to retry on errors before failing the task.";
+
+  public static final String RETRY_BACKOFF_MS = "retry.backoff.ms";
+  private static final int RETRY_BACKOFF_MS_DEFAULT = 3000;
+  private static final String RETRY_BACKOFF_MS_DOC = "The time in milliseconds to wait following an error before a retry attempt is made.";
+
+  public static final String BATCH_SIZE = "batch.size";
+  private static final int BATCH_SIZE_DEFAULT = 3000;
+  private static final String BATCH_SIZE_DOC =
+      "Specifies how many records to attempt to batch together for insertion, when possible." + TABLE_OVERRIDABLE_DOC;
+
+  public static final String AUTO_CREATE = "auto.create";
+  private static final String AUTO_CREATE_DEFAULT = "false";
+  private static final String AUTO_CREATE_DOC =
+      "Whether to automatically create tables based on record schema if the sink table is found to be missing, by issuing a CREATE statement." + TABLE_OVERRIDABLE_DOC;
+
+  public static final String AUTO_EVOLVE = "auto.evolve";
+  private static final String AUTO_EVOLVE_DEFAULT = "false";
+  private static final String AUTO_EVOLVE_DOC =
+      "Whether to automatically evolve table schema when record schema and table schema is found to be incompatible, by issuing an ALTER statement." + TABLE_OVERRIDABLE_DOC;
+
+  public static final String INSERT_MODE = "insert.mode";
+  private static final String INSERT_MODE_DEFAULT = "insert";
+  private static final String INSERT_MODE_DOC =
+      "The insertion mode to use. Supported modes are 'insert' and 'upsert', with the latter translated to the appropriate upsert semantics for the target database if it is supported."
+      + TABLE_OVERRIDABLE_DOC;
+
+  public static final String PK_MODE = "pk.mode";
+  private static final String PK_MODE_DEFAULT = "none";
+  private static final String PK_MODE_DOC =
+      "The primary key mode, also refer to 'pk.fields' documentation for interplay. Supported modes are: "
+      + "\n'none' - no keys utilized."
+      + "\n'kafka' - Kafka coordinates are used as the PK."
+      + "\n'record_key' - field(s) from the record key are used, which may be a primitive or a struct."
+      + "\n'record_value' - field(s) from the record value are used, which must be a struct.";
+
+  public static final String PK_FIELDS = "pk.fields";
+  private static final String PK_FIELDS_DEFAULT = "";
+  private static final String PK_FIELDS_DOC =
+      "List of comma-separated primary key field names. The interpretation of this config depends on the 'pk.mode':"
+      + "\n'none' - ignored."
+      + "\n'kafka' - must be a trio representing the Kafka coordinates (topic: string, partition: int, offset: long); defaulting to (__connect_topic, __connect_partition, __connect_offset) if empty."
+      + "\n'record_key' - if empty, all fields from the key struct will be used, otherwise used to whitelist the desired fields - for primitive key only a single field name must be configured."
+      + "\n'record_value' - if empty, all fields from the value struct will be used, otherwise used to whitelist the desired fields.";
+
+  private static final ConfigDef.Range NON_NEGATIVE_INT_VALIDATOR = ConfigDef.Range.atLeast(0);
+
+  public static final ConfigDef CONFIG_DEF = new ConfigDef()
+      .define(CONNECTION_URL, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.HIGH, CONNECTION_URL_DOC)
+      .define(CONNECTION_USER, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CONNECTION_USER_DOC)
+      .define(CONNECTION_PASSWORD, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, CONNECTION_PASSWORD_DOC)
+      .define(TABLE_NAME_FORMAT, ConfigDef.Type.STRING, TABLE_NAME_FORMAT_DEFAULT, ConfigDef.Importance.HIGH, TABLE_NAME_FORMAT_DOC)
+      .define(BATCH_SIZE, ConfigDef.Type.INT, BATCH_SIZE_DEFAULT, NON_NEGATIVE_INT_VALIDATOR, ConfigDef.Importance.HIGH, BATCH_SIZE_DOC)
+      .define(MAX_RETRIES, ConfigDef.Type.INT, MAX_RETRIES_DEFAULT, NON_NEGATIVE_INT_VALIDATOR, ConfigDef.Importance.MEDIUM, MAX_RETRIES_DOC)
+      .define(RETRY_BACKOFF_MS, ConfigDef.Type.INT, RETRY_BACKOFF_MS_DEFAULT, NON_NEGATIVE_INT_VALIDATOR, ConfigDef.Importance.MEDIUM, RETRY_BACKOFF_MS_DOC)
+      .define(AUTO_CREATE, ConfigDef.Type.BOOLEAN, AUTO_CREATE_DEFAULT, ConfigDef.Importance.MEDIUM, AUTO_CREATE_DOC)
+      .define(AUTO_EVOLVE, ConfigDef.Type.BOOLEAN, AUTO_EVOLVE_DEFAULT, ConfigDef.Importance.MEDIUM, AUTO_EVOLVE_DOC)
+      .define(INSERT_MODE, ConfigDef.Type.STRING, INSERT_MODE_DEFAULT, EnumValidator.in(InsertMode.values()), ConfigDef.Importance.MEDIUM, INSERT_MODE_DOC)
+      .define(PK_MODE, ConfigDef.Type.STRING, PK_MODE_DEFAULT, EnumValidator.in(PrimaryKeyMode.values()), ConfigDef.Importance.MEDIUM, PK_MODE_DOC)
+      .define(PK_FIELDS, ConfigDef.Type.LIST, PK_FIELDS_DEFAULT, ConfigDef.Importance.MEDIUM, PK_FIELDS_DOC);
+
+  public final String connectionUrl;
+  public final String connectionUser;
+  public final String connectionPassword;
+  public final String tableNameFormat;
+  public final int batchSize;
+  public final int maxRetries;
+  public final int retryBackoffMs;
+  public final boolean autoCreate;
+  public final boolean autoEvolve;
+  public final InsertMode insertMode;
+  public final PrimaryKeyMode pkMode;
+  public final List<String> pkFields;
+
+  public JdbcSinkConfig(Map<?, ?> props) {
+    super(CONFIG_DEF, props);
+    connectionUrl = getString(CONNECTION_URL);
+    connectionUser = getString(CONNECTION_USER);
+    connectionPassword = getString(CONNECTION_PASSWORD);
+    tableNameFormat = getString(TABLE_NAME_FORMAT);
+    batchSize = getInt(BATCH_SIZE);
+    maxRetries = getInt(MAX_RETRIES);
+    retryBackoffMs = getInt(RETRY_BACKOFF_MS);
+    autoCreate = getBoolean(AUTO_CREATE);
+    autoEvolve = getBoolean(AUTO_EVOLVE);
+    insertMode = InsertMode.valueOf(getString(INSERT_MODE).toUpperCase());
+    pkMode = PrimaryKeyMode.valueOf(getString(PK_MODE).toUpperCase());
+    pkFields = getList(PK_FIELDS);
+  }
+
+  public JdbcSinkConfig contextualConfig(String context) {
+    final Map<String, Object> properties = originals();
+    properties.putAll(originalsWithPrefix(context + "."));
+    return new JdbcSinkConfig(properties);
+  }
+
+  private static class EnumValidator implements ConfigDef.Validator {
+    private final Set<String> validValues;
+
+    private EnumValidator(Set<String> validValues) {
+      this.validValues = validValues;
+    }
+
+    public static <E> EnumValidator in(E[] enumerators) {
+      final HashSet<String> values = new HashSet<>();
+      for (E e : enumerators) {
+        values.add(e.toString().toUpperCase());
+        values.add(e.toString().toLowerCase());
+      }
+      return new EnumValidator(values);
+    }
+
+    @Override
+    public void ensureValid(String key, Object value) {
+      if (!validValues.contains(value)) {
+        throw new ConfigException(key, value, "Invalid enumerator");
+      }
+    }
+  }
+
+  public static void main(String... args) {
+    System.out.println(CONFIG_DEF.toRst());
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Map;
+
+public class JdbcSinkTask extends SinkTask {
+  private static final Logger log = LoggerFactory.getLogger(JdbcSinkTask.class);
+
+  private JdbcSinkConfig config;
+  private JdbcDbWriter writer;
+  private int remainingRetries;
+
+  @Override
+  public void start(final Map<String, String> props) {
+    log.info("Starting task");
+    config = new JdbcSinkConfig(props);
+    writer = new JdbcDbWriter(config);
+    remainingRetries = config.maxRetries;
+  }
+
+  @Override
+  public void put(Collection<SinkRecord> records) {
+    if (records.isEmpty()) {
+      return;
+    }
+    final SinkRecord first = records.iterator().next();
+    final int recordsCount = records.size();
+    log.trace("Received {} records. First record kafka coordinates:({}-{}-{}). Writing them to the database...",
+              recordsCount, first.topic(), first.kafkaPartition(), first.kafkaOffset());
+    try {
+      writer.write(records);
+    } catch (SQLException sqle) {
+      log.warn("Write of {} records failed, remainingRetries={}", records.size(), remainingRetries, sqle);
+      if (remainingRetries == 0) {
+        throw new ConnectException(sqle);
+      } else {
+        writer.closeQuietly();
+        writer = new JdbcDbWriter(config);
+        remainingRetries--;
+        context.timeout(config.retryBackoffMs);
+        throw new RetriableException(sqle);
+      }
+    }
+    remainingRetries = config.maxRetries;
+  }
+
+  @Override
+  public void flush(Map<TopicPartition, OffsetAndMetadata> map) {
+    // Not necessary
+  }
+
+  public void stop() {
+    log.info("Stopping task");
+    writer.closeQuietly();
+  }
+
+  @Override
+  public String version() {
+    return getClass().getPackage().getImplementationVersion();
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
+
+public class PreparedStatementBinder {
+  private final JdbcSinkConfig.PrimaryKeyMode pkMode;
+  private final PreparedStatement statement;
+  private final SchemaPair schemaPair;
+  private final FieldsMetadata fieldsMetadata;
+
+  public PreparedStatementBinder(
+      PreparedStatement statement,
+      JdbcSinkConfig.PrimaryKeyMode pkMode,
+      SchemaPair schemaPair,
+      FieldsMetadata fieldsMetadata
+  ) {
+    this.pkMode = pkMode;
+    this.statement = statement;
+    this.schemaPair = schemaPair;
+    this.fieldsMetadata = fieldsMetadata;
+  }
+
+  public void bindRecord(SinkRecord record) throws SQLException {
+    final Struct valueStruct = (Struct) record.value();
+
+    // Assumption: the relevant SQL has placeholders for keyFieldNames first followed by nonKeyFieldNames, in iteration order
+
+    int index = 1;
+
+    switch (pkMode) {
+      case NONE:
+        if (!fieldsMetadata.keyFieldNames.isEmpty()) {
+          throw new AssertionError();
+        }
+        break;
+
+      case KAFKA: {
+        assert fieldsMetadata.keyFieldNames.size() == 3;
+        bindField(index++, Schema.Type.STRING, record.topic());
+        bindField(index++, Schema.Type.INT32, record.kafkaPartition());
+        bindField(index++, Schema.Type.INT64, record.kafkaOffset());
+      }
+      break;
+
+      case RECORD_KEY: {
+        if (schemaPair.keySchema.type().isPrimitive()) {
+          assert fieldsMetadata.keyFieldNames.size() == 1;
+          bindField(index++, schemaPair.keySchema.type(), record.key());
+        } else {
+          for (String fieldName : fieldsMetadata.keyFieldNames) {
+            final Field field = schemaPair.keySchema.field(fieldName);
+            bindField(index++, field.schema().type(), ((Struct) record.key()).get(field));
+          }
+        }
+      }
+      break;
+
+      case RECORD_VALUE: {
+        for (String fieldName : fieldsMetadata.keyFieldNames) {
+          final Field field = schemaPair.valueSchema.field(fieldName);
+          bindField(index++, field.schema().type(), ((Struct) record.value()).get(field));
+        }
+      }
+      break;
+    }
+
+    for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
+      final Field field = record.valueSchema().field(fieldName);
+      bindField(index++, field.schema().type(), valueStruct.get(field));
+    }
+
+    statement.addBatch();
+  }
+
+  void bindField(int index, Schema.Type type, Object value) throws SQLException {
+    bindField(statement, index, type, value);
+  }
+
+  static void bindField(PreparedStatement statement, int index, Schema.Type type, Object value) throws SQLException {
+    if (value == null) {
+      statement.setObject(index, null);
+    } else {
+      switch (type) {
+        case INT8:
+          statement.setByte(index, (Byte) value);
+          break;
+        case INT16:
+          statement.setShort(index, (Short) value);
+          break;
+        case INT32:
+          statement.setInt(index, (Integer) value);
+          break;
+        case INT64:
+          statement.setLong(index, (Long) value);
+          break;
+        case FLOAT32:
+          statement.setFloat(index, (Float) value);
+          break;
+        case FLOAT64:
+          statement.setDouble(index, (Double) value);
+          break;
+        case BOOLEAN:
+          statement.setBoolean(index, (Boolean) value);
+          break;
+        case STRING:
+          statement.setString(index, (String) value);
+          break;
+        case BYTES:
+          final byte[] bytes;
+          if (value instanceof ByteBuffer) {
+            final ByteBuffer buffer = ((ByteBuffer) value).slice();
+            bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+          } else {
+            bytes = (byte[]) value;
+          }
+          statement.setBytes(index, bytes);
+          break;
+        default:
+          throw new ConnectException("Unsupported source data type: " + type);
+      }
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.Transform;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.stringSurroundTransform;
+
+public abstract class DbDialect {
+
+  private final Map<Schema.Type, String> schemaTypeToSqlTypeMap;
+  protected final String escapeColumnNamesStart;
+  protected final String escapeColumnNamesEnd;
+  protected final String lineSeparator = System.lineSeparator();
+
+  DbDialect(Map<Schema.Type, String> schemaTypeToSqlTypeMap, String escapeColumnNamesStart, String escapeColumnNamesEnd) {
+    this.escapeColumnNamesStart = escapeColumnNamesStart;
+    this.escapeColumnNamesEnd = escapeColumnNamesEnd;
+    this.schemaTypeToSqlTypeMap = schemaTypeToSqlTypeMap;
+  }
+
+  public final String getInsert(final String tableName, final Collection<String> keyColumns, final Collection<String> nonKeyColumns) {
+    StringBuilder builder = new StringBuilder("INSERT INTO ");
+    builder.append(escapeTableName(tableName));
+    builder.append("(");
+    joinToBuilder(builder, ",", keyColumns, nonKeyColumns, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") VALUES(");
+    nCopiesToBuilder(builder, ",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(")");
+    return builder.toString();
+  }
+
+  public abstract String getUpsertQuery(final String table, final Collection<String> keyColumns, final Collection<String> columns);
+
+  public String getCreateQuery(String tableName, Collection<SinkRecordField> fields) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("CREATE TABLE ");
+    builder.append(escapeTableName(tableName));
+    builder.append(" (");
+
+    joinToBuilder(builder, ",", fields, new Transform<SinkRecordField>() {
+      @Override
+      public void apply(StringBuilder builder, SinkRecordField f) {
+        builder.append(lineSeparator);
+        builder.append(escapeColumnNamesStart).append(f.name).append(escapeColumnNamesEnd);
+        builder.append(" ");
+
+        if (f.isPrimaryKey && f.type.equals(Schema.Type.STRING)) {
+          builder.append("VARCHAR(50)");
+        } else {
+          builder.append(getSqlType(f.type));
+        }
+
+        if (f.isOptional) {
+          builder.append(" NULL");
+        } else {
+          builder.append(" NOT NULL");
+        }
+      }
+    });
+
+    final List<String> pks = new ArrayList<>();
+    for (SinkRecordField f : fields) {
+      if (f.isPrimaryKey) {
+        pks.add(f.name);
+      }
+    }
+
+    if (!pks.isEmpty()) {
+      builder.append(",");
+      builder.append(lineSeparator);
+      builder.append("PRIMARY KEY(");
+      joinToBuilder(builder, ",", pks, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+      builder.append(")");
+    }
+
+    builder.append(")");
+    return builder.toString();
+  }
+
+  public List<String> getAlterTable(String tableName, Collection<SinkRecordField> fields) {
+    final StringBuilder builder = new StringBuilder("ALTER TABLE ");
+    builder.append(escapeTableName(tableName));
+    builder.append(" ");
+
+    joinToBuilder(builder, ",", fields, new Transform<SinkRecordField>() {
+      @Override
+      public void apply(StringBuilder builder, SinkRecordField f) {
+        builder.append(lineSeparator);
+        builder.append("ADD COLUMN ");
+        builder.append(escapeColumnNamesStart);
+        builder.append(f.name);
+        builder.append(escapeColumnNamesEnd);
+        builder.append(" ");
+        builder.append(getSqlType(f.type));
+        if (f.isOptional) {
+          builder.append(" NULL");
+        } else {
+          builder.append(" NOT NULL");
+        }
+      }
+    });
+
+    return Collections.singletonList(builder.toString());
+  }
+
+  String getSqlType(Schema.Type type) {
+    final String sqlType = schemaTypeToSqlTypeMap.get(type);
+    if (sqlType == null) {
+      throw new ConnectException(String.format("%s type doesn't have a mapping to the SQL database column type", type));
+    }
+    return sqlType;
+  }
+
+  protected String escapeTableName(String tableName) {
+    return escapeColumnNamesStart + tableName + escapeColumnNamesEnd;
+  }
+
+  public static DbDialect fromConnectionString(final String url) {
+    if (!url.startsWith("jdbc:")) {
+      throw new ConnectException(String.format("Not a valid JDBC URL: %s", url));
+    }
+
+    if (url.startsWith("jdbc:sqlite:")) {
+      // SQLite URL's are not in the format jdbc:protocol://FILE but jdbc:protocol:file
+      return new SqliteDialect();
+    }
+
+    if (url.startsWith("jdbc:oracle:thin:@")) {
+      return new OracleDialect();
+    }
+
+    final String protocol = extractProtocolFromUrl(url).toLowerCase();
+    switch (protocol) {
+      case "microsoft:sqlserver":
+      case "sqlserver":
+      case "jtds:sqlserver":
+        return new SqlServerDialect();
+      case "mariadb":
+      case "mysql":
+        return new MySqlDialect();
+      case "postgresql":
+        return new PostgreSqlDialect();
+      default:
+        throw new ConnectException(String.format("%s JDBC is not supported", protocol));
+    }
+  }
+
+  static String extractProtocolFromUrl(final String url) {
+    if (!url.startsWith("jdbc:")) {
+      throw new ConnectException(String.format("Not a valid JDBC URL: %s", url));
+    }
+    final int index = url.indexOf("://", "jdbc:".length());
+    if (index < 0) {
+      throw new ConnectException(String.format("Not a valid JDBC URL: %s", url));
+    }
+    return url.substring("jdbc:".length(), index);
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.stringSurroundTransform;
+
+public class MySqlDialect extends DbDialect {
+
+  public MySqlDialect() {
+    super(getSqlTypeMap(), "`", "`");
+  }
+
+  private static Map<Schema.Type, String> getSqlTypeMap() {
+    Map<Schema.Type, String> map = new HashMap<>();
+    map.put(Schema.Type.INT8, "TINYINT");
+    map.put(Schema.Type.INT16, "SMALLINT");
+    map.put(Schema.Type.INT32, "INT");
+    map.put(Schema.Type.INT64, "BIGINT");
+    map.put(Schema.Type.FLOAT32, "FLOAT");
+    map.put(Schema.Type.FLOAT64, "DOUBLE");
+    map.put(Schema.Type.BOOLEAN, "TINYINT");
+    map.put(Schema.Type.STRING, "VARCHAR(256)");
+    map.put(Schema.Type.BYTES, "VARBINARY(1024)");
+    return map;
+  }
+
+  @Override
+  public String getUpsertQuery(final String table, final Collection<String> keyCols, final Collection<String> cols) {
+    //MySql doesn't support SQL 2003:merge so here how the upsert is handled
+
+    final StringBuilder builder = new StringBuilder();
+    builder.append("insert into ");
+    builder.append(escapeTableName(table));
+    builder.append("(");
+    joinToBuilder(builder, ",", keyCols, cols, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") values(");
+    nCopiesToBuilder(builder, ",", "?", cols.size() + keyCols.size());
+    builder.append(") on duplicate key update ");
+    joinToBuilder(
+        builder,
+        ",",
+        cols,
+        new StringBuilderUtil.Transform<String>() {
+          @Override
+          public void apply(StringBuilder builder, String col) {
+            builder.append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd)
+                .append("=values(").append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd).append(")");
+          }
+        }
+    );
+    return builder.toString();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/OracleDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/OracleDialect.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.stringSurroundTransform;
+
+public class OracleDialect extends DbDialect {
+  public OracleDialect() {
+    super(getSqlTypeMap(), "\"", "\"");
+  }
+
+  private static Map<Schema.Type, String> getSqlTypeMap() {
+    Map<Schema.Type, String> map = new HashMap<>();
+    map.put(Schema.Type.INT8, "TINYINT");
+    map.put(Schema.Type.INT16, "SMALLINT");
+    map.put(Schema.Type.INT32, "INTEGER");
+    map.put(Schema.Type.INT64, "NUMBER(19)");
+    map.put(Schema.Type.FLOAT32, "REAL");
+    map.put(Schema.Type.FLOAT64, "BINARY_DOUBLE");
+    map.put(Schema.Type.BOOLEAN, "NUMBER(1,0)");
+    map.put(Schema.Type.STRING, "VARCHAR(256)");
+    map.put(Schema.Type.BYTES, "BLOB");
+    return map;
+  }
+
+  @Override
+  public List<String> getAlterTable(String tableName, Collection<SinkRecordField> fields) {
+    final StringBuilder builder = new StringBuilder("ALTER TABLE ");
+    builder.append(escapeTableName(tableName)); //yes oracles needs it uppercase
+    builder.append(" ADD(");
+
+    joinToBuilder(
+        builder,
+        ",",
+        fields,
+        new StringBuilderUtil.Transform<SinkRecordField>() {
+          @Override
+          public void apply(StringBuilder builder, SinkRecordField f) {
+            builder.append(lineSeparator);
+            builder.append(escapeColumnNamesStart)
+                .append(f.name)
+                .append(escapeColumnNamesEnd);
+            builder.append(" ");
+            builder.append(getSqlType(f.type));
+            if (f.isOptional) {
+              builder.append(" NULL");
+            } else {
+              builder.append(" NOT NULL");
+            }
+          }
+        }
+    );
+
+    builder.append(")");
+
+    final List<String> query = new ArrayList<String>(1);
+    query.add(builder.toString());
+    return query;
+  }
+
+  @Override
+  public String getUpsertQuery(final String table, Collection<String> keyCols, Collection<String> cols) {
+    // https://blogs.oracle.com/cmar/entry/using_merge_to_do_an
+
+    final StringBuilder builder = new StringBuilder();
+    builder.append("merge into ");
+    final String tableName = escapeTableName(table);
+    builder.append(tableName);
+    builder.append(" using (select ");
+    joinToBuilder(builder, ", ", keyCols, cols, stringSurroundTransform("? " + escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(" FROM dual) incoming on(");
+    joinToBuilder(builder, " and ", keyCols, new StringBuilderUtil.Transform<String>() {
+      @Override
+      public void apply(StringBuilder builder, String col) {
+        builder.append(tableName).append(".")
+            .append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd)
+            .append("=incoming.").append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd);
+      }
+    });
+    builder.append(")");
+    if (cols != null && cols.size() > 0) {
+      builder.append(" when matched then update set ");
+      joinToBuilder(builder, ",", cols, new StringBuilderUtil.Transform<String>() {
+        @Override
+        public void apply(StringBuilder builder, String col) {
+          builder.append(tableName).append(".")
+              .append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd)
+              .append("=incoming.").append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd);
+        }
+      });
+    }
+
+    builder.append(" when not matched then insert(");
+    joinToBuilder(builder, ",", cols, keyCols, stringSurroundTransform(tableName + "." + escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") values(");
+    joinToBuilder(builder, ",", cols, keyCols, stringSurroundTransform("incoming." + escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.stringSurroundTransform;
+
+public class PostgreSqlDialect extends DbDialect {
+
+  // The user is responsible for escaping the columns otherwise create table A and create table "A" is not the same
+
+  public PostgreSqlDialect() {
+    super(getSqlTypeMap(), "\"", "\"");
+  }
+
+  private static Map<Schema.Type, String> getSqlTypeMap() {
+    Map<Schema.Type, String> map = new HashMap<>();
+    map.put(Schema.Type.INT8, "SMALLINT");
+    map.put(Schema.Type.INT16, "SMALLINT");
+    map.put(Schema.Type.INT32, "INT");
+    map.put(Schema.Type.INT64, "BIGINT");
+    map.put(Schema.Type.FLOAT32, "FLOAT");
+    map.put(Schema.Type.FLOAT64, "DOUBLE PRECISION");
+    map.put(Schema.Type.BOOLEAN, "BOOLEAN");
+    map.put(Schema.Type.STRING, "TEXT");
+    map.put(Schema.Type.BYTES, "BYTEA");
+    return map;
+  }
+
+  @Override
+  public String getUpsertQuery(final String table, final Collection<String> keyCols, final Collection<String> cols) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(escapeTableName(table));
+    builder.append(" (");
+    joinToBuilder(builder, ",", keyCols, cols, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") VALUES (");
+    nCopiesToBuilder(builder, ",", "?", cols.size() + keyCols.size());
+    builder.append(") ON CONFLICT (");
+    joinToBuilder(builder, ",", keyCols, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") DO UPDATE SET ");
+    joinToBuilder(
+        builder,
+        ",",
+        cols,
+        new StringBuilderUtil.Transform<String>() {
+          @Override
+          public void apply(StringBuilder builder, String col) {
+            builder.append(escapeColumnNamesStart);
+            builder.append(col);
+            builder.append(escapeColumnNamesEnd);
+            builder.append("=EXCLUDED.");
+            builder.append(escapeColumnNamesStart);
+            builder.append(col);
+            builder.append(escapeColumnNamesEnd);
+          }
+        }
+    );
+    return builder.toString();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialect.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.stringSurroundTransform;
+
+public class SqlServerDialect extends DbDialect {
+
+  public SqlServerDialect() {
+    super(getSqlTypeMap(), "[", "]");
+  }
+
+  private static Map<Schema.Type, String> getSqlTypeMap() {
+    Map<Schema.Type, String> map = new HashMap<>();
+    map.put(Schema.Type.INT8, "tinyint");
+    map.put(Schema.Type.INT16, "smallint");
+    map.put(Schema.Type.INT32, "int");
+    map.put(Schema.Type.INT64, "bigint");
+    map.put(Schema.Type.FLOAT32, "real");
+    map.put(Schema.Type.FLOAT64, "float");
+    map.put(Schema.Type.BOOLEAN, "bit");
+    map.put(Schema.Type.STRING, "varchar(256)");
+    map.put(Schema.Type.BYTES, "varbinary(1024)");
+    return map;
+  }
+
+  @Override
+  public List<String> getAlterTable(String tableName, Collection<SinkRecordField> fields) {
+    final StringBuilder builder = new StringBuilder("ALTER TABLE ");
+    builder.append(escapeTableName(tableName));
+    builder.append(" ADD");
+    joinToBuilder(builder, ",", fields, new StringBuilderUtil.Transform<SinkRecordField>() {
+      @Override
+      public void apply(StringBuilder builder, SinkRecordField f) {
+        builder.append(lineSeparator);
+        builder.append(escapeColumnNamesStart).append(f.name).append(escapeColumnNamesEnd);
+        builder.append(" ");
+        builder.append(getSqlType(f.type));
+        if (f.isOptional) {
+          builder.append(" NULL");
+        } else {
+          builder.append(" NOT NULL");
+        }
+      }
+    });
+    return Collections.singletonList(builder.toString());
+  }
+
+  @Override
+  public String getUpsertQuery(String table, Collection<String> keyCols, Collection<String> cols) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("merge into ");
+    String tableName = escapeTableName(table);
+    builder.append(tableName);
+    builder.append(" with (HOLDLOCK) AS target using (select ");
+    joinToBuilder(builder, ", ", cols, keyCols, new StringBuilderUtil.Transform<String>() {
+      @Override
+      public void apply(StringBuilder builder, String col) {
+        builder.append("? AS ").append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd);
+      }
+    });
+    builder.append(") AS incoming on (");
+    joinToBuilder(builder, " and ", keyCols, new StringBuilderUtil.Transform<String>() {
+      @Override
+      public void apply(StringBuilder builder, String col) {
+        builder.append("target.")
+            .append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd)
+            .append("=incoming.").append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd);
+      }
+    });
+    builder.append(")");
+    if (cols != null && cols.size() > 0) {
+      builder.append(" when matched then update set ");
+      joinToBuilder(builder, ",", cols, new StringBuilderUtil.Transform<String>() {
+        @Override
+        public void apply(StringBuilder builder, String col) {
+          builder.append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd)
+              .append("=incoming.")
+              .append(escapeColumnNamesStart).append(col).append(escapeColumnNamesEnd);
+        }
+      });
+    }
+    builder.append(" when not matched then insert (");
+    joinToBuilder(builder, ", ", cols, keyCols, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") values (");
+    joinToBuilder(builder, ",", cols, keyCols, stringSurroundTransform("incoming." + escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(");");
+    return builder.toString();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialect.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.stringSurroundTransform;
+
+public class SqliteDialect extends DbDialect {
+  public SqliteDialect() {
+    super(getSqlTypeMap(), "`", "`");
+  }
+
+  private static Map<Schema.Type, String> getSqlTypeMap() {
+    Map<Schema.Type, String> map = new HashMap<>();
+    map.put(Schema.Type.INT8, "NUMERIC");
+    map.put(Schema.Type.INT16, "NUMERIC");
+    map.put(Schema.Type.INT32, "NUMERIC");
+    map.put(Schema.Type.INT64, "NUMERIC");
+    map.put(Schema.Type.FLOAT32, "REAL");
+    map.put(Schema.Type.FLOAT64, "REAL");
+    map.put(Schema.Type.BOOLEAN, "NUMERIC");
+    map.put(Schema.Type.STRING, "TEXT");
+    map.put(Schema.Type.BYTES, "BLOB");
+    return map;
+  }
+
+  /**
+   * Returns the query for creating a new table in the database
+   *
+   * @return The create query for the dialect
+   */
+  public String getCreateQuery(String tableName, Collection<SinkRecordField> fields) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append(String.format("CREATE TABLE %s (", escapeTableName(tableName)));
+
+    joinToBuilder(builder, ",", fields, new StringBuilderUtil.Transform<SinkRecordField>() {
+      @Override
+      public void apply(StringBuilder builder, SinkRecordField f) {
+        builder.append(lineSeparator);
+        builder.append(escapeColumnNamesStart).append(f.name).append(escapeColumnNamesEnd);
+        builder.append(" ");
+        builder.append(getSqlType(f.type));
+        if (f.isOptional) {
+          builder.append(" NULL");
+        } else {
+          builder.append(" NOT NULL ");
+        }
+      }
+    });
+
+    final List<String> pks = new ArrayList<>();
+    for (SinkRecordField f : fields) {
+      if (f.isPrimaryKey) {
+        pks.add(f.name);
+      }
+    }
+
+    if (!pks.isEmpty()) {
+      builder.append(",");
+      builder.append(lineSeparator);
+      builder.append("PRIMARY KEY(");
+      joinToBuilder(builder, ",", pks, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+      builder.append(")");
+    }
+
+    builder.append(");");
+    return builder.toString();
+  }
+
+  @Override
+  public List<String> getAlterTable(String tableName, Collection<SinkRecordField> fields) {
+    final List<String> queries = new ArrayList<>(fields.size());
+    for (final SinkRecordField f : fields) {
+      queries.add(String.format(
+          "ALTER TABLE %s ADD %s%s%s %s %s",
+          escapeTableName(tableName),
+          escapeColumnNamesStart, f.name, escapeColumnNamesEnd,
+          getSqlType(f.type),
+          f.isOptional ? "NULL" : "NOT NULL"
+      ));
+    }
+    return queries;
+  }
+
+  @Override
+  public String getUpsertQuery(String table, Collection<String> keyCols, Collection<String> cols) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("insert or ignore into ");
+    builder.append(escapeTableName(table)).append("(");
+    joinToBuilder(builder, ",", keyCols, cols, stringSurroundTransform(escapeColumnNamesStart, escapeColumnNamesEnd));
+    builder.append(") values(");
+    nCopiesToBuilder(builder, ",", "?", cols.size() + keyCols.size());
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/StringBuilderUtil.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/StringBuilderUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import java.util.Iterator;
+
+class StringBuilderUtil {
+
+  public interface Transform<T> {
+    void apply(StringBuilder builder, T input);
+  }
+
+  public static Transform<String> stringSurroundTransform(final String start, final String end) {
+    return new Transform<String>() {
+      @Override
+      public void apply(StringBuilder builder, String input) {
+        builder.append(start).append(input).append(end);
+      }
+    };
+  }
+
+  public static void nCopiesToBuilder(StringBuilder builder, String delim, String item, int n) {
+    for (int i = 0; i < n; i++) {
+      if (i > 0) {
+        builder.append(delim);
+      }
+      builder.append(item);
+    }
+  }
+
+  public static <T> void joinToBuilder(StringBuilder builder, String delim, Iterable<T> iter, Transform<T> transform) {
+    joinToBuilder(builder, delim, iter, false, transform);
+  }
+
+  public static <T> void joinToBuilder(StringBuilder builder, String delim, Iterable<T> a, Iterable<T> b, Transform<T> transform) {
+    final boolean updated = joinToBuilder(builder, delim, a, false, transform);
+    joinToBuilder(builder, delim, b, updated, transform);
+  }
+
+  private static <T> boolean joinToBuilder(StringBuilder builder, String delim, Iterable<T> items, boolean startingDelim, Transform<T> transform) {
+    boolean updated = false;
+    Iterator<T> iter = items.iterator();
+    if (iter.hasNext()) {
+      if (startingDelim) {
+        builder.append(delim);
+      }
+      T next = iter.next();
+      if (next != null) {
+        transform.apply(builder, next);
+      }
+      updated = true;
+    }
+    while (iter.hasNext()) {
+      builder.append(delim);
+      T next = iter.next();
+      if (next != null) {
+        transform.apply(builder, next);
+      }
+    }
+    return updated;
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/DbTable.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/DbTable.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DbTable {
+  public final String name;
+  public final Map<String, DbTableColumn> columns = new HashMap<>();
+  public final Set<String> primaryKeyColumnNames = new HashSet<>();
+
+  public DbTable(String name, List<DbTableColumn> columns) {
+    this.name = name;
+    for (final DbTableColumn column : columns) {
+      this.columns.put(column.name, column);
+      if (column.isPrimaryKey) {
+        primaryKeyColumnNames.add(column.name);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "DbTable{" +
+           "name='" + name + '\'' +
+           ", columns=" + columns +
+           '}';
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/DbTableColumn.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/DbTableColumn.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+public final class DbTableColumn {
+  public final String name;
+  public final boolean isPrimaryKey;
+  public final boolean allowsNull;
+  public final int sqlType;
+
+  public DbTableColumn(final String name, final boolean isPrimaryKey, final boolean allowsNull, final int sqlType) {
+    this.name = name;
+    this.isPrimaryKey = isPrimaryKey;
+    this.allowsNull = allowsNull;
+    this.sqlType = sqlType;
+  }
+
+  @Override
+  public String toString() {
+    return "DbTableColumn{" +
+           "name='" + name + '\'' +
+           ", isPrimaryKey=" + isPrimaryKey +
+           ", allowsNull=" + allowsNull +
+           ", sqlType=" + sqlType +
+           '}';
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+
+public class FieldsMetadata {
+
+  public static final List<String> DEFAULT_KAFKA_PK_NAMES = Arrays.asList(
+      "__connect_topic",
+      "__connect_partition",
+      "__connect_offset"
+  );
+
+  public final Set<String> keyFieldNames;
+  public final Set<String> nonKeyFieldNames;
+  public final Map<String, SinkRecordField> allFields;
+
+  private FieldsMetadata(Set<String> keyFieldNames, Set<String> nonKeyFieldNames, Map<String, SinkRecordField> allFields) {
+    if ((keyFieldNames.size() + nonKeyFieldNames.size() != allFields.size())
+        || !(allFields.keySet().containsAll(keyFieldNames) && allFields.keySet().containsAll(nonKeyFieldNames))) {
+      throw new IllegalArgumentException(String.format(
+          "Validation fail -- keyFieldNames:%s nonKeyFieldNames:%s allFields:%s",
+          keyFieldNames, nonKeyFieldNames, allFields
+      ));
+    }
+    this.keyFieldNames = keyFieldNames;
+    this.nonKeyFieldNames = nonKeyFieldNames;
+    this.allFields = allFields;
+  }
+
+  public static FieldsMetadata extract(
+      final String tableName,
+      final JdbcSinkConfig.PrimaryKeyMode pkMode,
+      final List<String> configuredPkFields,
+      final SchemaPair schemaPair
+  ) {
+    return extract(tableName, pkMode, configuredPkFields, schemaPair.keySchema, schemaPair.valueSchema);
+  }
+
+  public static FieldsMetadata extract(
+      final String tableName,
+      final JdbcSinkConfig.PrimaryKeyMode pkMode,
+      final List<String> configuredPkFields,
+      final Schema keySchema,
+      final Schema valueSchema
+  ) {
+    if (valueSchema == null) {
+      throw new ConnectException("Record value schema missing");
+    }
+    if (valueSchema.type() != Schema.Type.STRUCT) {
+      throw new ConnectException("Value schema must be of type Struct");
+    }
+
+    final Set<String> keyFieldNames = new LinkedHashSet<>();
+    final Set<String> nonKeyFieldNames = new LinkedHashSet<>();
+    final Map<String, SinkRecordField> allFields = new HashMap<>();
+
+    switch (pkMode) {
+
+      case KAFKA: {
+        if (configuredPkFields.isEmpty()) {
+          keyFieldNames.addAll(DEFAULT_KAFKA_PK_NAMES);
+        } else if (configuredPkFields.size() == 3) {
+          keyFieldNames.addAll(configuredPkFields);
+        } else {
+          throw new ConnectException(String.format(
+              "PK mode for table '%s' is %s so there should either be no field names defined for defaults %s to be applicable, "
+              + "or exactly 3, defined fields are: %s",
+              tableName, pkMode, DEFAULT_KAFKA_PK_NAMES, configuredPkFields
+          ));
+        }
+        final Iterator<String> it = keyFieldNames.iterator();
+        final String topicFieldName = it.next();
+        allFields.put(topicFieldName, new SinkRecordField(Schema.Type.STRING, topicFieldName, true, false));
+        final String partitionFieldName = it.next();
+        allFields.put(partitionFieldName, new SinkRecordField(Schema.Type.INT32, partitionFieldName, true));
+        final String offsetFieldName = it.next();
+        allFields.put(offsetFieldName, new SinkRecordField(Schema.Type.INT64, offsetFieldName, true));
+      }
+      break;
+
+      case RECORD_KEY: {
+
+        if (keySchema == null) {
+          throw new ConnectException(String.format(
+              "PK mode for table '%s' is %s, but record key schema is missing", tableName, pkMode
+          ));
+        }
+        final Schema.Type keySchemaType = keySchema.type();
+        if (keySchemaType.isPrimitive()) {
+          if (configuredPkFields.size() != 1) {
+            throw new ConnectException(String.format(
+                "Need exactly one PK column defined since the key schema for records is a primitive type, defined columns are: %s",
+                configuredPkFields
+            ));
+          }
+          final String fieldName = configuredPkFields.get(0);
+          keyFieldNames.add(fieldName);
+          allFields.put(fieldName, new SinkRecordField(keySchemaType, fieldName, true, false));
+        } else if (keySchemaType == Schema.Type.STRUCT) {
+          if (configuredPkFields.isEmpty()) {
+            for (Field keyField : keySchema.fields()) {
+              keyFieldNames.add(keyField.name());
+            }
+          } else {
+            for (String fieldName : configuredPkFields) {
+              final Field keyField = keySchema.field(fieldName);
+              if (keyField == null) {
+                throw new ConnectException(String.format(
+                    "PK mode for table '%s' is %s with configured PK fields %s, but record key schema does not contain field: %s",
+                    tableName, pkMode, configuredPkFields, fieldName
+                ));
+              }
+            }
+            keyFieldNames.addAll(configuredPkFields);
+          }
+          for (String fieldName : keyFieldNames) {
+            final Field keyField = keySchema.field(fieldName);
+            allFields.put(fieldName, new SinkRecordField(keyField.schema().type(), fieldName, true, false));
+          }
+        } else {
+          throw new ConnectException("Key schema must be primitive type or Struct, but is of type: " + keySchemaType);
+        }
+      }
+      break;
+
+      case RECORD_VALUE: {
+        if (configuredPkFields.isEmpty()) {
+          for (Field keyField : valueSchema.fields()) {
+            keyFieldNames.add(keyField.name());
+          }
+        } else {
+          for (String fieldName : configuredPkFields) {
+            if (valueSchema.field(fieldName) == null) {
+              throw new ConnectException(String.format(
+                  "PK mode for table '%s' is %s with configured PK fields %s, but record value schema does not contain field: %s",
+                  tableName, pkMode, configuredPkFields, fieldName
+              ));
+            }
+          }
+          keyFieldNames.addAll(configuredPkFields);
+        }
+      }
+      break;
+
+    }
+
+    for (Field field : valueSchema.fields()) {
+      final boolean isKeyField = keyFieldNames.contains(field.name());
+      if (!isKeyField) {
+        nonKeyFieldNames.add(field.name());
+      }
+      final Schema fieldSchema = field.schema();
+      allFields.put(field.name(), new SinkRecordField(fieldSchema.type(), field.name(), isKeyField, !isKeyField && fieldSchema.isOptional()));
+    }
+
+    if (allFields.isEmpty()) {
+      throw new ConnectException("No fields found using key and value schemas for table: " + tableName);
+    }
+
+    if (allFields.isEmpty()) {
+      throw new ConnectException("No fields found");
+    }
+
+    return new FieldsMetadata(keyFieldNames, nonKeyFieldNames, allFields);
+  }
+
+  @Override
+  public String toString() {
+    return "FieldsMetadata{" +
+           "keyFieldNames=" + keyFieldNames +
+           ", nonKeyFieldNames=" + nonKeyFieldNames +
+           ", allFields=" + allFields +
+           '}';
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SchemaPair.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SchemaPair.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Objects;
+
+public class SchemaPair {
+  public final Schema keySchema;
+  public final Schema valueSchema;
+
+  public SchemaPair(Schema keySchema, Schema valueSchema) {
+    this.keySchema = keySchema;
+    this.valueSchema = valueSchema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SchemaPair that = (SchemaPair) o;
+    return Objects.equals(keySchema, that.keySchema) &&
+           Objects.equals(valueSchema, that.valueSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keySchema, valueSchema);
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+import org.apache.kafka.connect.data.Schema;
+
+public class SinkRecordField {
+  public final Schema.Type type;
+  public final String name;
+  public final boolean isPrimaryKey;
+  public final boolean isOptional;
+
+  public SinkRecordField(final Schema.Type type, final String name, final boolean isPrimaryKey) {
+    this(type, name, isPrimaryKey, !isPrimaryKey);
+  }
+
+  public SinkRecordField(
+      final Schema.Type type,
+      final String name,
+      final boolean isPrimaryKey,
+      final boolean isOptional
+  ) {
+    this.type = type;
+    this.name = name;
+    this.isPrimaryKey = isPrimaryKey;
+    this.isOptional = isOptional;
+  }
+
+  @Override
+  public String toString() {
+    return "SinkRecordField{" +
+           "type=" + type +
+           ", name='" + name + '\'' +
+           ", isPrimaryKey=" + isPrimaryKey +
+           ", isOptional=" + isOptional +
+           '}';
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/TableMetadataLoadingCache.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/TableMetadataLoadingCache.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.DbMetadataQueries;
+
+public class TableMetadataLoadingCache {
+  private static final Logger log = LoggerFactory.getLogger(TableMetadataLoadingCache.class);
+
+  private final Map<String, DbTable> cache = new HashMap<>();
+
+  public DbTable get(final Connection connection, final String tableName) throws SQLException {
+    DbTable dbTable = cache.get(tableName);
+    if (dbTable == null) {
+      if (DbMetadataQueries.tableExists(connection, tableName)) {
+        dbTable = DbMetadataQueries.table(connection, tableName);
+        cache.put(tableName, dbTable);
+      } else {
+        return null;
+      }
+    }
+    return dbTable;
+  }
+
+  public DbTable refresh(final Connection connection, final String tableName) throws SQLException {
+    DbTable dbTable = DbMetadataQueries.table(connection, tableName);
+    log.info("Updating cached metadata -- {}", dbTable);
+    cache.put(dbTable.name, dbTable);
+    return dbTable;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -190,10 +190,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         .define(TOPIC_PREFIX_CONFIG, Type.STRING, Importance.HIGH, TOPIC_PREFIX_DOC, CONNECTOR_GROUP, 4, Width.MEDIUM, TOPIC_PREFIX_DISPLAY)
         .define(TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, Type.LONG, TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT, Importance.HIGH, TIMESTAMP_DELAY_INTERVAL_MS_DOC, CONNECTOR_GROUP, 5, Width.MEDIUM, TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);
   }
-  static ConfigDef config = baseConfigDef();
+
+  public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
   public JdbcSourceConnectorConfig(Map<String, String> props) {
-    super(config, props);
+    super(CONFIG_DEF, props);
     String mode = getString(JdbcSourceConnectorConfig.MODE_CONFIG);
     if (mode.equals(JdbcSourceConnectorConfig.MODE_UNSPECIFIED))
       throw new ConfigException("Query mode must be specified");
@@ -254,6 +255,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   }
 
   public static void main(String[] args) {
-    System.out.println(config.toRst());
+    System.out.println(CONFIG_DEF.toRst());
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 public class JdbcSourceConnectorConstants {
   public static final String TABLE_NAME_KEY = "table";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.SystemTime;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import java.sql.Timestamp;
 import java.util.HashMap;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -35,6 +35,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.connect.jdbc.source.EmbeddedDerby;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import io.confluent.connect.jdbc.source.JdbcSourceTask;
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+
+import io.confluent.connect.jdbc.sink.dialect.DbDialect;
+
+import static org.junit.Assert.assertEquals;
+
+public class BufferedRecordsTest {
+
+  private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+
+  @Before
+  public void setUp() throws IOException, SQLException {
+    sqliteHelper.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, SQLException {
+    sqliteHelper.tearDown();
+  }
+
+  @Test
+  public void correctBatching() throws SQLException {
+    final DbDialect dbDialect = DbDialect.fromConnectionString(sqliteHelper.sqliteUri());
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final HashMap<Object, Object> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", true);
+    props.put("auto.evolve", true);
+    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final BufferedRecords buffer = new BufferedRecords(config, "dummy", dbDialect, dbStructure, sqliteHelper.connection);
+
+    final Schema schemaA = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .build();
+    final Struct valueA = new Struct(schemaA)
+        .put("name", "cuba");
+    final SinkRecord recordA = new SinkRecord("dummy", 0, null, null, schemaA, valueA, 0);
+
+    final Schema schemaB = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        .build();
+    final Struct valueB = new Struct(schemaB)
+        .put("name", "cuba")
+        .put("age", 4);
+    final SinkRecord recordB = new SinkRecord("dummy", 1, null, null, schemaB, valueB, 1);
+
+    // test records are batched correctly based on schema equality as records are added
+    //   (schemaA,schemaA,schemaA,schemaB,schemaA) -> ([schemaA,schemaA,schemaA],[schemaB],[schemaA])
+
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+
+    assertEquals(Arrays.asList(recordA, recordA, recordA), buffer.add(recordB));
+
+    assertEquals(Collections.singletonList(recordB), buffer.add(recordA));
+
+    assertEquals(Collections.singletonList(recordA), buffer.flush());
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbMetadataQueriesTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbMetadataQueriesTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collections;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DbMetadataQueriesTest {
+
+  private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+
+  @Before
+  public void setUp() throws IOException, SQLException {
+    sqliteHelper.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, SQLException {
+    sqliteHelper.tearDown();
+  }
+
+  @Test
+  public void tableExistsOnEmptyDb() throws SQLException {
+    assertFalse(DbMetadataQueries.tableExists(sqliteHelper.connection, "somerandomtable"));
+  }
+
+  @Test
+  public void tableExists() throws SQLException {
+    sqliteHelper.createTable("create table somerandomtable (id int)");
+    assertTrue(DbMetadataQueries.tableExists(sqliteHelper.connection, "somerandomtable"));
+    assertFalse(DbMetadataQueries.tableExists(sqliteHelper.connection, "someotherrandomtable"));
+  }
+
+  @Test(expected =  SQLException.class)
+  public void tableOnEmptyDb() throws SQLException {
+    DbMetadataQueries.table(sqliteHelper.connection, "somerand");
+  }
+
+  @Test
+  public void basicTable() throws SQLException {
+    sqliteHelper.createTable("create table x (id int primary key, name text not null, optional_age int null)");
+    DbTable metadata = DbMetadataQueries.table(sqliteHelper.connection, "x");
+    assertEquals(metadata.name, "x");
+
+    assertEquals(Collections.singleton("id"), metadata.primaryKeyColumnNames);
+
+    Map<String, DbTableColumn> columns = metadata.columns;
+    assertEquals(3, columns.size());
+
+    DbTableColumn idCol = columns.get("id");
+    assertEquals("id", idCol.name);
+    assertTrue(idCol.isPrimaryKey);
+    assertFalse(idCol.allowsNull);
+    assertEquals(Types.INTEGER, idCol.sqlType);
+
+    DbTableColumn textCol = columns.get("name");
+    assertFalse(textCol.isPrimaryKey);
+    assertFalse(textCol.allowsNull);
+    assertEquals(Types.VARCHAR, textCol.sqlType);
+
+    DbTableColumn ageCol = columns.get("optional_age");
+    assertFalse(ageCol.isPrimaryKey);
+    assertTrue(ageCol.allowsNull);
+    assertEquals(Types.INTEGER, ageCol.sqlType);
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class JdbcDbWriterTest {
+
+  private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+
+  @Before
+  public void setUp() throws IOException, SQLException {
+    sqliteHelper.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, SQLException {
+    sqliteHelper.tearDown();
+  }
+
+  @Test
+  public void autoCreateWithAutoEvolve() throws SQLException {
+    String topic = "books";
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("auto.evolve", "true");
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id"); // assigned name for the primitive key
+
+    JdbcDbWriter writer = new JdbcDbWriter(new JdbcSinkConfig(props));
+
+    Schema keySchema = Schema.INT64_SCHEMA;
+
+    Schema valueSchema1 = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+
+    Struct valueStruct1 = new Struct(valueSchema1)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+
+    writer.write(Collections.singleton(new SinkRecord(topic, 0, keySchema, 1L, valueSchema1, valueStruct1, 0)));
+
+    DbTable metadata = DbMetadataQueries.table(writer.connection, topic);
+    assertTrue(metadata.columns.get("id").isPrimaryKey);
+    for (Field field : valueSchema1.fields()) {
+      assertTrue(metadata.columns.containsKey(field.name()));
+    }
+
+    Schema valueSchema2 = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .field("year", Schema.OPTIONAL_INT32_SCHEMA); // new field
+
+    Struct valueStruct2 = new Struct(valueSchema2)
+        .put("author", "Tom Robbins")
+        .put("title", "Fierce Invalids")
+        .put("year", 2016);
+
+    writer.write(Collections.singleton(new SinkRecord(topic, 0, keySchema, 2L, valueSchema2, valueStruct2, 0)));
+
+    DbTable refreshedMetadata = DbMetadataQueries.table(sqliteHelper.connection, topic);
+    assertTrue(metadata.columns.get("id").isPrimaryKey);
+    for (Field field : valueSchema2.fields()) {
+      assertTrue(refreshedMetadata.columns.containsKey(field.name()));
+    }
+  }
+
+  @Test(expected = SQLException.class)
+  public void multiInsertWithKafkaPkFailsDueToUniqueConstraint() throws SQLException {
+    writeSameRecordTwiceExpectingSingleUpdate(JdbcSinkConfig.InsertMode.INSERT, JdbcSinkConfig.PrimaryKeyMode.KAFKA, "");
+  }
+
+  @Test
+  public void idempotentUpsertWithKafkaPk() throws SQLException {
+    writeSameRecordTwiceExpectingSingleUpdate(JdbcSinkConfig.InsertMode.UPSERT, JdbcSinkConfig.PrimaryKeyMode.KAFKA, "");
+  }
+
+  @Test(expected = SQLException.class)
+  public void multiInsertWithRecordKeyPkFailsDueToUniqueConstraint() throws SQLException {
+    writeSameRecordTwiceExpectingSingleUpdate(JdbcSinkConfig.InsertMode.INSERT, JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY, "");
+  }
+
+  @Test
+  public void idempotentUpsertWithRecordKeyPk() throws SQLException {
+    writeSameRecordTwiceExpectingSingleUpdate(JdbcSinkConfig.InsertMode.UPSERT, JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY, "");
+  }
+
+  @Test(expected = SQLException.class)
+  public void multiInsertWithRecordValuePkFailsDueToUniqueConstraint() throws SQLException {
+    writeSameRecordTwiceExpectingSingleUpdate(JdbcSinkConfig.InsertMode.INSERT, JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE, "author,title");
+  }
+
+  @Test
+  public void idempotentUpsertWithRecordValuePk() throws SQLException {
+    writeSameRecordTwiceExpectingSingleUpdate(JdbcSinkConfig.InsertMode.UPSERT, JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE, "author,title");
+  }
+
+  private void writeSameRecordTwiceExpectingSingleUpdate(
+      JdbcSinkConfig.InsertMode insertMode,
+      JdbcSinkConfig.PrimaryKeyMode pkMode,
+      String pkFields
+  ) throws SQLException {
+    String topic = "books";
+    int partition = 7;
+    long offset = 42;
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("pk.mode", pkMode.toString());
+    props.put("pk.fields", pkFields);
+    props.put("insert.mode", insertMode.toString());
+
+    JdbcDbWriter writer = new JdbcDbWriter(new JdbcSinkConfig(props));
+
+    Schema keySchema = SchemaBuilder.struct()
+        .field("id", SchemaBuilder.INT64_SCHEMA);
+
+    Struct keyStruct = new Struct(keySchema).put("id", 0L);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+
+    SinkRecord record = new SinkRecord(topic, partition, keySchema, keyStruct, valueSchema, valueStruct, offset);
+
+    writer.write(Collections.nCopies(2, record));
+
+    assertEquals(
+        1,
+        sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+          @Override
+          public void read(ResultSet rs) throws SQLException {
+            assertEquals(1, rs.getInt(1));
+          }
+        })
+    );
+  }
+
+  @Test
+  public void sameRecordNTimes() throws SQLException {
+    String tableName = "batched_statement_test_100";
+    String createTable = "CREATE TABLE " + tableName + " (" +
+                         "    firstName  TEXT," +
+                         "    lastName  TEXT," +
+                         "    age INTEGER," +
+                         "    bool  NUMERIC," +
+                         "    byte  INTEGER," +
+                         "    short INTEGER," +
+                         "    long INTEGER," +
+                         "    float NUMERIC," +
+                         "    double NUMERIC," +
+                         "    bytes BLOB " +
+                         ");";
+
+    sqliteHelper.deleteTable(tableName);
+    sqliteHelper.createTable(createTable);
+
+    Schema schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstName", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("lastName", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("bool", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("short", Schema.OPTIONAL_INT16_SCHEMA)
+        .field("byte", Schema.OPTIONAL_INT8_SCHEMA)
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("float", Schema.OPTIONAL_FLOAT32_SCHEMA)
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("bytes", Schema.OPTIONAL_BYTES_SCHEMA);
+
+    final Struct struct = new Struct(schema)
+        .put("firstName", "Alex")
+        .put("lastName", "Smith")
+        .put("bool", true)
+        .put("short", (short) 1234)
+        .put("byte", (byte) -32)
+        .put("long", 12425436L)
+        .put("float", 2356.3f)
+        .put("double", -2436546.56457d)
+        .put("bytes", new byte[]{-32, 124});
+
+    int numRecords = ThreadLocalRandom.current().nextInt(20, 80);
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("table.name.format", tableName);
+    props.put("batch.size", String.valueOf(ThreadLocalRandom.current().nextInt(20, 100)));
+
+    JdbcDbWriter writer = new JdbcDbWriter(new JdbcSinkConfig(props));
+    writer.write(Collections.nCopies(
+        numRecords,
+        new SinkRecord("topic", 0, null, null, schema, struct, 0)
+    ));
+
+    assertEquals(
+        numRecords,
+        sqliteHelper.select(
+            "SELECT * FROM " + tableName + " ORDER BY firstName",
+            new SqliteHelper.ResultSetReadCallback() {
+              @Override
+              public void read(ResultSet rs) throws SQLException {
+                assertEquals(struct.getString("firstName"), rs.getString("firstName"));
+                assertEquals(struct.getString("lastName"), rs.getString("lastName"));
+                assertEquals(struct.getBoolean("bool"), rs.getBoolean("bool"));
+                assertEquals(struct.getInt8("byte").byteValue(), rs.getByte("byte"));
+                assertEquals(struct.getInt16("short").shortValue(), rs.getShort("short"));
+                rs.getInt("age");
+                assertTrue(rs.wasNull());
+                assertEquals(struct.getInt64("long").longValue(), rs.getLong("long"));
+                assertEquals(struct.getFloat32("float"), rs.getFloat("float"), 0.01);
+                assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
+                assertTrue(Arrays.equals(struct.getBytes("bytes"), rs.getBytes("bytes")));
+              }
+            }
+        )
+    );
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class PreparedStatementBinderTest {
+
+  @Test
+  public void bindRecord() throws SQLException {
+    Schema valueSchema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstName", Schema.STRING_SCHEMA)
+        .field("lastName", Schema.STRING_SCHEMA)
+        .field("age", Schema.INT32_SCHEMA)
+        .field("bool", Schema.BOOLEAN_SCHEMA)
+        .field("short", Schema.INT16_SCHEMA)
+        .field("byte", Schema.INT8_SCHEMA)
+        .field("long", Schema.INT64_SCHEMA)
+        .field("float", Schema.FLOAT32_SCHEMA)
+        .field("double", Schema.FLOAT64_SCHEMA)
+        .field("bytes", Schema.BYTES_SCHEMA)
+        .field("threshold", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+        .put("firstName", "Alex")
+        .put("lastName", "Smith")
+        .put("bool", true)
+        .put("short", (short) 1234)
+        .put("byte", (byte) -32)
+        .put("long", (long) 12425436)
+        .put("float", (float) 2356.3)
+        .put("double", -2436546.56457)
+        .put("bytes", new byte[]{-32, 124})
+        .put("age", 30);
+
+    SchemaPair schemaPair = new SchemaPair(null, valueSchema);
+
+    JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE;
+
+    List<String> pkFields = Collections.singletonList("long");
+
+    FieldsMetadata fieldsMetadata = FieldsMetadata.extract("people", pkMode, pkFields, schemaPair);
+
+    PreparedStatement statement = mock(PreparedStatement.class);
+
+    PreparedStatementBinder binder = new PreparedStatementBinder(
+        statement,
+        pkMode,
+        schemaPair,
+        fieldsMetadata
+    );
+
+    binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
+
+    int index = 1;
+    // key field first
+    verify(statement, times(1)).setLong(index++, valueStruct.getInt64("long"));
+    // rest in order of schema def
+    verify(statement, times(1)).setString(index++, valueStruct.getString("firstName"));
+    verify(statement, times(1)).setString(index++, valueStruct.getString("lastName"));
+    verify(statement, times(1)).setInt(index++, valueStruct.getInt32("age"));
+    verify(statement, times(1)).setBoolean(index++, valueStruct.getBoolean("bool"));
+    verify(statement, times(1)).setShort(index++, valueStruct.getInt16("short"));
+    verify(statement, times(1)).setByte(index++, valueStruct.getInt8("byte"));
+    verify(statement, times(1)).setFloat(index++, valueStruct.getFloat32("float"));
+    verify(statement, times(1)).setDouble(index++, valueStruct.getFloat64("double"));
+    verify(statement, times(1)).setBytes(index++, valueStruct.getBytes("bytes"));
+    // last field is optional and is null-valued in struct
+    verify(statement, times(1)).setObject(index++, null);
+  }
+
+
+  @Test
+  public void bindFieldPrimitiveValues() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.Type.INT8, (byte) 42).setByte(index, (byte) 42);
+    verifyBindField(++index, Schema.Type.INT16, (short) 42).setShort(index, (short) 42);
+    verifyBindField(++index, Schema.Type.INT32, 42).setInt(index, 42);
+    verifyBindField(++index, Schema.Type.INT64, 42L).setLong(index, 42L);
+    verifyBindField(++index, Schema.Type.BOOLEAN, false).setBoolean(index, false);
+    verifyBindField(++index, Schema.Type.BOOLEAN, true).setBoolean(index, true);
+    verifyBindField(++index, Schema.Type.FLOAT32, -42f).setFloat(index, -42f);
+    verifyBindField(++index, Schema.Type.FLOAT64, 42d).setDouble(index, 42d);
+    verifyBindField(++index, Schema.Type.BYTES, new byte[]{42}).setBytes(index, new byte[]{42});
+    verifyBindField(++index, Schema.Type.BYTES, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
+    verifyBindField(++index, Schema.Type.STRING, "yep").setString(index, "yep");
+  }
+
+  @Test
+  public void bindFieldNull() throws SQLException {
+    final List<Schema.Type> nullableTypes = Arrays.asList(
+        Schema.Type.INT8,
+        Schema.Type.INT16,
+        Schema.Type.INT32,
+        Schema.Type.INT64,
+        Schema.Type.FLOAT32,
+        Schema.Type.FLOAT64,
+        Schema.Type.BOOLEAN,
+        Schema.Type.BYTES,
+        Schema.Type.STRING
+    );
+    int index = 0;
+    for (Schema.Type type : nullableTypes) {
+      verifyBindField(++index, type, null).setObject(index, null);
+    }
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, Schema.Type.STRUCT, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, Schema.Type.ARRAY, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, Schema.Type.MAP, Collections.emptyMap());
+  }
+
+  private PreparedStatement verifyBindField(int index, Schema.Type schemaType, Object value) throws SQLException {
+    PreparedStatement statement = mock(PreparedStatement.class);
+    PreparedStatementBinder.bindField(statement, index, schemaType, value);
+    return verify(statement, times(1));
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/SinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SinkTaskTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class SinkTaskTest {
+  private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+
+  @Before
+  public void setUp() throws IOException, SQLException {
+    sqliteHelper.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, SQLException {
+    sqliteHelper.tearDown();
+  }
+
+  @Test
+  public void putPropagatesToDb() throws Exception {
+    final String tableName1 = "table1";
+    final String tableName2 = "table2";
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put(String.format("%s.pk.mode", tableName1), "kafka");
+    props.put(String.format("%s.pk.fields", tableName1), "kafka_topic,kafka_partition,kafka_offset");
+    props.put(String.format("%s.pk.mode", tableName2), "record_value");
+    props.put(String.format("%s.pk.fields", tableName2), "firstName,lastName");
+
+    JdbcSinkTask task = new JdbcSinkTask();
+    task.initialize(mock(SinkTaskContext.class));
+
+    String createTable2 = "CREATE TABLE " + tableName2 + "(" +
+                          "    firstName  TEXT," +
+                          "    lastName  TEXT," +
+                          "    age INTEGER," +
+                          "    bool  NUMERIC," +
+                          "    byte  INTEGER," +
+                          "    short INTEGER NULL," +
+                          "    long INTEGER," +
+                          "    float NUMERIC," +
+                          "    double NUMERIC," +
+                          "    bytes BLOB, " +
+                          "PRIMARY KEY (firstName, lastName));";
+
+    sqliteHelper.deleteTable(tableName1);
+    sqliteHelper.deleteTable(tableName2);
+    sqliteHelper.createTable(createTable2);
+
+    task.start(props);
+
+    Schema schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstName", Schema.STRING_SCHEMA)
+        .field("lastName", Schema.STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("bool", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("short", Schema.OPTIONAL_INT16_SCHEMA)
+        .field("byte", Schema.OPTIONAL_INT8_SCHEMA)
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("float", Schema.OPTIONAL_FLOAT32_SCHEMA)
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build();
+
+    final Struct struct1 = new Struct(schema)
+        .put("firstName", "Alex")
+        .put("lastName", "Smith")
+        .put("bool", true)
+        .put("short", (short) 1234)
+        .put("byte", (byte) -32)
+        .put("long", 12425436L)
+        .put("float", (float) 2356.3)
+        .put("double", -2436546.56457)
+        .put("age", 21);
+
+    final Struct struct2 = new Struct(schema)
+        .put("firstName", "Christina")
+        .put("lastName", "Brams")
+        .put("bool", false)
+        .put("byte", (byte) -72)
+        .put("long", 8594L)
+        .put("double", 3256677.56457d)
+        .put("age", 28);
+
+    task.put(Arrays.asList(
+        new SinkRecord(tableName1, 1, null, null, schema, struct1, 42),
+        new SinkRecord(tableName2, 1, null, null, schema, struct2, 43)
+    ));
+
+    Thread.sleep(300); //SQLite delay
+
+    assertEquals(
+        1,
+        sqliteHelper.select(
+            "SELECT * FROM " + tableName1,
+            new SqliteHelper.ResultSetReadCallback() {
+              @Override
+              public void read(ResultSet rs) throws SQLException {
+                assertEquals(tableName1, rs.getString("kafka_topic"));
+                assertEquals(1, rs.getInt("kafka_partition"));
+                assertEquals(42, rs.getLong("kafka_offset"));
+                assertEquals(struct1.getString("firstName"), rs.getString("firstName"));
+                assertEquals(struct1.getString("lastName"), rs.getString("lastName"));
+                assertEquals(struct1.getBoolean("bool"), rs.getBoolean("bool"));
+                assertEquals(struct1.getInt8("byte").byteValue(), rs.getByte("byte"));
+                assertEquals(struct1.getInt16("short").shortValue(), rs.getShort("short"));
+                assertEquals(struct1.getInt32("age").intValue(), rs.getInt("age"));
+                assertEquals(struct1.getInt64("long").longValue(), rs.getLong("long"));
+                assertEquals(struct1.getFloat32("float"), rs.getFloat("float"), 0.01);
+                assertEquals(struct1.getFloat64("double"), rs.getDouble("double"), 0.01);
+              }
+            }
+        )
+    );
+
+    assertEquals(
+        1,
+        sqliteHelper.select(
+            "SELECT * FROM " + tableName2 + " WHERE firstName='" + struct2.getString("firstName") + "' and lastName='" + struct2.getString("lastName") + "'",
+            new SqliteHelper.ResultSetReadCallback() {
+              @Override
+              public void read(ResultSet rs) throws SQLException {
+                assertEquals(struct2.getBoolean("bool"), rs.getBoolean("bool"));
+                rs.getShort("short");
+                assertTrue(rs.wasNull());
+                assertEquals(struct2.getInt8("byte").byteValue(), rs.getByte("byte"));
+                assertEquals(struct2.getInt32("age").intValue(), rs.getInt("age"));
+                assertEquals(struct2.getInt64("long").longValue(), rs.getLong("long"));
+                rs.getShort("float");
+                assertTrue(rs.wasNull());
+                assertEquals(struct2.getFloat64("double"), rs.getDouble("double"), 0.01);
+              }
+            }
+        )
+    );
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelper.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public final class SqliteHelper {
+
+  public interface ResultSetReadCallback {
+    void read(final ResultSet rs) throws SQLException;
+  }
+
+  public final Path dbPath;
+
+  public Connection connection;
+
+  public SqliteHelper(String testId) {
+    dbPath = Paths.get(testId + ".db");
+  }
+
+  public String sqliteUri() {
+    return "jdbc:sqlite:" + dbPath;
+  }
+
+  public void setUp() throws SQLException, IOException {
+    Files.deleteIfExists(dbPath);
+    connection = DriverManager.getConnection(sqliteUri());
+    connection.setAutoCommit(false);
+  }
+
+  public void tearDown() throws SQLException, IOException {
+    connection.close();
+    Files.deleteIfExists(dbPath);
+  }
+
+  public void createTable(final String createSql) throws SQLException {
+    execute(createSql);
+  }
+
+  public void deleteTable(final String table) throws SQLException {
+    execute("DROP TABLE IF EXISTS " + table);
+
+    //random errors of table not being available happens in the unit tests
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public int select(final String query, final SqliteHelper.ResultSetReadCallback callback) throws SQLException {
+    int count = 0;
+    try (Statement stmt = connection.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery(query)) {
+        while (rs.next()) {
+          callback.read(rs);
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  public void execute(String sql) throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      stmt.executeUpdate(sql);
+      connection.commit();
+    }
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SqliteHelperTest {
+
+  private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+
+  @Before
+  public void setUp() throws IOException, SQLException {
+    sqliteHelper.setUp();
+  }
+
+  @After
+  public void tearDown() throws IOException, SQLException {
+    sqliteHelper.tearDown();
+  }
+
+  @Test
+  public void returnTheDatabaseTableInformation() throws SQLException {
+    String createEmployees = "CREATE TABLE employees\n" +
+                             "( employee_id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
+                             "  last_name VARCHAR NOT NULL,\n" +
+                             "  first_name VARCHAR,\n" +
+                             "  hire_date DATE\n" +
+                             ");";
+
+    String createProducts = "CREATE TABLE products\n" +
+                            "( product_id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
+                            "  product_name VARCHAR NOT NULL,\n" +
+                            "  quantity INTEGER NOT NULL DEFAULT 0\n" +
+                            ");";
+
+    String createNonPkTable = "CREATE TABLE nonPk (id numeric, response text)";
+
+    sqliteHelper.createTable(createEmployees);
+    sqliteHelper.createTable(createProducts);
+    sqliteHelper.createTable(createNonPkTable);
+
+    final Map<String, DbTable> tables = DbMetadataQueries.allTables(sqliteHelper.connection);
+
+    assertEquals(tables.size(), 4);  //sqlite_sequence is automatic
+    assertTrue(tables.containsKey("employees"));
+    assertTrue(tables.containsKey("products"));
+    assertTrue(tables.containsKey("nonPk"));
+
+    DbTable nonPk = tables.get("nonPk");
+
+    Map<String, DbTableColumn> columns = nonPk.columns;
+    assertEquals(columns.size(), 2);
+    assertTrue(columns.containsKey("id"));
+    assertTrue(columns.get("id").allowsNull);
+    assertFalse(columns.get("id").isPrimaryKey);
+    assertEquals(columns.get("id").sqlType, Types.FLOAT);
+    assertTrue(columns.containsKey("response"));
+    assertTrue(columns.get("response").allowsNull);
+    assertFalse(columns.get("response").isPrimaryKey);
+    assertEquals(columns.get("response").sqlType, Types.VARCHAR);
+
+    DbTable employees = tables.get("employees");
+    columns = employees.columns;
+    assertEquals(columns.size(), 4);
+    assertTrue(columns.containsKey("employee_id"));
+    assertFalse(columns.get("employee_id").allowsNull);
+    assertTrue(columns.get("employee_id").isPrimaryKey);
+    assertEquals(columns.get("employee_id").sqlType, Types.INTEGER);
+    assertTrue(columns.containsKey("last_name"));
+    assertFalse(columns.get("last_name").allowsNull);
+    assertFalse(columns.get("last_name").isPrimaryKey);
+    assertEquals(columns.get("last_name").sqlType, Types.VARCHAR);
+    assertTrue(columns.containsKey("first_name"));
+    assertTrue(columns.get("first_name").allowsNull);
+    assertFalse(columns.get("first_name").isPrimaryKey);
+    assertEquals(columns.get("first_name").sqlType, Types.VARCHAR);
+    assertTrue(columns.containsKey("hire_date"));
+    assertTrue(columns.get("hire_date").allowsNull);
+    assertFalse(columns.get("hire_date").isPrimaryKey);
+    // sqlite returns VARCHAR for DATE. why?!
+    // assertEquals(columns.get("hire_date").getSqlType(), Types.DATE);
+
+    DbTable products = tables.get("products");
+    columns = products.columns;
+    assertEquals(columns.size(), 3);
+    assertTrue(columns.containsKey("product_id"));
+    assertFalse(columns.get("product_id").allowsNull);
+    assertTrue(columns.get("product_id").isPrimaryKey);
+    assertEquals(columns.get("product_id").sqlType, Types.INTEGER);
+
+    assertTrue(columns.containsKey("product_name"));
+    assertFalse(columns.get("product_name").allowsNull);
+    assertFalse(columns.get("product_name").isPrimaryKey);
+    assertEquals(columns.get("product_name").sqlType, Types.VARCHAR);
+
+    assertTrue(columns.containsKey("quantity"));
+    assertFalse(columns.get("quantity").allowsNull);
+    assertFalse(columns.get("quantity").isPrimaryKey);
+    assertEquals(columns.get("quantity").sqlType, Types.INTEGER);
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DbDialectTest {
+  @Test(expected = ConnectException.class)
+  public void shouldThrowAndExceptionIfTheUriDoesNotStartWithJdbcWhenExtractingTheProtocol() {
+    DbDialect.extractProtocolFromUrl("mysql://Server:port");
+  }
+
+  @Test
+  public void handleSqlServerJTDS() {
+    String[] conns = new String[]{
+        "jdbc:sqlserver://what.amazonaws.com:1433/jdbc_sink_01",
+        "jdbc:jtds:sqlserver://localhost;instance=SQLEXPRESS;DatabaseName=jdbc_sink_01"
+    };
+    for (String c : conns) {
+      assertEquals(SqlServerDialect.class, DbDialect.fromConnectionString(c).getClass());
+    }
+  }
+
+  @Test(expected = ConnectException.class)
+  public void shouldThrowAndExceptionIfTheUriDoesntHaveSemiColonAndForwardSlashWhenExtractingTheProtocol() {
+    DbDialect.extractProtocolFromUrl("jdbc:protocol:somethingelse;field=value;");
+  }
+
+  @Test
+  public void shouldExtractTheProtocol() {
+    assertEquals(DbDialect.extractProtocolFromUrl("jdbc:protocol_test://SERVER:21421;field=value"), "protocol_test");
+  }
+
+  @Test
+  public void getTheSqLiteDialect() {
+    assertEquals(DbDialect.fromConnectionString("jdbc:sqlite:/folder/db.file").getClass(), SqliteDialect.class);
+  }
+
+  @Test
+  public void getSql2003DialectForOracle() {
+    assertEquals(DbDialect.fromConnectionString("jdbc:oracle:thin:@localhost:1521:xe").getClass(), OracleDialect.class);
+  }
+
+  @Test
+  public void getMySqlDialect() {
+    assertEquals(DbDialect.fromConnectionString("jdbc:mysql://HOST/DATABASE").getClass(), MySqlDialect.class);
+  }
+
+  @Test
+  public void getSqlServerDialect() {
+    assertEquals(DbDialect.fromConnectionString("jdbc:microsoft:sqlserver://HOST:1433;DatabaseName=DATABASE").getClass(), SqlServerDialect.class);
+  }
+
+  @Test
+  public void getPostgreDialect() {
+    assertEquals(DbDialect.fromConnectionString("jdbc:postgresql://HOST:1433;DatabaseName=DATABASE").getClass(), PostgreSqlDialect.class);
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static org.junit.Assert.assertEquals;
+
+public class MySqlDialectTest {
+  private final MySqlDialect dialect = new MySqlDialect();
+
+  @Test
+  public void handleCreateTableMultiplePKColumns() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "userid", true),
+        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(Schema.Type.STRING, "info", false)
+    ));
+
+    String expected = "CREATE TABLE `tableA` (" + System.lineSeparator() +
+                      "`userid` INT NOT NULL," + System.lineSeparator() +
+                      "`userdataid` INT NOT NULL," + System.lineSeparator() +
+                      "`info` VARCHAR(256) NULL," + System.lineSeparator() +
+                      "PRIMARY KEY(`userid`,`userdataid`))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableOnePKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", true),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE `tableA` (" + System.lineSeparator() +
+                      "`col1` INT NOT NULL," + System.lineSeparator() +
+                      "`col2` BIGINT NULL," + System.lineSeparator() +
+                      "`col3` VARCHAR(256) NULL," + System.lineSeparator() +
+                      "`col4` FLOAT NULL," + System.lineSeparator() +
+                      "`col5` DOUBLE NULL," + System.lineSeparator() +
+                      "`col6` TINYINT NULL," + System.lineSeparator() +
+                      "`col7` TINYINT NULL," + System.lineSeparator() +
+                      "`col8` SMALLINT NULL," + System.lineSeparator() +
+                      "PRIMARY KEY(`col1`))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableNoPKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE `tableA` (" + System.lineSeparator() +
+                      "`col1` INT NULL," + System.lineSeparator() +
+                      "`col2` BIGINT NULL," + System.lineSeparator() +
+                      "`col3` VARCHAR(256) NULL," + System.lineSeparator() +
+                      "`col4` FLOAT NULL," + System.lineSeparator() +
+                      "`col5` DOUBLE NULL," + System.lineSeparator() +
+                      "`col6` TINYINT NULL," + System.lineSeparator() +
+                      "`col7` TINYINT NULL," + System.lineSeparator() +
+                      "`col8` SMALLINT NULL)";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleAmendAddColumns() {
+    List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    assertEquals(1, actual.size());
+
+    String expected = "ALTER TABLE `tableA` " + System.lineSeparator() +
+                      "ADD COLUMN `col1` INT NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col2` BIGINT NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col3` VARCHAR(256) NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col4` FLOAT NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col5` DOUBLE NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col6` TINYINT NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col7` TINYINT NULL," + System.lineSeparator() +
+                      "ADD COLUMN `col8` SMALLINT NULL";
+    assertEquals(expected, actual.get(0));
+  }
+
+  @Test
+  public void createTheUpsertQuery() {
+    String expected = "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
+                      "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`)," +
+                      "`score`=values(`score`)";
+
+    String upsert = dialect.getUpsertQuery("actor",
+                                           Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score")
+    );
+    assertEquals(expected, upsert);
+  }
+
+  @Test
+  public void anotherInsertQuery() {
+    String query = dialect.getInsert("customers", Collections.<String>emptyList(), Arrays.asList("age", "firstName", "lastName"));
+    assertEquals(query, "INSERT INTO `customers`(`age`,`firstName`,`lastName`) VALUES(?,?,?)");
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/OracleDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/OracleDialectTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static org.junit.Assert.assertEquals;
+
+public class OracleDialectTest {
+  private final OracleDialect dialect = new OracleDialect();
+
+  @Test
+  public void handleCreateTableMultiplePKColumns() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "userid", true),
+        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(Schema.Type.STRING, "info", false)
+    ));
+
+    String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
+                      "\"userid\" INTEGER NOT NULL," + System.lineSeparator() +
+                      "\"userdataid\" INTEGER NOT NULL," + System.lineSeparator() +
+                      "\"info\" VARCHAR(256) NULL," + System.lineSeparator() +
+                      "PRIMARY KEY(\"userid\",\"userdataid\"))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableOnePKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", true),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
+                      "\"col1\" INTEGER NOT NULL," + System.lineSeparator() +
+                      "\"col2\" NUMBER(19) NULL," + System.lineSeparator() +
+                      "\"col3\" VARCHAR(256) NULL," + System.lineSeparator() +
+                      "\"col4\" REAL NULL," + System.lineSeparator() +
+                      "\"col5\" BINARY_DOUBLE NULL," + System.lineSeparator() +
+                      "\"col6\" NUMBER(1,0) NULL," + System.lineSeparator() +
+                      "\"col7\" TINYINT NULL," + System.lineSeparator() +
+                      "\"col8\" SMALLINT NULL," + System.lineSeparator() +
+                      "PRIMARY KEY(\"col1\"))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableNoPKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
+                      "\"col1\" INTEGER NULL," + System.lineSeparator() +
+                      "\"col2\" NUMBER(19) NULL," + System.lineSeparator() +
+                      "\"col3\" VARCHAR(256) NULL," + System.lineSeparator() +
+                      "\"col4\" REAL NULL," + System.lineSeparator() +
+                      "\"col5\" BINARY_DOUBLE NULL," + System.lineSeparator() +
+                      "\"col6\" NUMBER(1,0) NULL," + System.lineSeparator() +
+                      "\"col7\" TINYINT NULL," + System.lineSeparator() +
+                      "\"col8\" SMALLINT NULL)";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleAmendAddColumns() {
+    List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    assertEquals(1, actual.size());
+
+    String expected = "ALTER TABLE \"tableA\" ADD(" + System.lineSeparator() +
+                      "\"col1\" INTEGER NULL," + System.lineSeparator() +
+                      "\"col2\" NUMBER(19) NULL," + System.lineSeparator() +
+                      "\"col3\" VARCHAR(256) NULL," + System.lineSeparator() +
+                      "\"col4\" REAL NULL," + System.lineSeparator() +
+                      "\"col5\" BINARY_DOUBLE NULL," + System.lineSeparator() +
+                      "\"col6\" NUMBER(1,0) NULL," + System.lineSeparator() +
+                      "\"col7\" TINYINT NULL," + System.lineSeparator() +
+                      "\"col8\" SMALLINT NULL)";
+    assertEquals(expected, actual.get(0));
+  }
+
+  @Test
+  public void createTheUpsertStatement() {
+    String expected = "merge into \"ARTICLE\" " +
+                      "using (select ? \"title\", ? \"author\", ? \"body\" FROM dual) incoming on" +
+                      "(\"ARTICLE\".\"title\"=incoming.\"title\" and \"ARTICLE\".\"author\"=incoming.\"author\") " +
+                      "when matched then update set \"ARTICLE\".\"body\"=incoming.\"body\" " +
+                      "when not matched then insert(\"ARTICLE\".\"body\",\"ARTICLE\".\"title\",\"ARTICLE\".\"author\") " +
+                      "values(incoming.\"body\",incoming.\"title\",incoming.\"author\")";
+
+    String upsert = dialect.getUpsertQuery("ARTICLE",
+                                           Arrays.asList("title", "author"), Collections.singletonList("body")
+    );
+
+    assertEquals(expected, upsert);
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgreSqlDialectTest {
+
+  private final DbDialect dialect = new PostgreSqlDialect();
+
+  @Test
+  public void produceTheUpsertQuery() {
+    String expected = "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET " +
+                      "\"name\"=EXCLUDED.\"name\",\"salary\"=EXCLUDED.\"salary\",\"address\"=EXCLUDED.\"address\"";
+    String insert = dialect.getUpsertQuery("Customer", Collections.singletonList("id"), Arrays.asList("name", "salary", "address"));
+    assertEquals(expected, insert);
+  }
+
+  @Test
+  public void handleCreateTableMultiplePKColumns() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "userid", true),
+        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(Schema.Type.STRING, "info", false)
+    ));
+
+    String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
+                      "\"userid\" INT NOT NULL," + System.lineSeparator() +
+                      "\"userdataid\" INT NOT NULL," + System.lineSeparator() +
+                      "\"info\" TEXT NULL," + System.lineSeparator() +
+                      "PRIMARY KEY(\"userid\",\"userdataid\"))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableOnePKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", true),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
+                      "\"col1\" INT NOT NULL," + System.lineSeparator() +
+                      "\"col2\" BIGINT NULL," + System.lineSeparator() +
+                      "\"col3\" TEXT NULL," + System.lineSeparator() +
+                      "\"col4\" FLOAT NULL," + System.lineSeparator() +
+                      "\"col5\" DOUBLE PRECISION NULL," + System.lineSeparator() +
+                      "\"col6\" BOOLEAN NULL," + System.lineSeparator() +
+                      "\"col7\" SMALLINT NULL," + System.lineSeparator() +
+                      "\"col8\" SMALLINT NULL," + System.lineSeparator() +
+                      "PRIMARY KEY(\"col1\"))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableNoPKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
+                      "\"col1\" INT NULL," + System.lineSeparator() +
+                      "\"col2\" BIGINT NULL," + System.lineSeparator() +
+                      "\"col3\" TEXT NULL," + System.lineSeparator() +
+                      "\"col4\" FLOAT NULL," + System.lineSeparator() +
+                      "\"col5\" DOUBLE PRECISION NULL," + System.lineSeparator() +
+                      "\"col6\" BOOLEAN NULL," + System.lineSeparator() +
+                      "\"col7\" SMALLINT NULL," + System.lineSeparator() +
+                      "\"col8\" SMALLINT NULL)";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleAmendAddColumns() {
+    List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    assertEquals(1, actual.size());
+
+    String expected = "ALTER TABLE \"tableA\" " + System.lineSeparator() +
+                      "ADD COLUMN \"col1\" INT NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col2\" BIGINT NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col3\" TEXT NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col4\" FLOAT NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col5\" DOUBLE PRECISION NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col6\" BOOLEAN NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col7\" SMALLINT NULL," + System.lineSeparator() +
+                      "ADD COLUMN \"col8\" SMALLINT NULL";
+    assertEquals(expected, actual.get(0));
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialectTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static org.junit.Assert.assertEquals;
+
+public class SqlServerDialectTest {
+  private final DbDialect dialect = new SqlServerDialect();
+
+  @Test
+  public void produceTheRightSqlStatementWhithASinglePK() {
+    String insert = dialect.getUpsertQuery("Customer", Collections.singletonList("id"), Arrays.asList("name", "salary", "address"));
+    assertEquals(insert, "merge into [Customer] with (HOLDLOCK) AS target using (select ? AS [name], ? AS [salary], ? AS " +
+                         "[address], ? AS [id]) AS incoming on (target.[id]=incoming.[id]) when matched then update set " +
+                         "[name]=incoming.[name],[salary]=incoming.[salary],[address]=incoming.[address] when not matched then insert " +
+                         "([name], [salary], [address], [id]) values (incoming.[name],incoming.[salary],incoming.[address],incoming.[id]);");
+
+  }
+
+  @Test
+  public void produceTheRightSqlStatementWhithACompositePK() {
+    String insert = dialect.getUpsertQuery("Book", Arrays.asList("author", "title"), Arrays.asList("ISBN", "year", "pages"));
+    assertEquals(insert, "merge into [Book] with (HOLDLOCK) AS target using (select ? AS [ISBN], ? AS [year], ? AS [pages], " +
+                         "? AS [author], ? AS [title]) AS incoming on (target.[author]=incoming.[author] and target.[title]=incoming.[title])" +
+                         " when matched then update set [ISBN]=incoming.[ISBN],[year]=incoming.[year],[pages]=incoming.[pages] when not " +
+                         "matched then insert ([ISBN], [year], [pages], [author], [title]) values (incoming.[ISBN],incoming.[year]," +
+                         "incoming.[pages],incoming.[author],incoming.[title]);");
+
+  }
+
+
+  @Test
+  public void handleCreateTableMultiplePKColumns() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "userid", true),
+        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(Schema.Type.STRING, "info", false)
+    ));
+
+    String expected = "CREATE TABLE [tableA] (" + System.lineSeparator() +
+                      "[userid] int NOT NULL," + System.lineSeparator() +
+                      "[userdataid] int NOT NULL," + System.lineSeparator() +
+                      "[info] varchar(256) NULL," + System.lineSeparator() +
+                      "PRIMARY KEY([userid],[userdataid]))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableOnePKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", true),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE [tableA] (" + System.lineSeparator() +
+                      "[col1] int NOT NULL," + System.lineSeparator() +
+                      "[col2] bigint NULL," + System.lineSeparator() +
+                      "[col3] varchar(256) NULL," + System.lineSeparator() +
+                      "[col4] real NULL," + System.lineSeparator() +
+                      "[col5] float NULL," + System.lineSeparator() +
+                      "[col6] bit NULL," + System.lineSeparator() +
+                      "[col7] tinyint NULL," + System.lineSeparator() +
+                      "[col8] smallint NULL," + System.lineSeparator() +
+                      "PRIMARY KEY([col1]))";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleCreateTableNoPKColumn() {
+    String actual = dialect.getCreateQuery("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    String expected = "CREATE TABLE [tableA] (" + System.lineSeparator() +
+                      "[col1] int NULL," + System.lineSeparator() +
+                      "[col2] bigint NULL," + System.lineSeparator() +
+                      "[col3] varchar(256) NULL," + System.lineSeparator() +
+                      "[col4] real NULL," + System.lineSeparator() +
+                      "[col5] float NULL," + System.lineSeparator() +
+                      "[col6] bit NULL," + System.lineSeparator() +
+                      "[col7] tinyint NULL," + System.lineSeparator() +
+                      "[col8] smallint NULL)";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void handleAmendAddColumns() {
+    List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.INT32, "col1", false),
+        new SinkRecordField(Schema.Type.INT64, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(Schema.Type.INT8, "col7", false),
+        new SinkRecordField(Schema.Type.INT16, "col8", false)
+    ));
+
+    assertEquals(1, actual.size());
+
+    String expected = "ALTER TABLE [tableA] ADD" + System.lineSeparator() +
+                      "[col1] int NULL," + System.lineSeparator() +
+                      "[col2] bigint NULL," + System.lineSeparator() +
+                      "[col3] varchar(256) NULL," + System.lineSeparator() +
+                      "[col4] real NULL," + System.lineSeparator() +
+                      "[col5] float NULL," + System.lineSeparator() +
+                      "[col6] bit NULL," + System.lineSeparator() +
+                      "[col7] tinyint NULL," + System.lineSeparator() +
+                      "[col8] smallint NULL";
+    assertEquals(expected, actual.get(0));
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialectTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.dialect;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
+import static org.junit.Assert.assertEquals;
+
+public class SqliteDialectTest {
+  @Test
+  public void validateAlterTable() {
+    List<String> queries = new SqliteDialect().getAlterTable("tableA", Arrays.asList(
+        new SinkRecordField(Schema.Type.BOOLEAN, "col1", false),
+        new SinkRecordField(Schema.Type.FLOAT32, "col2", false),
+        new SinkRecordField(Schema.Type.STRING, "col3", false)
+    ));
+
+    assertEquals(3, queries.size());
+    assertEquals("ALTER TABLE `tableA` ADD `col1` NUMERIC NULL", queries.get(0));
+    assertEquals("ALTER TABLE `tableA` ADD `col2` REAL NULL", queries.get(1));
+    assertEquals("ALTER TABLE `tableA` ADD `col3` TEXT NULL", queries.get(2));
+  }
+
+  @Test
+  public void produceTheRightSqlStatementWhithACompositePK() {
+    String insert = new SqliteDialect().getUpsertQuery("Book", Arrays.asList("author", "title"), Arrays.asList("ISBN", "year", "pages"));
+    assertEquals("insert or ignore into `Book`(`author`,`title`,`ISBN`,`year`,`pages`) values(?,?,?,?,?)", insert);
+
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.metadata;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FieldsMetadataTest {
+
+  private static final Schema SIMPLE_PRIMITIVE_SCHEMA = Schema.INT64_SCHEMA;
+  private static final Schema SIMPLE_STRUCT_SCHEMA = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA).build();
+  private static final Schema SIMPLE_MAP_SCHEMA = SchemaBuilder.map(SchemaBuilder.INT64_SCHEMA, Schema.STRING_SCHEMA);
+
+  @Test(expected = ConnectException.class)
+  public void valueSchemaMustBePresent() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        Collections.<String>emptyList(),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        null
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void valueSchemaMustBeStruct() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        Collections.<String>emptyList(),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        SIMPLE_PRIMITIVE_SCHEMA
+    );
+  }
+
+  @Test
+  public void kafkaPkMode() {
+    FieldsMetadata metadata = extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        Collections.<String>emptyList(),
+        null,
+        SIMPLE_STRUCT_SCHEMA
+    );
+    assertEquals(new HashSet<>(FieldsMetadata.DEFAULT_KAFKA_PK_NAMES), metadata.keyFieldNames);
+    assertEquals(Collections.singleton("name"), metadata.nonKeyFieldNames);
+
+    SinkRecordField topicField = metadata.allFields.get("__connect_topic");
+    assertEquals(Schema.Type.STRING, topicField.type);
+    assertTrue(topicField.isPrimaryKey);
+    assertFalse(topicField.isOptional);
+
+    SinkRecordField partitionField = metadata.allFields.get("__connect_partition");
+    assertEquals(Schema.Type.INT32, partitionField.type);
+    assertTrue(partitionField.isPrimaryKey);
+    assertFalse(partitionField.isOptional);
+
+    SinkRecordField offsetField = metadata.allFields.get("__connect_offset");
+    assertEquals(Schema.Type.INT64, offsetField.type);
+    assertTrue(offsetField.isPrimaryKey);
+    assertFalse(offsetField.isOptional);
+  }
+
+  @Test
+  public void kafkaPkModeCustomNames() {
+    List<String> customKeyNames = Arrays.asList("the_topic", "the_partition", "the_offset");
+    FieldsMetadata metadata = extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        customKeyNames,
+        null,
+        SIMPLE_STRUCT_SCHEMA
+    );
+    assertEquals(new HashSet<>(customKeyNames), metadata.keyFieldNames);
+    assertEquals(Collections.singleton("name"), metadata.nonKeyFieldNames);
+  }
+
+  @Test(expected = ConnectException.class)
+  public void kafkaPkModeBadFieldSpec() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        Collections.singletonList("lone"),
+        null,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  /**
+   * RECORD_KEY test cases:
+   * if keySchema is a struct, pkCols must be a subset of the keySchema fields
+   */
+
+  @Test
+  public void recordKeyPkModePrimitiveKey() {
+    FieldsMetadata metadata = extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Collections.singletonList("the_pk"),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        SIMPLE_STRUCT_SCHEMA
+    );
+
+    assertEquals(Collections.singleton("the_pk"), metadata.keyFieldNames);
+
+    assertEquals(Collections.singleton("name"), metadata.nonKeyFieldNames);
+
+    assertEquals(SIMPLE_PRIMITIVE_SCHEMA.type(), metadata.allFields.get("the_pk").type);
+    assertTrue(metadata.allFields.get("the_pk").isPrimaryKey);
+    assertFalse(metadata.allFields.get("the_pk").isOptional);
+
+    assertEquals(Schema.Type.STRING, metadata.allFields.get("name").type);
+    assertFalse(metadata.allFields.get("name").isPrimaryKey);
+    assertFalse(metadata.allFields.get("name").isOptional);
+  }
+
+  @Test(expected = ConnectException.class)
+  public void recordKeyPkModeWithPrimitiveKeyButMultiplePkFieldsSpecified() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Arrays.asList("pk1", "pk2"),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void recordKeyPkModeButKeySchemaMissing() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Collections.<String>emptyList(),
+        null,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void recordKeyPkModeButKeySchemaAsNonStructCompositeType() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Collections.<String>emptyList(),
+        SIMPLE_MAP_SCHEMA,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void recordKeyPkModeWithStructKeyButMissingField() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Collections.singletonList("nonexistent"),
+        SIMPLE_STRUCT_SCHEMA,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void recordValuePkModeWithMissingPkField() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE,
+        Collections.singletonList("nonexistent"),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  @Test
+  public void recordValuePkModeWithValidPkFields() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE,
+        Collections.singletonList("name"),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        SIMPLE_STRUCT_SCHEMA
+    );
+  }
+
+  private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Schema keySchema, Schema valueSchema) {
+    return FieldsMetadata.extract("table", pkMode, pkFields, keySchema, valueSchema);
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.derby.jdbc.EmbeddedDriver;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.source.SourceTaskContext;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/io/confluent/connect/jdbc/source/MockTime.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/MockTime.java
@@ -1,4 +1,20 @@
-package io.confluent.connect.jdbc;
+/*
+ *  Copyright 2016 Confluent Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.common.utils.Time;
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.easymock.EasyMock;

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.jdbc;
+package io.confluent.connect.jdbc.source;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Timestamp;
+
+import io.confluent.connect.jdbc.source.TimestampIncrementingOffset;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
There are 2 commits to review here:

1. Preparatory -- move classes from source into a subpkg (except the Connector):
https://github.com/confluentinc/kafka-connect-jdbc/pull/100/commits/d0d47923c4c4712dfa20377dd55af61b81f5bb8c

2. The merge -- https://github.com/confluentinc/kafka-connect-jdbc/pull/100/commits/2c6cb8ced93aa874b41419a0d55cf71423529233 -- which introduces all the history. The merge-related changes worth reviewing are in: `checkstyle.xml` & `pom.xml`. Rest is purely code addition.