### PR TITLE
Added support for tinyint primary keys

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -26,13 +27,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.GregorianCalendar;
-import java.util.Map;
-import java.util.TimeZone;
-
-import io.confluent.connect.jdbc.util.JdbcUtils;
+import java.util.*;
 
 /**
  * <p>
@@ -183,6 +178,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
     Timestamp latest = null;
     if (incrementingColumn != null) {
       switch (schema.field(incrementingColumn).schema().type()) {
+        case INT8:
+          id = (long) (Byte) record.get(incrementingColumn);
+          break;
         case INT32:
           id = (long) (Integer) record.get(incrementingColumn);
           break;


### PR DESCRIPTION
Few of the tables in our legacy MySQL schema have a tinyint value as ID columns. These are also auto-incrementing and hence would be the incrementing.id.column values in the properties file. But when we try to run this with that setting, following exception is thrown:

org.apache.kafka.connect.errors.ConnectException: Invalid type for incrementing column: INT8
at io.confluent.connect.jdbc.TimestampIncrementingTableQuerier.extractRecord(TimestampIncrementingTableQuerier.java:191)
at io.confluent.connect.jdbc.JdbcSourceTask.poll(JdbcSourceTask.java:217)
at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:155)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:140)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:175)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)

I have added code to support tinyInt. Please someone review