### PR TITLE
Fixes tests failing at clean up due to locked resources.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 import io.confluent.connect.jdbc.sink.dialect.DbDialect;
 
-public class JdbcDbWriter {
+public class JdbcDbWriter implements AutoCloseable{
   private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
 
   private final JdbcSinkConfig config;
@@ -88,6 +88,11 @@ public class JdbcDbWriter {
         log.warn("Ignoring error closing connection", sqle);
       }
     }
+  }
+
+  @Override
+  public void close() throws Exception {
+    closeQuietly();
   }
 
   String destinationTable(String topic) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/SinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SinkTaskTest.java
@@ -114,6 +114,7 @@ public class SinkTaskTest {
             }
         )
     );
+    task.stop();
   }
 
   @Test
@@ -176,6 +177,7 @@ public class SinkTaskTest {
             }
         )
     );
+    task.stop();
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -125,7 +125,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     task.poll();
     assertEquals(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT,
                  time.milliseconds());
-
+    task.stop();
   }
 
   @Test
@@ -204,6 +204,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
                    time.milliseconds());
       validatePollResultTable(records, 1, SECOND_TABLE_NAME);
     }
+    task.stop();
   }
 
   private static void validatePollResultTable(List<SourceRecord> records,


### PR DESCRIPTION
Some tests fail out of the box in my dev environment (Windows 7, Java 1.7.0_79, Intellij IDEA 15.0.6). The majority of these are solved by adding task.stop() or writer.closeQuietly() to the end of tests. In a few cases when exception were expected all passing through the method...

JdbcDbWriterTest.writeSameRecordTwiceExpectingSingleUpdate

... a try-with-resources was used to catch the exception, passing the expected SQLException and Assert.fail(String) on the others. Because Assert.fail(String) is deprecated in junit.framework.Assert the new package org.junit.Assert was used.