### PR TITLE
CC-278: Sink: support Connect schema logical types

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -161,11 +161,11 @@ public class PreparedStatementBinder {
     } else {
       if (schema.name() != null) {
         LogicalTypeConverter logicalConverter = LOGICAL_CONVERTERS.get(schema.name());
-        if (logicalConverter != null)
+        if (logicalConverter != null) {
           value = logicalConverter.convert(schema, value);
+        }
       }
-      Schema.Type type = schema.type();
-      switch (type) {
+      switch (schema.type()) {
         case INT8:
           statement.setByte(index, (Byte) value);
           break;
@@ -202,7 +202,7 @@ public class PreparedStatementBinder {
           statement.setBytes(index, bytes);
           break;
         default:
-          throw new ConnectException("Unsupported source data type: " + type);
+          throw new ConnectException("Unsupported source data type: " + schema.type());
       }
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -16,20 +16,72 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.HashMap;
 
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 
 public class PreparedStatementBinder {
+
+  // Convert values in Connect form from their logical types. These logical converters are discovered by logical type
+  // names specified in the field
+  private static final HashMap<String, LogicalTypeConverter> LOGICAL_CONVERTERS = new HashMap<>();
+  static {
+    LOGICAL_CONVERTERS.put(Decimal.LOGICAL_NAME, new LogicalTypeConverter() {
+      @Override
+      public Object convert(Schema schema, Object value) {
+        if (!(value instanceof BigDecimal)) {
+          throw new DataException("Invalid type for Decimal, underlying representation should be BigDecimal but was " + value.getClass());
+        }
+        return Decimal.fromLogical(schema, (BigDecimal) value);
+      }
+    });
+
+    LOGICAL_CONVERTERS.put(Date.LOGICAL_NAME, new LogicalTypeConverter() {
+      @Override
+      public Object convert(Schema schema, Object value) {
+        if (!(value instanceof java.util.Date)) {
+          throw new DataException("Invalid type for Date, underlying representation should be java.util.Date but was " + value.getClass());
+        }
+        return Date.fromLogical(schema, (java.util.Date) value);
+      }
+    });
+
+    LOGICAL_CONVERTERS.put(Time.LOGICAL_NAME, new LogicalTypeConverter() {
+      @Override
+      public Object convert(Schema schema, Object value) {
+        if (!(value instanceof java.util.Date)) {
+          throw new DataException("Invalid type for Date, underlying representation should be java.util.Date but was " + value.getClass());
+        }
+        return Time.fromLogical(schema, (java.util.Date) value);
+      }
+    });
+
+    LOGICAL_CONVERTERS.put(Timestamp.LOGICAL_NAME, new LogicalTypeConverter() {
+      @Override
+      public Object convert(Schema schema, Object value) {
+        if (!(value instanceof java.util.Date)) {
+          throw new DataException("Invalid type for Date, underlying representation should be java.util.Date but was " + value.getClass());
+        }
+        return Timestamp.fromLogical(schema, (java.util.Date) value);
+      }
+    });
+  }
   private final JdbcSinkConfig.PrimaryKeyMode pkMode;
   private final PreparedStatement statement;
   private final SchemaPair schemaPair;
@@ -63,20 +115,20 @@ public class PreparedStatementBinder {
 
       case KAFKA: {
         assert fieldsMetadata.keyFieldNames.size() == 3;
-        bindField(index++, Schema.Type.STRING, record.topic());
-        bindField(index++, Schema.Type.INT32, record.kafkaPartition());
-        bindField(index++, Schema.Type.INT64, record.kafkaOffset());
+        bindField(index++, Schema.STRING_SCHEMA, record.topic());
+        bindField(index++, Schema.INT32_SCHEMA, record.kafkaPartition());
+        bindField(index++, Schema.INT64_SCHEMA, record.kafkaOffset());
       }
       break;
 
       case RECORD_KEY: {
         if (schemaPair.keySchema.type().isPrimitive()) {
           assert fieldsMetadata.keyFieldNames.size() == 1;
-          bindField(index++, schemaPair.keySchema.type(), record.key());
+          bindField(index++, schemaPair.keySchema, record.key());
         } else {
           for (String fieldName : fieldsMetadata.keyFieldNames) {
             final Field field = schemaPair.keySchema.field(fieldName);
-            bindField(index++, field.schema().type(), ((Struct) record.key()).get(field));
+            bindField(index++, field.schema(), ((Struct) record.key()).get(field));
           }
         }
       }
@@ -85,7 +137,7 @@ public class PreparedStatementBinder {
       case RECORD_VALUE: {
         for (String fieldName : fieldsMetadata.keyFieldNames) {
           final Field field = schemaPair.valueSchema.field(fieldName);
-          bindField(index++, field.schema().type(), ((Struct) record.value()).get(field));
+          bindField(index++, field.schema(), ((Struct) record.value()).get(field));
         }
       }
       break;
@@ -93,20 +145,26 @@ public class PreparedStatementBinder {
 
     for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
       final Field field = record.valueSchema().field(fieldName);
-      bindField(index++, field.schema().type(), valueStruct.get(field));
+      bindField(index++, field.schema(), valueStruct.get(field));
     }
 
     statement.addBatch();
   }
 
-  void bindField(int index, Schema.Type type, Object value) throws SQLException {
-    bindField(statement, index, type, value);
+  void bindField(int index, Schema schema, Object value) throws SQLException {
+    bindField(statement, index, schema, value);
   }
 
-  static void bindField(PreparedStatement statement, int index, Schema.Type type, Object value) throws SQLException {
+  static void bindField(PreparedStatement statement, int index, Schema schema, Object value) throws SQLException {
     if (value == null) {
       statement.setObject(index, null);
     } else {
+      if (schema.name() != null) {
+        LogicalTypeConverter logicalConverter = LOGICAL_CONVERTERS.get(schema.name());
+        if (logicalConverter != null)
+          value = logicalConverter.convert(schema, value);
+      }
+      Schema.Type type = schema.type();
       switch (type) {
         case INT8:
           statement.setByte(index, (Byte) value);
@@ -147,5 +205,9 @@ public class PreparedStatementBinder {
           throw new ConnectException("Unsupported source data type: " + type);
       }
     }
+  }
+
+  private interface LogicalTypeConverter {
+    Object convert(Schema schema, Object value);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -16,17 +16,24 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -41,7 +48,7 @@ import static org.mockito.Mockito.verify;
 public class PreparedStatementBinderTest {
 
   @Test
-  public void bindRecord() throws SQLException {
+  public void bindRecord() throws SQLException, ParseException {
     Schema valueSchema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstName", Schema.STRING_SCHEMA)
         .field("lastName", Schema.STRING_SCHEMA)
@@ -54,6 +61,10 @@ public class PreparedStatementBinderTest {
         .field("double", Schema.FLOAT64_SCHEMA)
         .field("bytes", Schema.BYTES_SCHEMA)
         .field("threshold", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("date", Date.SCHEMA)
+        .field("time", Time.SCHEMA)
+        .field("timestamp", Timestamp.SCHEMA)
+        .field("decimal", Decimal.schema(0))
         .build();
 
     Struct valueStruct = new Struct(valueSchema)
@@ -66,7 +77,18 @@ public class PreparedStatementBinderTest {
         .put("float", (float) 2356.3)
         .put("double", -2436546.56457)
         .put("bytes", new byte[]{-32, 124})
-        .put("age", 30);
+        .put("age", 30)
+        .put("decimal", new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN));
+
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTimeInMillis(0);
+    calendar.set(2000, 1, 1);
+    valueStruct.put("date", calendar.getTime());
+
+    calendar.setTimeInMillis(1000);
+    valueStruct.put("time", calendar.getTime());
+
+    valueStruct.put("timestamp", calendar.getTime());
 
     SchemaPair schemaPair = new SchemaPair(null, valueSchema);
 
@@ -108,57 +130,59 @@ public class PreparedStatementBinderTest {
   @Test
   public void bindFieldPrimitiveValues() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
-    verifyBindField(++index, Schema.Type.INT8, (byte) 42).setByte(index, (byte) 42);
-    verifyBindField(++index, Schema.Type.INT16, (short) 42).setShort(index, (short) 42);
-    verifyBindField(++index, Schema.Type.INT32, 42).setInt(index, 42);
-    verifyBindField(++index, Schema.Type.INT64, 42L).setLong(index, 42L);
-    verifyBindField(++index, Schema.Type.BOOLEAN, false).setBoolean(index, false);
-    verifyBindField(++index, Schema.Type.BOOLEAN, true).setBoolean(index, true);
-    verifyBindField(++index, Schema.Type.FLOAT32, -42f).setFloat(index, -42f);
-    verifyBindField(++index, Schema.Type.FLOAT64, 42d).setDouble(index, 42d);
-    verifyBindField(++index, Schema.Type.BYTES, new byte[]{42}).setBytes(index, new byte[]{42});
-    verifyBindField(++index, Schema.Type.BYTES, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
-    verifyBindField(++index, Schema.Type.STRING, "yep").setString(index, "yep");
+    verifyBindField(++index, Schema.INT8_SCHEMA, (byte) 42).setByte(index, (byte) 42);
+    verifyBindField(++index, Schema.INT16_SCHEMA, (short) 42).setShort(index, (short) 42);
+    verifyBindField(++index, Schema.INT32_SCHEMA, 42).setInt(index, 42);
+    verifyBindField(++index, Schema.INT64_SCHEMA, 42L).setLong(index, 42L);
+    verifyBindField(++index, Schema.BOOLEAN_SCHEMA, false).setBoolean(index, false);
+    verifyBindField(++index, Schema.BOOLEAN_SCHEMA, true).setBoolean(index, true);
+    verifyBindField(++index, Schema.FLOAT32_SCHEMA, -42f).setFloat(index, -42f);
+    verifyBindField(++index, Schema.FLOAT64_SCHEMA, 42d).setDouble(index, 42d);
+    verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
+    verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
   }
 
   @Test
   public void bindFieldNull() throws SQLException {
-    final List<Schema.Type> nullableTypes = Arrays.asList(
-        Schema.Type.INT8,
-        Schema.Type.INT16,
-        Schema.Type.INT32,
-        Schema.Type.INT64,
-        Schema.Type.FLOAT32,
-        Schema.Type.FLOAT64,
-        Schema.Type.BOOLEAN,
-        Schema.Type.BYTES,
-        Schema.Type.STRING
+    final List<Schema> nullableTypes = Arrays.asList(
+        Schema.INT8_SCHEMA,
+        Schema.INT16_SCHEMA,
+        Schema.INT32_SCHEMA,
+        Schema.INT64_SCHEMA,
+        Schema.FLOAT32_SCHEMA,
+        Schema.FLOAT64_SCHEMA,
+        Schema.BOOLEAN_SCHEMA,
+        Schema.BYTES_SCHEMA,
+        Schema.STRING_SCHEMA
     );
     int index = 0;
-    for (Schema.Type type : nullableTypes) {
-      verifyBindField(++index, type, null).setObject(index, null);
+    for (Schema schema : nullableTypes) {
+      verifyBindField(++index, schema, null).setObject(index, null);
     }
   }
 
   @Test(expected = ConnectException.class)
   public void bindFieldStructUnsupported() throws SQLException {
     Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
-    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, Schema.Type.STRUCT, new Struct(structSchema));
+    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
   }
 
   @Test(expected = ConnectException.class)
   public void bindFieldArrayUnsupported() throws SQLException {
-    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, Schema.Type.ARRAY, Collections.emptyList());
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
   }
 
   @Test(expected = ConnectException.class)
   public void bindFieldMapUnsupported() throws SQLException {
-    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, Schema.Type.MAP, Collections.emptyMap());
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 
-  private PreparedStatement verifyBindField(int index, Schema.Type schemaType, Object value) throws SQLException {
+  private PreparedStatement verifyBindField(int index, Schema schema, Object value) throws SQLException {
     PreparedStatement statement = mock(PreparedStatement.class);
-    PreparedStatementBinder.bindField(statement, index, schemaType, value);
+    PreparedStatementBinder.bindField(statement, index, schema, value);
     return verify(statement, times(1));
   }
 


### PR DESCRIPTION
Currently the sink doesn't support the logical types:

* `org.apache.kafka.connect.data.Date`
* `org.apache.kafka.connect.data.Time`
* `org.apache.kafka.connect.data.Timestamp`
* `org.apache.kafka.connect.data.Decimal`

The fields with such types have primitive schema type, but also a name.
The logical type is determined by the name.

When the converter see a logical type it converts the value to some higher level type:
 * `Date`: from `int` to `java.util.Date`
 * `Time`: from `int` to `java.util.Date`
 * `Timestamp`: from `long` to `java.util.Date`
 * `Decimal`: from `bytes[]` to `BigDecimal`

The problem is that the statement builder doesn't know that. For example it thinks that `Timestamp` is `long`, but it is `java.util.Date`.

I don't write much Java and maybe the code is not very good, but it fixes the problem.