### PR TITLE
Remove 'contextual' config bits

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -39,9 +39,6 @@ public class JdbcSinkConfig extends AbstractConfig {
     RECORD_VALUE;
   }
 
-  private static final String TABLE_OVERRIDABLE_DOC = "\nThis config is overridable at the table-level by using a '$table.' prefix.";
-  private static final String TOPIC_OVERRIDABLE_DOC = "\nThis config is overridable at the topic-level by using a '$topic.' prefix.";
-
   public static final String CONNECTION_URL = "connection.url";
   private static final String CONNECTION_URL_DOC = "JDBC connection URL."
                                                    + "\nThe protocol portion will be used for determining the SQL dialect to be used.";
@@ -56,7 +53,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
   private static final String TABLE_NAME_FORMAT_DOC =
       "A format string for the destination table name, which may contain '${topic}' as a placeholder for the originating topic name."
-      + "\nFor example, \"kafka_${topic}\" for the topic 'orders' will map to the table name 'kafka_orders'." + TOPIC_OVERRIDABLE_DOC;
+      + "\nFor example, \"kafka_${topic}\" for the topic 'orders' will map to the table name 'kafka_orders'.";
 
   public static final String MAX_RETRIES = "max.retries";
   private static final int MAX_RETRIES_DEFAULT = 10;
@@ -69,23 +66,22 @@ public class JdbcSinkConfig extends AbstractConfig {
   public static final String BATCH_SIZE = "batch.size";
   private static final int BATCH_SIZE_DEFAULT = 3000;
   private static final String BATCH_SIZE_DOC =
-      "Specifies how many records to attempt to batch together for insertion, when possible." + TABLE_OVERRIDABLE_DOC;
+      "Specifies how many records to attempt to batch together for insertion, when possible.";
 
   public static final String AUTO_CREATE = "auto.create";
   private static final String AUTO_CREATE_DEFAULT = "false";
   private static final String AUTO_CREATE_DOC =
-      "Whether to automatically create tables based on record schema if the sink table is found to be missing, by issuing a CREATE statement." + TABLE_OVERRIDABLE_DOC;
+      "Whether to automatically create tables based on record schema if the sink table is found to be missing, by issuing a CREATE statement.";
 
   public static final String AUTO_EVOLVE = "auto.evolve";
   private static final String AUTO_EVOLVE_DEFAULT = "false";
   private static final String AUTO_EVOLVE_DOC =
-      "Whether to automatically evolve table schema when record schema and table schema is found to be incompatible, by issuing an ALTER statement." + TABLE_OVERRIDABLE_DOC;
+      "Whether to automatically evolve table schema when record schema and table schema is found to be incompatible, by issuing an ALTER statement.";
 
   public static final String INSERT_MODE = "insert.mode";
   private static final String INSERT_MODE_DEFAULT = "insert";
   private static final String INSERT_MODE_DOC =
-      "The insertion mode to use. Supported modes are 'insert' and 'upsert', with the latter translated to the appropriate upsert semantics for the target database if it is supported."
-      + TABLE_OVERRIDABLE_DOC;
+      "The insertion mode to use. Supported modes are 'insert' and 'upsert', with the latter translated to the appropriate upsert semantics for the target database if it is supported.";
 
   public static final String PK_MODE = "pk.mode";
   private static final String PK_MODE_DEFAULT = "none";
@@ -139,7 +135,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getString(CONNECTION_PASSWORD);
-    tableNameFormat = getString(TABLE_NAME_FORMAT);
+    tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
     maxRetries = getInt(MAX_RETRIES);
     retryBackoffMs = getInt(RETRY_BACKOFF_MS);
@@ -148,12 +144,6 @@ public class JdbcSinkConfig extends AbstractConfig {
     insertMode = InsertMode.valueOf(getString(INSERT_MODE).toUpperCase());
     pkMode = PrimaryKeyMode.valueOf(getString(PK_MODE).toUpperCase());
     pkFields = getList(PK_FIELDS);
-  }
-
-  public JdbcSinkConfig contextualConfig(String context) {
-    final Map<String, Object> properties = originals();
-    properties.putAll(originalsWithPrefix(context + "."));
-    return new JdbcSinkConfig(properties);
   }
 
   private static class EnumValidator implements ConfigDef.Validator {


### PR DESCRIPTION
If custom configuration is desired for some topics, tables etc. currently going to go with expecting users to start multiple connectors