### PR TITLE
Ability to set the schema pattern for tables metadata retrieval

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -16,6 +16,12 @@
 
 package io.confluent.connect.jdbc;
 
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import io.confluent.connect.jdbc.source.JdbcSourceTask;
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+import io.confluent.connect.jdbc.source.TableMonitorThread;
+import io.confluent.connect.jdbc.util.StringUtils;
+import io.confluent.connect.jdbc.util.Version;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
@@ -35,13 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
-import io.confluent.connect.jdbc.source.JdbcSourceTask;
-import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
-import io.confluent.connect.jdbc.source.TableMonitorThread;
-import io.confluent.connect.jdbc.util.StringUtils;
-import io.confluent.connect.jdbc.util.Version;
 
 /**
  * JdbcConnector is a Kafka Connect Connector implementation that watches a JDBC database and
@@ -96,6 +95,7 @@ public class JdbcSourceConnector extends SourceConnector {
                                  + JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG + " are "
                                  + "exclusive.");
     String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
+    String schemaPattern = config.getString(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG);
     if (!query.isEmpty()) {
       if (whitelistSet != null || blacklistSet != null)
         throw new ConnectException(JdbcSourceConnectorConfig.QUERY_CONFIG + " may not be combined"
@@ -104,7 +104,7 @@ public class JdbcSourceConnector extends SourceConnector {
       // query.
       whitelistSet = Collections.emptySet();
     }
-    tableMonitorThread = new TableMonitorThread(db, context, tablePollMs, whitelistSet,
+    tableMonitorThread = new TableMonitorThread(db, schemaPattern, context, tablePollMs, whitelistSet,
                                                 blacklistSet, tableTypesSet);
     tableMonitorThread.start();
   }

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -105,7 +105,7 @@ public class JdbcSourceConnector extends SourceConnector {
       // query.
       whitelistSet = Collections.emptySet();
     }
-    tableMonitorThread = new TableMonitorThread(db, schemaPattern, context, tablePollMs,
+    tableMonitorThread = new TableMonitorThread(db, context, schemaPattern, tablePollMs,
                                                 whitelistSet, blacklistSet, tableTypesSet);
     tableMonitorThread.start();
   }

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -16,12 +16,6 @@
 
 package io.confluent.connect.jdbc;
 
-import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
-import io.confluent.connect.jdbc.source.JdbcSourceTask;
-import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
-import io.confluent.connect.jdbc.source.TableMonitorThread;
-import io.confluent.connect.jdbc.util.StringUtils;
-import io.confluent.connect.jdbc.util.Version;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
@@ -41,6 +35,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import io.confluent.connect.jdbc.source.JdbcSourceTask;
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+import io.confluent.connect.jdbc.source.TableMonitorThread;
+import io.confluent.connect.jdbc.util.StringUtils;
+import io.confluent.connect.jdbc.util.Version;
 
 /**
  * JdbcConnector is a Kafka Connect Connector implementation that watches a JDBC database and
@@ -104,8 +105,8 @@ public class JdbcSourceConnector extends SourceConnector {
       // query.
       whitelistSet = Collections.emptySet();
     }
-    tableMonitorThread = new TableMonitorThread(db, schemaPattern, context, tablePollMs, whitelistSet,
-                                                blacklistSet, tableTypesSet);
+    tableMonitorThread = new TableMonitorThread(db, schemaPattern, context, tablePollMs,
+                                                whitelistSet, blacklistSet, tableTypesSet);
     tableMonitorThread.start();
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -28,16 +29,14 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
-
 /**
  * BulkTableQuerier always returns the entire table.
  */
 public class BulkTableQuerier extends TableQuerier {
   private static final Logger log = LoggerFactory.getLogger(BulkTableQuerier.class);
 
-  public BulkTableQuerier(QueryMode mode, String name, String topicPrefix) {
-    super(mode, name, topicPrefix);
+  public BulkTableQuerier(QueryMode mode, String name, String schemaPattern, String topicPrefix) {
+    super(mode, name, topicPrefix, schemaPattern);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -28,6 +27,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 /**
  * BulkTableQuerier always returns the entire table.

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -143,7 +143,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
 
-  public static final String SCHEMA_PATTERN_CONFIG = "schemaPattern";
+  public static final String SCHEMA_PATTERN_CONFIG = "schema.pattern";
   private static final String SCHEMA_PATTERN_DOC = "Schema pattern to fetch tables metadata";
 
   public static final String DATABASE_GROUP = "Database";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -110,10 +110,10 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public static final String SCHEMA_PATTERN_CONFIG = "schema.pattern";
   private static final String SCHEMA_PATTERN_DOC =
-      "Schema pattern to fetch tables metadata from:\n"
+      "Schema pattern to fetch tables metadata from the database:\n"
       + "  * \"\" retrieves those without a schema,"
       + "  * null (default) means that the schema name should not be used to narrow the search, all tables "
-      + "metadata would be fetched, regardless there schema.";
+      + "metadata would be fetched, regardless their schema.";
   private static final String SCHEMA_PATTERN_DISPLAY = "Schema pattern";
 
   public static final String QUERY_CONFIG = "query";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -108,6 +108,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String TABLE_BLACKLIST_DEFAULT = "";
   private static final String TABLE_BLACKLIST_DISPLAY = "Table Blacklist";
 
+  public static final String SCHEMA_PATTERN_CONFIG = "schema.pattern";
+  private static final String SCHEMA_PATTERN_DOC =
+      "Schema pattern to fetch tables metadata from:\n"
+      + "  * \"\" retrieves those without a schema,"
+      + "  * null (default) means that the schema name should not be used to narrow the search, all tables "
+      + "metadata would be fetched, regardless there schema.";
+  private static final String SCHEMA_PATTERN_DISPLAY = "Schema pattern";
+
   public static final String QUERY_CONFIG = "query";
   private static final String QUERY_DOC =
       "If specified, the query to perform to select new or updated rows. Use this setting if you "
@@ -143,9 +151,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
 
-  public static final String SCHEMA_PATTERN_CONFIG = "schema.pattern";
-  private static final String SCHEMA_PATTERN_DOC = "Schema pattern to fetch tables metadata";
-
   public static final String DATABASE_GROUP = "Database";
   public static final String MODE_GROUP = "Mode";
   public static final String CONNECTOR_GROUP = "Connector";
@@ -177,6 +182,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                 TABLE_RECOMMENDER)
         .define(TABLE_BLACKLIST_CONFIG, Type.LIST, TABLE_BLACKLIST_DEFAULT, Importance.MEDIUM, TABLE_BLACKLIST_DOC, DATABASE_GROUP, 3, Width.LONG, TABLE_BLACKLIST_DISPLAY,
                 TABLE_RECOMMENDER)
+        .define(SCHEMA_PATTERN_CONFIG, Type.STRING, null, Importance.MEDIUM, SCHEMA_PATTERN_DOC, DATABASE_GROUP, 4, Width.SHORT, SCHEMA_PATTERN_DISPLAY)
         .define(TABLE_TYPE_CONFIG, Type.LIST, TABLE_TYPE_DEFAULT, Importance.LOW,
                 TABLE_TYPE_DOC, CONNECTOR_GROUP, 4, Width.MEDIUM, TABLE_TYPE_DISPLAY)
         .define(MODE_CONFIG, Type.STRING, MODE_UNSPECIFIED, ConfigDef.ValidString.in(MODE_UNSPECIFIED, MODE_BULK, MODE_TIMESTAMP, MODE_INCREMENTING, MODE_TIMESTAMP_INCREMENTING),
@@ -192,7 +198,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         .define(BATCH_MAX_ROWS_CONFIG, Type.INT, BATCH_MAX_ROWS_DEFAULT, Importance.LOW, BATCH_MAX_ROWS_DOC, CONNECTOR_GROUP, 2, Width.SHORT, BATCH_MAX_ROWS_DISPLAY)
         .define(TABLE_POLL_INTERVAL_MS_CONFIG, Type.LONG, TABLE_POLL_INTERVAL_MS_DEFAULT, Importance.LOW, TABLE_POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 3, Width.SHORT, TABLE_POLL_INTERVAL_MS_DISPLAY)
         .define(TOPIC_PREFIX_CONFIG, Type.STRING, Importance.HIGH, TOPIC_PREFIX_DOC, CONNECTOR_GROUP, 4, Width.MEDIUM, TOPIC_PREFIX_DISPLAY)
-        .define(SCHEMA_PATTERN_CONFIG, Type.STRING, null, Importance.MEDIUM, SCHEMA_PATTERN_DOC, DATABASE_GROUP, 5, Width.SHORT, QUERY_DISPLAY)
         .define(TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, Type.LONG, TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT, Importance.HIGH, TIMESTAMP_DELAY_INTERVAL_MS_DOC, CONNECTOR_GROUP, 5, Width.MEDIUM, TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -16,8 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
-import io.confluent.connect.jdbc.util.Version;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -36,6 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
+import io.confluent.connect.jdbc.util.Version;
 
 /**
  * JdbcSourceTask is a Kafka Connect SourceTask implementation that reads from JDBC databases and

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -49,7 +49,6 @@ public class JdbcSourceTask extends SourceTask {
   private Time time;
   private JdbcSourceTaskConfig config;
   private Connection db;
-  private String schemaPattern;
   private PriorityQueue<TableQuerier> tableQueue = new PriorityQueue<TableQuerier>();
   private AtomicBoolean stop;
 
@@ -74,7 +73,6 @@ public class JdbcSourceTask extends SourceTask {
       throw new ConnectException("Couldn't start JdbcSourceTask due to configuration error", e);
     }
 
-    this.schemaPattern = config.getString(JdbcSourceTaskConfig.SCHEMA_PATTERN_CONFIG);
     List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
     if ((tables.isEmpty() && query.isEmpty()) || (!tables.isEmpty() && !query.isEmpty())) {
@@ -135,7 +133,7 @@ public class JdbcSourceTask extends SourceTask {
       switch (queryMode) {
         case TABLE:
           if (validateNonNulls) {
-            validateNonNullable(mode, tableOrQuery, incrementingColumn, timestampColumn);
+            validateNonNullable(mode, schemaPattern, tableOrQuery, incrementingColumn, timestampColumn);
           }
           partition = Collections.singletonMap(
               JdbcSourceConnectorConstants.TABLE_NAME_KEY, tableOrQuery);
@@ -251,7 +249,7 @@ public class JdbcSourceTask extends SourceTask {
     return null;
   }
 
-  private void validateNonNullable(String incrementalMode, String table, String incrementingColumn,
+  private void validateNonNullable(String incrementalMode, String schemaPattern, String table, String incrementingColumn,
                                    String timestampColumn) {
     try {
       // Validate that requested columns for offsets are NOT NULL. Currently this is only performed

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
@@ -30,6 +29,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 /**
  * Thread that monitors the database for changes to the set of tables in the database that this

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -49,7 +49,7 @@ public class TableMonitorThread extends Thread {
   private List<String> tables;
   private Set<String> tableTypes;
 
-  public TableMonitorThread(Connection db, String schemaPattern, ConnectorContext context, long pollMs,
+  public TableMonitorThread(Connection db, ConnectorContext context, String schemaPattern, long pollMs,
                             Set<String> whitelist, Set<String> blacklist, Set<String> tableTypes) {
     this.db = db;
     this.schemaPattern = schemaPattern;

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -36,6 +36,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   }
 
   protected final QueryMode mode;
+  protected String schemaPattern;
   protected final String name;
   protected final String query;
   protected final String topicPrefix;
@@ -44,8 +45,9 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected ResultSet resultSet;
   protected Schema schema;
 
-  public TableQuerier(QueryMode mode, String nameOrQuery, String topicPrefix) {
+  public TableQuerier(QueryMode mode, String nameOrQuery, String topicPrefix, String schemaPattern) {
     this.mode = mode;
+    this.schemaPattern = schemaPattern;
     this.name = mode.equals(QueryMode.TABLE) ? nameOrQuery : null;
     this.query = mode.equals(QueryMode.QUERY) ? nameOrQuery : null;
     this.topicPrefix = topicPrefix;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Confluent Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -31,8 +32,6 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.Map;
 import java.util.TimeZone;
-
-import io.confluent.connect.jdbc.util.JdbcUtils;
 
 /**
  * <p>
@@ -63,8 +62,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
                                            String timestampColumn, String incrementingColumn,
-                                           Map<String, Object> offsetMap, Long timestampDelay) {
-    super(mode, name, topicPrefix);
+                                           Map<String, Object> offsetMap, Long timestampDelay, String schemaPattern) {
+    super(mode, name, topicPrefix, schemaPattern);
     this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
     this.timestampDelay = timestampDelay;
@@ -75,7 +74,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   protected void createPreparedStatement(Connection db) throws SQLException {
     // Default when unspecified uses an autoincrementing column
     if (incrementingColumn != null && incrementingColumn.isEmpty()) {
-      incrementingColumn = JdbcUtils.getAutoincrementColumn(db, name);
+      incrementingColumn = JdbcUtils.getAutoincrementColumn(db, schemaPattern, name);
     }
 
     String quoteString = JdbcUtils.getIdentifierQuoteString(db);
@@ -145,7 +144,6 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   }
 
 
-
   @Override
   protected ResultSet executeQuery() throws SQLException {
     if (incrementingColumn != null && timestampColumn != null) {
@@ -157,9 +155,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       stmt.setLong(3, incOffset);
       stmt.setTimestamp(4, tsOffset, UTC_CALENDAR);
       log.debug("Executing prepared statement with start time value = {} end time = {} and incrementing value = {}",
-              JdbcUtils.formatUTC(tsOffset),
-              JdbcUtils.formatUTC(endTime),
-              incOffset);
+          JdbcUtils.formatUTC(tsOffset),
+          JdbcUtils.formatUTC(endTime),
+          incOffset);
     } else if (incrementingColumn != null) {
       Long incOffset = offset.getIncrementingOffset();
       stmt.setLong(1, incOffset);
@@ -170,8 +168,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       stmt.setTimestamp(1, tsOffset, UTC_CALENDAR);
       stmt.setTimestamp(2, endTime, UTC_CALENDAR);
       log.debug("Executing prepared statement with timestamp value = {} end time = {}",
-              JdbcUtils.formatUTC(tsOffset),
-              JdbcUtils.formatUTC(endTime));
+          JdbcUtils.formatUTC(tsOffset),
+          JdbcUtils.formatUTC(endTime));
     }
     return stmt.executeQuery();
   }
@@ -191,7 +189,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
           break;
         default:
           throw new ConnectException("Invalid type for incrementing column: "
-                                            + schema.field(incrementingColumn).schema().type());
+            + schema.field(incrementingColumn).schema().type());
       }
 
       // If we are only using an incrementing column, then this must be incrementing. If we are also
@@ -216,7 +214,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
         break;
       case QUERY:
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-                                             JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
+          JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
         topic = topicPrefix;
         break;
       default:
@@ -228,11 +226,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   @Override
   public String toString() {
     return "TimestampIncrementingTableQuerier{" +
-           "name='" + name + '\'' +
-           ", query='" + query + '\'' +
-           ", topicPrefix='" + topicPrefix + '\'' +
-           ", timestampColumn='" + timestampColumn + '\'' +
-           ", incrementingColumn='" + incrementingColumn + '\'' +
-           '}';
+      "name='" + name + '\'' +
+      ", query='" + query + '\'' +
+      ", topicPrefix='" + topicPrefix + '\'' +
+      ", timestampColumn='" + timestampColumn + '\'' +
+      ", incrementingColumn='" + incrementingColumn + '\'' +
+      '}';
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Confluent Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -32,6 +31,8 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.Map;
 import java.util.TimeZone;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 /**
  * <p>
@@ -62,7 +63,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
                                            String timestampColumn, String incrementingColumn,
-                                           Map<String, Object> offsetMap, Long timestampDelay, String schemaPattern) {
+                                           Map<String, Object> offsetMap, Long timestampDelay,
+                                           String schemaPattern) {
     super(mode, name, topicPrefix, schemaPattern);
     this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
@@ -144,6 +146,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   }
 
 
+
   @Override
   protected ResultSet executeQuery() throws SQLException {
     if (incrementingColumn != null && timestampColumn != null) {
@@ -155,9 +158,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       stmt.setLong(3, incOffset);
       stmt.setTimestamp(4, tsOffset, UTC_CALENDAR);
       log.debug("Executing prepared statement with start time value = {} end time = {} and incrementing value = {}",
-          JdbcUtils.formatUTC(tsOffset),
-          JdbcUtils.formatUTC(endTime),
-          incOffset);
+              JdbcUtils.formatUTC(tsOffset),
+              JdbcUtils.formatUTC(endTime),
+              incOffset);
     } else if (incrementingColumn != null) {
       Long incOffset = offset.getIncrementingOffset();
       stmt.setLong(1, incOffset);
@@ -168,8 +171,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       stmt.setTimestamp(1, tsOffset, UTC_CALENDAR);
       stmt.setTimestamp(2, endTime, UTC_CALENDAR);
       log.debug("Executing prepared statement with timestamp value = {} end time = {}",
-          JdbcUtils.formatUTC(tsOffset),
-          JdbcUtils.formatUTC(endTime));
+              JdbcUtils.formatUTC(tsOffset),
+              JdbcUtils.formatUTC(endTime));
     }
     return stmt.executeQuery();
   }
@@ -189,7 +192,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
           break;
         default:
           throw new ConnectException("Invalid type for incrementing column: "
-            + schema.field(incrementingColumn).schema().type());
+                                            + schema.field(incrementingColumn).schema().type());
       }
 
       // If we are only using an incrementing column, then this must be incrementing. If we are also
@@ -214,7 +217,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
         break;
       case QUERY:
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-          JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
+                                             JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
         topic = topicPrefix;
         break;
       default:
@@ -226,11 +229,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   @Override
   public String toString() {
     return "TimestampIncrementingTableQuerier{" +
-      "name='" + name + '\'' +
-      ", query='" + query + '\'' +
-      ", topicPrefix='" + topicPrefix + '\'' +
-      ", timestampColumn='" + timestampColumn + '\'' +
-      ", incrementingColumn='" + incrementingColumn + '\'' +
-      '}';
+           "name='" + name + '\'' +
+           ", query='" + query + '\'' +
+           ", topicPrefix='" + topicPrefix + '\'' +
+           ", timestampColumn='" + timestampColumn + '\'' +
+           ", incrementingColumn='" + incrementingColumn + '\'' +
+           '}';
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -78,8 +78,8 @@ public class JdbcUtils {
    * @return a list of tables
    * @throws SQLException
    */
-  public static List<String> getTables(Connection conn) throws SQLException {
-    return getTables(conn, DEFAULT_TABLE_TYPES);
+  public static List<String> getTables(Connection conn, String schemaPattern) throws SQLException {
+    return getTables(conn, schemaPattern, DEFAULT_TABLE_TYPES);
   }
 
   /**
@@ -88,9 +88,9 @@ public class JdbcUtils {
    * @param types a set of table types that should be included in the results
    * @throws SQLException
    */
-  public static List<String> getTables(Connection conn, Set<String> types) throws SQLException {
+  public static List<String> getTables(Connection conn, String schemaPattern, Set<String> types) throws SQLException {
     DatabaseMetaData metadata = conn.getMetaData();
-    try (ResultSet rs = metadata.getTables(null, null, "%", null)) {
+    try (ResultSet rs = metadata.getTables(null, schemaPattern, "%", null)) {
       List<String> tableNames = new ArrayList<>();
       while (rs.next()) {
         if (types.contains(rs.getString(GET_TABLES_TYPE_COLUMN))) {
@@ -115,11 +115,11 @@ public class JdbcUtils {
    *         autoincrement column or more than one exists
    * @throws SQLException
    */
-  public static String getAutoincrementColumn(Connection conn, String table) throws SQLException {
+  public static String getAutoincrementColumn(Connection conn, String schemaPattern, String table) throws SQLException {
     String result = null;
     int matches = 0;
 
-    try (ResultSet rs = conn.getMetaData().getColumns(null, null, table, "%")) {
+    try (ResultSet rs = conn.getMetaData().getColumns(null, schemaPattern, table, "%")) {
       // Some database drivers (SQLite) don't include all the columns
       if (rs.getMetaData().getColumnCount() >= GET_COLUMNS_IS_AUTOINCREMENT) {
         while (rs.next()) {
@@ -149,9 +149,9 @@ public class JdbcUtils {
     return (matches == 1 ? result : null);
   }
 
-  public static boolean isColumnNullable(Connection conn, String table, String column)
+  public static boolean isColumnNullable(Connection conn, String schemaPattern, String table, String column)
       throws SQLException {
-    try (ResultSet rs = conn.getMetaData().getColumns(null, null, table, column)) {
+    try (ResultSet rs = conn.getMetaData().getColumns(null, schemaPattern, table, column)) {
       if (rs.getMetaData().getColumnCount() > GET_COLUMNS_IS_NULLABLE) {
         // Should only be one match
         if (!rs.next()) {

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -30,6 +30,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,12 +40,13 @@ import io.confluent.connect.jdbc.source.EmbeddedDerby;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.source.JdbcSourceTask;
 import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({JdbcSourceConnector.class})
+@PrepareForTest({JdbcSourceConnector.class, JdbcUtils.class})
 @PowerMockIgnore("javax.management.*")
 public class JdbcSourceConnectorTest {
 
@@ -175,6 +177,22 @@ public class JdbcSourceConnectorTest {
     connProps.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
     connProps.put(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, "foo,bar");
     connector.start(connProps);
+  }
+
+  @Test
+  public void testSchemaPatternUsedForConfigValidation() throws Exception {
+    connProps.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "SOME_SCHEMA");
+
+    PowerMock.mockStatic(JdbcUtils.class);
+    EasyMock.expect(JdbcUtils.getTables(EasyMock.anyObject(Connection.class), EasyMock.eq("SOME_SCHEMA")))
+      .andReturn(new ArrayList<String>())
+      .atLeastOnce();
+
+    PowerMock.replayAll();
+
+    connector.validate(connProps);
+
+    PowerMock.verifyAll();
   }
 
   private void assertTaskConfigsHaveParentConfigs(List<Map<String, String>> configs) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
@@ -16,6 +16,9 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,10 +28,6 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
-
-import io.confluent.connect.jdbc.sink.metadata.DbTable;
-import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
-import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,7 +69,7 @@ public class SqliteHelperTest {
     sqliteHelper.createTable(createNonPkTable);
 
     final Map<String, DbTable> tables = new HashMap<>();
-    for (String tableName : JdbcUtils.getTables(sqliteHelper.connection)) {
+    for (String tableName : JdbcUtils.getTables(sqliteHelper.connection, null)) {
       tables.put(tableName, DbMetadataQueries.getTableMetadata(sqliteHelper.connection, tableName));
     }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
@@ -16,9 +16,6 @@
 
 package io.confluent.connect.jdbc.sink;
 
-import io.confluent.connect.jdbc.sink.metadata.DbTable;
-import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
-import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +25,10 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
+
+import io.confluent.connect.jdbc.sink.metadata.DbTable;
+import io.confluent.connect.jdbc.sink.metadata.DbTableColumn;
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,8 +24,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-
-import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,13 +47,13 @@ public class JdbcUtilsTest {
 
   @Test
   public void testGetTablesEmpty() throws Exception {
-    assertEquals(Collections.emptyList(), JdbcUtils.getTables(db.getConnection()));
+    assertEquals(Collections.emptyList(), JdbcUtils.getTables(db.getConnection(), null));
   }
 
   @Test
   public void testGetTablesSingle() throws Exception {
     db.createTable("test", "id", "INT");
-    assertEquals(Arrays.asList("test"), JdbcUtils.getTables(db.getConnection()));
+    assertEquals(Arrays.asList("test"), JdbcUtils.getTables(db.getConnection(), null));
   }
 
   @Test
@@ -64,18 +63,18 @@ public class JdbcUtilsTest {
     db.createTable("zab", "id", "INT");
     assertEquals(
         new HashSet<String>(Arrays.asList("test", "foo", "zab")),
-        new HashSet<String>(JdbcUtils.getTables(db.getConnection())));
+        new HashSet<String>(JdbcUtils.getTables(db.getConnection(), null)));
   }
 
   @Test
   public void testGetAutoincrement() throws Exception {
     // Normal case
     db.createTable("test", "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY", "bar", "INTEGER");
-    assertEquals("id", JdbcUtils.getAutoincrementColumn(db.getConnection(), "test"));
+    assertEquals("id", JdbcUtils.getAutoincrementColumn(db.getConnection(), null, "test"));
 
     // No auto increment
     db.createTable("none", "id", "INTEGER", "bar", "INTEGER");
-    assertNull(JdbcUtils.getAutoincrementColumn(db.getConnection(), "none"));
+    assertNull(JdbcUtils.getAutoincrementColumn(db.getConnection(), null, "none"));
 
     // We can't check multiple columns because Derby ties auto increment to identity and
     // disallows multiple auto increment columns. This is probably ok, multiple auto increment
@@ -86,21 +85,21 @@ public class JdbcUtilsTest {
                    "foo", "INTEGER",
                    "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY",
                    "bar", "INTEGER");
-    assertEquals("id", JdbcUtils.getAutoincrementColumn(db.getConnection(), "mixed"));
+    assertEquals("id", JdbcUtils.getAutoincrementColumn(db.getConnection(), null, "mixed"));
   }
 
   @Test
   public void testIsColumnNullable() throws Exception {
     db.createTable("test", "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY", "bar", "INTEGER");
-    assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), "test", "id"));
-    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), "test", "bar"));
+    assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), null, "test", "id"));
+    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), null, "test", "bar"));
 
     // Derby does not seem to allow null
     db.createTable("tstest", "ts", "TIMESTAMP NOT NULL", "tsdefault", "TIMESTAMP",
                    "tsnull", "TIMESTAMP DEFAULT NULL");
-    assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), "tstest", "ts"));
+    assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), null, "tstest", "ts"));
     // The default for TIMESTAMP columns can vary between databases, but for Derby it is nullable
-    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), "tstest", "tsdefault"));
-    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), "tstest", "tsnull"));
+    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), null, "tstest", "tsdefault"));
+    assertTrue(JdbcUtils.isColumnNullable(db.getConnection(), null, "tstest", "tsnull"));
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +23,8 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
@@ -68,6 +68,30 @@ public class JdbcUtilsTest {
   }
 
   @Test
+  public void testGetTablesNarrowedToSchemas() throws Exception {
+    db.createTable("some_table", "id", "INT");
+
+    db.execute("CREATE SCHEMA PUBLIC_SCHEMA");
+    db.execute("SET SCHEMA PUBLIC_SCHEMA");
+    db.createTable("public_table", "id", "INT");
+
+    db.execute("CREATE SCHEMA PRIVATE_SCHEMA");
+    db.execute("SET SCHEMA PRIVATE_SCHEMA");
+    db.createTable("private_table", "id", "INT");
+    db.createTable("another_private_table", "id", "INT");
+
+    assertEquals(
+      new HashSet<String>(Arrays.asList("public_table")),
+      new HashSet<String>(JdbcUtils.getTables(db.getConnection(), "PUBLIC_SCHEMA")));
+    assertEquals(
+      new HashSet<String>(Arrays.asList("private_table", "another_private_table")),
+      new HashSet<String>(JdbcUtils.getTables(db.getConnection(), "PRIVATE_SCHEMA")));
+    assertEquals(
+      new HashSet<String>(Arrays.asList("some_table", "public_table", "private_table", "another_private_table")),
+      new HashSet<String>(JdbcUtils.getTables(db.getConnection(), null)));
+  }
+
+  @Test
   public void testGetAutoincrement() throws Exception {
     // Normal case
     db.createTable("test", "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY", "bar", "INTEGER");

--- a/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -32,9 +33,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.*;
-
-import io.confluent.connect.jdbc.util.JdbcUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
@@ -75,9 +78,9 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testSingleLookup() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, context, POLL_INTERVAL, null, null,DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(dbConn,DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -96,10 +99,10 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testWhitelist() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, context, POLL_INTERVAL,
-                                                new HashSet<>(Arrays.asList("foo", "bar")), null,DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL,
+                                                new HashSet<>(Arrays.asList("foo", "bar")), null, DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(dbConn,DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -118,10 +121,10 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testBlacklist() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, context, POLL_INTERVAL,
+    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL,
                                                 null, new HashSet<>(Arrays.asList("bar", "baz")),DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(dbConn,DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -140,11 +143,11 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testReconfigOnUpdate() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, context, POLL_INTERVAL, null, null,DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL, null, null,DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(dbConn, DEFAULT_TABLE_TYPES)).andReturn(FIRST_TOPIC_LIST);
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andReturn(FIRST_TOPIC_LIST);
     // Returning same list should not change results
-    EasyMock.expect(JdbcUtils.getTables(dbConn, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         assertEquals(FIRST_TOPIC_LIST, tableMonitorThread.tables());
@@ -152,11 +155,11 @@ public class TableMonitorThreadTest {
       }
     });
     // Changing the result should trigger a task reconfiguration
-    EasyMock.expect(JdbcUtils.getTables(dbConn, DEFAULT_TABLE_TYPES)).andReturn(SECOND_TOPIC_LIST);
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andReturn(SECOND_TOPIC_LIST);
     context.requestTaskReconfiguration();
     PowerMock.expectLastCall();
     // Changing again should result in another update
-    EasyMock.expect(JdbcUtils.getTables(dbConn, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         assertEquals(SECOND_TOPIC_LIST, tableMonitorThread.tables());
@@ -178,9 +181,9 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testTableType() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, context, POLL_INTERVAL, null, null,VIEW_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL, null, null,VIEW_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(dbConn,VIEW_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(dbConn, null, VIEW_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();

--- a/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
@@ -75,7 +75,7 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testSingleLookup() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, context, null, POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
 
     EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
@@ -96,7 +96,7 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testWhitelist() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL,
+    tableMonitorThread = new TableMonitorThread(dbConn, context, null, POLL_INTERVAL,
                                                 new HashSet<>(Arrays.asList("foo", "bar")), null, DEFAULT_TABLE_TYPES);
 
     EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
@@ -118,7 +118,7 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testBlacklist() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL,
+    tableMonitorThread = new TableMonitorThread(dbConn, context, null, POLL_INTERVAL,
                                                 null, new HashSet<>(Arrays.asList("bar", "baz")),DEFAULT_TABLE_TYPES);
 
     EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
@@ -140,7 +140,7 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testReconfigOnUpdate() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL, null, null,DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, context, null, POLL_INTERVAL, null, null,DEFAULT_TABLE_TYPES);
 
     EasyMock.expect(JdbcUtils.getTables(dbConn, null, DEFAULT_TABLE_TYPES)).andReturn(FIRST_TOPIC_LIST);
     // Returning same list should not change results
@@ -178,7 +178,7 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testTableType() throws Exception {
-    tableMonitorThread = new TableMonitorThread(dbConn, null, context, POLL_INTERVAL, null, null,VIEW_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(dbConn, context, null, POLL_INTERVAL, null, null,VIEW_TABLE_TYPES);
 
     EasyMock.expect(JdbcUtils.getTables(dbConn, null, VIEW_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override

--- a/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -33,11 +32,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
This adds the ability to configure jdbc schemaPattern from connector configuration.
Reported here https://github.com/confluentinc/kafka-connect-jdbc/issues/32