### PR TITLE
Provide better support for logical types in sink

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -157,13 +157,11 @@ public abstract class DbDialect {
   }
 
   protected String getSqlType(String schemaName, Schema.Type type) {
-    String sqlType;
+    String sqlType = null;
     if (schemaName != null) {
       sqlType = logicalNameToSqlTypeMap.get(schemaName);
-      if (sqlType == null) {
-        sqlType = schemaTypeToSqlTypeMap.get(type);
-      }
-    } else {
+    }
+    if (sqlType == null) {
       sqlType = schemaTypeToSqlTypeMap.get(type);
     }
     if (sqlType == null) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -37,11 +37,13 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesTo
 public abstract class DbDialect {
 
   private final Map<Schema.Type, String> schemaTypeToSqlTypeMap;
+  private final Map<String, String> logicalNameToSqlTypeMap;
   private final String escapeStart;
   private final String escapeEnd;
 
-  DbDialect(Map<Schema.Type, String> schemaTypeToSqlTypeMap, String escapeStart, String escapeEnd) {
+  DbDialect(Map<Schema.Type, String> schemaTypeToSqlTypeMap, Map<String, String> logicalNameToSqlTypeMap, String escapeStart, String escapeEnd) {
     this.schemaTypeToSqlTypeMap = schemaTypeToSqlTypeMap;
+    this.logicalNameToSqlTypeMap = logicalNameToSqlTypeMap;
     this.escapeStart = escapeStart;
     this.escapeEnd = escapeEnd;
   }
@@ -109,7 +111,7 @@ public abstract class DbDialect {
   protected void writeColumnSpec(StringBuilder builder, SinkRecordField f) {
     builder.append(escaped(f.name));
     builder.append(" ");
-    builder.append(getSqlType(f.type));
+    builder.append(getSqlType(f.schemaName, f.type));
     if (f.defaultValue != null) {
       builder.append(" DEFAULT ");
       formatColumnValue(builder, f.type, f.defaultValue);
@@ -154,8 +156,13 @@ public abstract class DbDialect {
     }
   }
 
-  protected String getSqlType(Schema.Type type) {
-    final String sqlType = schemaTypeToSqlTypeMap.get(type);
+  protected String getSqlType(String schemaName, Schema.Type type) {
+    final String sqlType;
+    if (schemaName != null && logicalNameToSqlTypeMap.containsKey(schemaName)) {
+      sqlType = logicalNameToSqlTypeMap.get(schemaName);
+    } else {
+      sqlType = schemaTypeToSqlTypeMap.get(type);
+    }
     if (sqlType == null) {
       throw new ConnectException(String.format("%s type doesn't have a mapping to the SQL database column type", type));
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -157,9 +157,12 @@ public abstract class DbDialect {
   }
 
   protected String getSqlType(String schemaName, Schema.Type type) {
-    final String sqlType;
-    if (schemaName != null && logicalNameToSqlTypeMap.containsKey(schemaName)) {
+    String sqlType;
+    if (schemaName != null) {
       sqlType = logicalNameToSqlTypeMap.get(schemaName);
+      if (sqlType == null) {
+        sqlType = schemaTypeToSqlTypeMap.get(type);
+      }
     } else {
       sqlType = schemaTypeToSqlTypeMap.get(type);
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/GenericDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/GenericDialect.java
@@ -26,7 +26,7 @@ import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 
 public class GenericDialect extends DbDialect {
   public GenericDialect() {
-    super(Collections.<Schema.Type, String>emptyMap(), "\"", "\"");
+    super(Collections.<Schema.Type, String>emptyMap(), Collections.<String, String>emptyMap(), "\"", "\"");
   }
 
   // Only INSERT supported for now. CREATE and ALTER may be possible if we can figure out a reasonable type map.

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/HANADialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/HANADialect.java
@@ -33,7 +33,7 @@ public class HANADialect extends DbDialect {
 
 
   public HANADialect() {
-    super(getSqlTypeMap(), "\"", "\"");
+    super(getSqlTypeMap(), getLogicalToSqlTypeMap(), "\"", "\"");
   }
 
   private static Map<Schema.Type, String> getSqlTypeMap() {
@@ -47,6 +47,11 @@ public class HANADialect extends DbDialect {
     map.put(Schema.Type.BOOLEAN, "BOOLEAN");
     map.put(Schema.Type.STRING, "VARCHAR(1000)");
     map.put(Schema.Type.BYTES, "BLOB");
+    return map;
+  }
+
+  private static Map<String, String> getLogicalToSqlTypeMap() {
+    Map<String, String> map = new HashMap<>();
     return map;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
@@ -28,7 +28,7 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesTo
 public class MySqlDialect extends DbDialect {
 
   public MySqlDialect() {
-    super(getSqlTypeMap(), "`", "`");
+    super(getSqlTypeMap(), getLogicalToSqlTypeMap(), "`", "`");
   }
 
   private static Map<Schema.Type, String> getSqlTypeMap() {
@@ -42,6 +42,11 @@ public class MySqlDialect extends DbDialect {
     map.put(Schema.Type.BOOLEAN, "TINYINT");
     map.put(Schema.Type.STRING, "VARCHAR(256)");
     map.put(Schema.Type.BYTES, "VARBINARY(1024)");
+    return map;
+  }
+
+  private static Map<String, String> getLogicalToSqlTypeMap() {
+    Map<String, String> map = new HashMap<>();
     return map;
   }
 
@@ -70,4 +75,5 @@ public class MySqlDialect extends DbDialect {
     );
     return builder.toString();
   }
+
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/OracleDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/OracleDialect.java
@@ -30,7 +30,7 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBui
 
 public class OracleDialect extends DbDialect {
   public OracleDialect() {
-    super(getSqlTypeMap(), "\"", "\"");
+    super(getSqlTypeMap(), getLogicalToSqlTypeMap(), "\"", "\"");
   }
 
   private static Map<Schema.Type, String> getSqlTypeMap() {
@@ -44,6 +44,11 @@ public class OracleDialect extends DbDialect {
     map.put(Schema.Type.BOOLEAN, "NUMBER(1,0)");
     map.put(Schema.Type.STRING, "NVARCHAR2(4000)");
     map.put(Schema.Type.BYTES, "BLOB");
+    return map;
+  }
+
+  private static Map<String, String> getLogicalToSqlTypeMap() {
+    Map<String, String> map = new HashMap<>();
     return map;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
@@ -16,7 +16,11 @@
 
 package io.confluent.connect.jdbc.sink.dialect;
 
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,7 +34,7 @@ public class PostgreSqlDialect extends DbDialect {
   // The user is responsible for escaping the columns otherwise create table A and create table "A" is not the same
 
   public PostgreSqlDialect() {
-    super(getSqlTypeMap(), "\"", "\"");
+    super(getSqlTypeMap(), getSqlTypeFromLogicalMap(), "\"", "\"");
   }
 
   private static Map<Schema.Type, String> getSqlTypeMap() {
@@ -44,6 +48,15 @@ public class PostgreSqlDialect extends DbDialect {
     map.put(Schema.Type.BOOLEAN, "BOOLEAN");
     map.put(Schema.Type.STRING, "TEXT");
     map.put(Schema.Type.BYTES, "BYTEA");
+    return map;
+  }
+
+  private static Map<String, String> getSqlTypeFromLogicalMap() {
+    Map<String, String> map = new HashMap<>();
+    map.put(Date.LOGICAL_NAME, "DATE");
+    map.put(Decimal.LOGICAL_NAME, "DECIMAL");
+    map.put(Time.LOGICAL_NAME, "TIME");
+    map.put(Timestamp.LOGICAL_NAME, "TIMESTAMP");
     return map;
   }
 
@@ -72,4 +85,5 @@ public class PostgreSqlDialect extends DbDialect {
     );
     return builder.toString();
   }
+
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialect.java
@@ -31,7 +31,7 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBui
 public class SqlServerDialect extends DbDialect {
 
   public SqlServerDialect() {
-    super(getSqlTypeMap(), "[", "]");
+    super(getSqlTypeMap(), getLogicalToSqlTypeMap(), "[", "]");
   }
 
   private static Map<Schema.Type, String> getSqlTypeMap() {
@@ -45,6 +45,11 @@ public class SqlServerDialect extends DbDialect {
     map.put(Schema.Type.BOOLEAN, "bit");
     map.put(Schema.Type.STRING, "varchar(max)");
     map.put(Schema.Type.BYTES, "varbinary(max)");
+    return map;
+  }
+
+  private static Map<String, String> getLogicalToSqlTypeMap() {
+    Map<String, String> map = new HashMap<>();
     return map;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialect.java
@@ -32,7 +32,7 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesTo
 
 public class SqliteDialect extends DbDialect {
   public SqliteDialect() {
-    super(getSqlTypeMap(), "`", "`");
+    super(getSqlTypeMap(), getLogicalToSqlTypeMap(), "`", "`");
   }
 
   private static Map<Schema.Type, String> getSqlTypeMap() {
@@ -46,6 +46,11 @@ public class SqliteDialect extends DbDialect {
     map.put(Schema.Type.BOOLEAN, "NUMERIC");
     map.put(Schema.Type.STRING, "TEXT");
     map.put(Schema.Type.BYTES, "BLOB");
+    return map;
+  }
+
+  private static Map<String, String> getLogicalToSqlTypeMap() {
+    Map<String, String> map = new HashMap<>();
     return map;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -89,11 +89,11 @@ public class FieldsMetadata {
         }
         final Iterator<String> it = keyFieldNames.iterator();
         final String topicFieldName = it.next();
-        allFields.put(topicFieldName, new SinkRecordField(Schema.Type.STRING, topicFieldName, true));
+        allFields.put(topicFieldName, new SinkRecordField(null, Schema.Type.STRING, topicFieldName, true));
         final String partitionFieldName = it.next();
-        allFields.put(partitionFieldName, new SinkRecordField(Schema.Type.INT32, partitionFieldName, true));
+        allFields.put(partitionFieldName, new SinkRecordField(null, Schema.Type.INT32, partitionFieldName, true));
         final String offsetFieldName = it.next();
-        allFields.put(offsetFieldName, new SinkRecordField(Schema.Type.INT64, offsetFieldName, true));
+        allFields.put(offsetFieldName, new SinkRecordField(null, Schema.Type.INT64, offsetFieldName, true));
       }
       break;
 
@@ -113,7 +113,7 @@ public class FieldsMetadata {
           }
           final String fieldName = configuredPkFields.get(0);
           keyFieldNames.add(fieldName);
-          allFields.put(fieldName, new SinkRecordField(keySchemaType, fieldName, true, false, keySchema.defaultValue()));
+          allFields.put(fieldName, new SinkRecordField(keySchema.name(), keySchemaType, fieldName, true, false, keySchema.defaultValue()));
         } else if (keySchemaType == Schema.Type.STRUCT) {
           if (configuredPkFields.isEmpty()) {
             for (Field keyField : keySchema.fields()) {
@@ -133,7 +133,7 @@ public class FieldsMetadata {
           }
           for (String fieldName : keyFieldNames) {
             final Schema fieldSchema = keySchema.field(fieldName).schema();
-            allFields.put(fieldName, new SinkRecordField(fieldSchema.type(), fieldName, true, false, fieldSchema.defaultValue()));
+            allFields.put(fieldName, new SinkRecordField(fieldSchema.name(), fieldSchema.type(), fieldName, true, false, fieldSchema.defaultValue()));
           }
         } else {
           throw new ConnectException("Key schema must be primitive type or Struct, but is of type: " + keySchemaType);
@@ -162,7 +162,7 @@ public class FieldsMetadata {
         }
         for (String fieldName : keyFieldNames) {
           final Schema fieldSchema = valueSchema.field(fieldName).schema();
-          allFields.put(fieldName, new SinkRecordField(fieldSchema.type(), fieldName, true, false, fieldSchema.defaultValue()));
+          allFields.put(fieldName, new SinkRecordField(fieldSchema.name(), fieldSchema.type(), fieldName, true, false, fieldSchema.defaultValue()));
         }
       }
       break;
@@ -182,7 +182,7 @@ public class FieldsMetadata {
         nonKeyFieldNames.add(field.name());
 
         final Schema fieldSchema = field.schema();
-        allFields.put(field.name(), new SinkRecordField(fieldSchema.type(), field.name(), false, fieldSchema.isOptional(), fieldSchema.defaultValue()));
+        allFields.put(field.name(), new SinkRecordField(fieldSchema.name(), fieldSchema.type(), field.name(), false, fieldSchema.isOptional(), fieldSchema.defaultValue()));
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
@@ -19,23 +19,26 @@ package io.confluent.connect.jdbc.sink.metadata;
 import org.apache.kafka.connect.data.Schema;
 
 public class SinkRecordField {
+  public final String schemaName;
   public final Schema.Type type;
   public final String name;
   public final boolean isPrimaryKey;
   public final boolean isOptional;
   public final Object defaultValue;
 
-  public SinkRecordField(final Schema.Type type, final String name, final boolean isPrimaryKey) {
-    this(type, name, isPrimaryKey, !isPrimaryKey, null);
+  public SinkRecordField(final String schemaName, final Schema.Type type, final String name, final boolean isPrimaryKey) {
+    this(schemaName, type, name, isPrimaryKey, !isPrimaryKey, null);
   }
 
   public SinkRecordField(
+      final String schemaName,
       final Schema.Type type,
       final String name,
       final boolean isPrimaryKey,
       final boolean isOptional,
       final Object defaultValue
   ) {
+    this.schemaName = schemaName;
     this.type = type;
     this.name = name;
     this.isPrimaryKey = isPrimaryKey;
@@ -46,6 +49,7 @@ public class SinkRecordField {
   @Override
   public String toString() {
     return "SinkRecordField{" +
+           "schemaName=" + schemaName +
            "type=" + type +
            ", name='" + name + '\'' +
            ", isPrimaryKey=" + isPrimaryKey +

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -116,10 +116,10 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setFloat(index++, valueStruct.getFloat32("float"));
     verify(statement, times(1)).setDouble(index++, valueStruct.getFloat64("double"));
     verify(statement, times(1)).setBytes(index++, valueStruct.getBytes("bytes"));
-    verify(statement, times(1)).setBytes(index++, Decimal.fromLogical(Decimal.schema(0), (BigDecimal) valueStruct.get("decimal")));
-    verify(statement, times(1)).setInt(index++, Date.fromLogical(Date.SCHEMA, (java.util.Date) valueStruct.get("date")));
-    verify(statement, times(1)).setInt(index++, Time.fromLogical(Time.SCHEMA, (java.util.Date) valueStruct.get("time")));
-    verify(statement, times(1)).setLong(index++, Timestamp.fromLogical(Timestamp.SCHEMA, (java.util.Date) valueStruct.get("timestamp")));
+    verify(statement, times(1)).setBigDecimal(index++, (BigDecimal) valueStruct.get("decimal"));
+    verify(statement, times(1)).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()));
+    verify(statement, times(1)).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()));
+    verify(statement, times(1)).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()));
     // last field is optional and is null-valued in struct
     verify(statement, times(1)).setObject(index++, null);
   }
@@ -139,10 +139,10 @@ public class PreparedStatementBinderTest {
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
-    verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBytes(index, new byte[]{2});
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setInt(index, 0);
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setInt(index, 1000);
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setLong(index, 100);
+    verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
+    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date(0));
+    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000));
+    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/HANADialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/HANADialectTest.java
@@ -32,9 +32,9 @@ public class HANADialectTest {
   @Test
   public void handleCreateTableMultiplePKColumns() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-      new SinkRecordField(Schema.Type.INT32, "userid", true),
-      new SinkRecordField(Schema.Type.INT32, "userdataid", true),
-      new SinkRecordField(Schema.Type.STRING, "info", false)
+      new SinkRecordField(null, Schema.Type.INT32, "userid", true),
+      new SinkRecordField(null, Schema.Type.INT32, "userdataid", true),
+      new SinkRecordField(null, Schema.Type.STRING, "info", false)
     ));
 
     String expected = "CREATE COLUMN TABLE \"tableA\" (" + System.lineSeparator() +
@@ -48,13 +48,13 @@ public class HANADialectTest {
   @Test
   public void handleCreateTableOnePKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-      new SinkRecordField(Schema.Type.INT32, "col1", true),
-      new SinkRecordField(Schema.Type.INT64, "col2", false),
-      new SinkRecordField(Schema.Type.STRING, "col3", false),
-      new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-      new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-      new SinkRecordField(Schema.Type.INT8, "col6", false),
-      new SinkRecordField(Schema.Type.INT16, "col7", false)
+      new SinkRecordField(null, Schema.Type.INT32, "col1", true),
+      new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+      new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+      new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+      new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+      new SinkRecordField(null, Schema.Type.INT8, "col6", false),
+      new SinkRecordField(null, Schema.Type.INT16, "col7", false)
     ));
 
     String expected = "CREATE COLUMN TABLE \"tableA\" (" + System.lineSeparator() +
@@ -73,13 +73,13 @@ public class HANADialectTest {
   @Test
   public void handleCreateTableNoPKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-      new SinkRecordField(Schema.Type.INT32, "col1", false),
-      new SinkRecordField(Schema.Type.INT64, "col2", false),
-      new SinkRecordField(Schema.Type.STRING, "col3", false),
-      new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-      new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-      new SinkRecordField(Schema.Type.INT8, "col6", false),
-      new SinkRecordField(Schema.Type.INT16, "col7", false)
+      new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+      new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+      new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+      new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+      new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+      new SinkRecordField(null, Schema.Type.INT8, "col6", false),
+      new SinkRecordField(null, Schema.Type.INT16, "col7", false)
     ));
 
     String expected = "CREATE COLUMN TABLE \"tableA\" (" + System.lineSeparator() +
@@ -97,13 +97,13 @@ public class HANADialectTest {
   @Test
   public void handleAmendAddColumns() {
     List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
-            new SinkRecordField(Schema.Type.INT32, "col1", false, false, null),
-            new SinkRecordField(Schema.Type.INT64, "col2", false),
-            new SinkRecordField(Schema.Type.STRING, "col3", false),
-            new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-            new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-            new SinkRecordField(Schema.Type.INT8, "col6", false),
-            new SinkRecordField(Schema.Type.INT16, "col7", false)
+            new SinkRecordField(null, Schema.Type.INT32, "col1", false, false, null),
+            new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+            new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+            new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+            new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+            new SinkRecordField(null, Schema.Type.INT8, "col6", false),
+            new SinkRecordField(null, Schema.Type.INT16, "col7", false)
     ));
 
     assertEquals(1, actual.size());

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -33,9 +33,9 @@ public class MySqlDialectTest {
   @Test
   public void handleCreateTableMultiplePKColumns() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "userid", true),
-        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
-        new SinkRecordField(Schema.Type.STRING, "info", false)
+        new SinkRecordField(null, Schema.Type.INT32, "userid", true),
+        new SinkRecordField(null, Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(null, Schema.Type.STRING, "info", false)
     ));
 
     String expected = "CREATE TABLE `tableA` (" + System.lineSeparator() +
@@ -49,14 +49,14 @@ public class MySqlDialectTest {
   @Test
   public void handleCreateTableOnePKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", true),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", true),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE `tableA` (" + System.lineSeparator() +
@@ -75,14 +75,14 @@ public class MySqlDialectTest {
   @Test
   public void handleCreateTableNoPKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE `tableA` (" + System.lineSeparator() +
@@ -100,14 +100,14 @@ public class MySqlDialectTest {
   @Test
   public void handleAmendAddColumns() {
     List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     assertEquals(1, actual.size());

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/OracleDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/OracleDialectTest.java
@@ -33,9 +33,9 @@ public class OracleDialectTest {
   @Test
   public void handleCreateTableMultiplePKColumns() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "userid", true),
-        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
-        new SinkRecordField(Schema.Type.STRING, "info", false)
+        new SinkRecordField(null, Schema.Type.INT32, "userid", true),
+        new SinkRecordField(null, Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(null, Schema.Type.STRING, "info", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -49,14 +49,14 @@ public class OracleDialectTest {
   @Test
   public void handleCreateTableOnePKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", true),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", true),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -75,14 +75,14 @@ public class OracleDialectTest {
   @Test
   public void handleCreateTableNoPKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -100,14 +100,14 @@ public class OracleDialectTest {
   @Test
   public void handleAmendAddColumns() {
     List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     assertEquals(1, actual.size());

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -16,7 +16,7 @@
 
 package io.confluent.connect.jdbc.sink.dialect;
 
-import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.*;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -65,7 +65,11 @@ public class PostgreSqlDialectTest {
         new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
         new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
         new SinkRecordField(null, Schema.Type.INT8, "col7", false),
-        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false),
+        new SinkRecordField(Timestamp.LOGICAL_NAME, Schema.Type.INT64, "col9", false),
+        new SinkRecordField(Date.LOGICAL_NAME, Schema.Type.INT64, "col10", false),
+        new SinkRecordField(Time.LOGICAL_NAME, Schema.Type.INT64, "col11", false),
+        new SinkRecordField(Decimal.LOGICAL_NAME, Schema.Type.INT64, "col12", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -77,6 +81,10 @@ public class PostgreSqlDialectTest {
                       "\"col6\" BOOLEAN NULL," + System.lineSeparator() +
                       "\"col7\" SMALLINT NULL," + System.lineSeparator() +
                       "\"col8\" SMALLINT NULL," + System.lineSeparator() +
+                      "\"col9\" TIMESTAMP NULL," + System.lineSeparator() +
+                      "\"col10\" DATE NULL," + System.lineSeparator() +
+                      "\"col11\" TIME NULL," + System.lineSeparator() +
+                      "\"col12\" DECIMAL NULL," + System.lineSeparator() +
                       "PRIMARY KEY(\"col1\"))";
     assertEquals(expected, actual);
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -42,9 +42,9 @@ public class PostgreSqlDialectTest {
   @Test
   public void handleCreateTableMultiplePKColumns() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "userid", true),
-        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
-        new SinkRecordField(Schema.Type.STRING, "info", false)
+        new SinkRecordField(null, Schema.Type.INT32, "userid", true),
+        new SinkRecordField(null, Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(null, Schema.Type.STRING, "info", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -58,14 +58,14 @@ public class PostgreSqlDialectTest {
   @Test
   public void handleCreateTableOnePKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", true),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", true),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -84,14 +84,14 @@ public class PostgreSqlDialectTest {
   @Test
   public void handleCreateTableNoPKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -109,14 +109,14 @@ public class PostgreSqlDialectTest {
   @Test
   public void handleAmendAddColumns() {
     List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     assertEquals(1, actual.size());

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -16,7 +16,11 @@
 
 package io.confluent.connect.jdbc.sink.dialect;
 
-import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -67,9 +71,9 @@ public class PostgreSqlDialectTest {
         new SinkRecordField(null, Schema.Type.INT8, "col7", false),
         new SinkRecordField(null, Schema.Type.INT16, "col8", false),
         new SinkRecordField(Timestamp.LOGICAL_NAME, Schema.Type.INT64, "col9", false),
-        new SinkRecordField(Date.LOGICAL_NAME, Schema.Type.INT64, "col10", false),
-        new SinkRecordField(Time.LOGICAL_NAME, Schema.Type.INT64, "col11", false),
-        new SinkRecordField(Decimal.LOGICAL_NAME, Schema.Type.INT64, "col12", false)
+        new SinkRecordField(Date.LOGICAL_NAME, Schema.Type.INT32, "col10", false),
+        new SinkRecordField(Time.LOGICAL_NAME, Schema.Type.INT32, "col11", false),
+        new SinkRecordField(Decimal.LOGICAL_NAME, Schema.Type.BYTES, "col12", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -99,7 +103,11 @@ public class PostgreSqlDialectTest {
         new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
         new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
         new SinkRecordField(null, Schema.Type.INT8, "col7", false),
-        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false),
+        new SinkRecordField(Timestamp.LOGICAL_NAME, Schema.Type.INT64, "col9", false),
+        new SinkRecordField(Date.LOGICAL_NAME, Schema.Type.INT32, "col10", false),
+        new SinkRecordField(Time.LOGICAL_NAME, Schema.Type.INT32, "col11", false),
+        new SinkRecordField(Decimal.LOGICAL_NAME, Schema.Type.BYTES, "col12", false)
     ));
 
     String expected = "CREATE TABLE \"tableA\" (" + System.lineSeparator() +
@@ -110,7 +118,11 @@ public class PostgreSqlDialectTest {
                       "\"col5\" DOUBLE PRECISION NULL," + System.lineSeparator() +
                       "\"col6\" BOOLEAN NULL," + System.lineSeparator() +
                       "\"col7\" SMALLINT NULL," + System.lineSeparator() +
-                      "\"col8\" SMALLINT NULL)";
+                      "\"col8\" SMALLINT NULL," + System.lineSeparator() +
+                      "\"col9\" TIMESTAMP NULL," + System.lineSeparator() +
+                      "\"col10\" DATE NULL," + System.lineSeparator() +
+                      "\"col11\" TIME NULL," + System.lineSeparator() +
+                      "\"col12\" DECIMAL NULL)";
     assertEquals(expected, actual);
   }
 
@@ -124,7 +136,11 @@ public class PostgreSqlDialectTest {
         new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
         new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
         new SinkRecordField(null, Schema.Type.INT8, "col7", false),
-        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false),
+        new SinkRecordField(Timestamp.LOGICAL_NAME, Schema.Type.INT64, "col9", false),
+        new SinkRecordField(Date.LOGICAL_NAME, Schema.Type.INT32, "col10", false),
+        new SinkRecordField(Time.LOGICAL_NAME, Schema.Type.INT32, "col11", false),
+        new SinkRecordField(Decimal.LOGICAL_NAME, Schema.Type.BYTES, "col12", false)
     ));
 
     assertEquals(1, actual.size());
@@ -137,7 +153,11 @@ public class PostgreSqlDialectTest {
                       "ADD \"col5\" DOUBLE PRECISION NULL," + System.lineSeparator() +
                       "ADD \"col6\" BOOLEAN NULL," + System.lineSeparator() +
                       "ADD \"col7\" SMALLINT NULL," + System.lineSeparator() +
-                      "ADD \"col8\" SMALLINT NULL";
+                      "ADD \"col8\" SMALLINT NULL," + System.lineSeparator() +
+                      "ADD \"col9\" TIMESTAMP NULL," + System.lineSeparator() +
+                      "ADD \"col10\" DATE NULL," + System.lineSeparator() +
+                      "ADD \"col11\" TIME NULL," + System.lineSeparator() +
+                      "ADD \"col12\" DECIMAL NULL";
     assertEquals(expected, actual.get(0));
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialectTest.java
@@ -55,9 +55,9 @@ public class SqlServerDialectTest {
   @Test
   public void handleCreateTableMultiplePKColumns() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "userid", true),
-        new SinkRecordField(Schema.Type.INT32, "userdataid", true),
-        new SinkRecordField(Schema.Type.STRING, "info", false)
+        new SinkRecordField(null, Schema.Type.INT32, "userid", true),
+        new SinkRecordField(null, Schema.Type.INT32, "userdataid", true),
+        new SinkRecordField(null, Schema.Type.STRING, "info", false)
     ));
 
     String expected = "CREATE TABLE [tableA] (" + System.lineSeparator() +
@@ -71,14 +71,14 @@ public class SqlServerDialectTest {
   @Test
   public void handleCreateTableOnePKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", true),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", true),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE [tableA] (" + System.lineSeparator() +
@@ -97,14 +97,14 @@ public class SqlServerDialectTest {
   @Test
   public void handleCreateTableNoPKColumn() {
     String actual = dialect.getCreateQuery("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     String expected = "CREATE TABLE [tableA] (" + System.lineSeparator() +
@@ -122,14 +122,14 @@ public class SqlServerDialectTest {
   @Test
   public void handleAmendAddColumns() {
     List<String> actual = dialect.getAlterTable("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.INT32, "col1", false),
-        new SinkRecordField(Schema.Type.INT64, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col4", false),
-        new SinkRecordField(Schema.Type.FLOAT64, "col5", false),
-        new SinkRecordField(Schema.Type.BOOLEAN, "col6", false),
-        new SinkRecordField(Schema.Type.INT8, "col7", false),
-        new SinkRecordField(Schema.Type.INT16, "col8", false)
+        new SinkRecordField(null, Schema.Type.INT32, "col1", false),
+        new SinkRecordField(null, Schema.Type.INT64, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col4", false),
+        new SinkRecordField(null, Schema.Type.FLOAT64, "col5", false),
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col6", false),
+        new SinkRecordField(null, Schema.Type.INT8, "col7", false),
+        new SinkRecordField(null, Schema.Type.INT16, "col8", false)
     ));
 
     assertEquals(1, actual.size());

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialectTest.java
@@ -30,9 +30,9 @@ public class SqliteDialectTest {
   @Test
   public void validateAlterTable() {
     List<String> queries = new SqliteDialect().getAlterTable("tableA", Arrays.asList(
-        new SinkRecordField(Schema.Type.BOOLEAN, "col1", false),
-        new SinkRecordField(Schema.Type.FLOAT32, "col2", false),
-        new SinkRecordField(Schema.Type.STRING, "col3", false)
+        new SinkRecordField(null, Schema.Type.BOOLEAN, "col1", false),
+        new SinkRecordField(null, Schema.Type.FLOAT32, "col2", false),
+        new SinkRecordField(null, Schema.Type.STRING, "col3", false)
     ));
 
     assertEquals(3, queries.size());


### PR DESCRIPTION
Converts Kafka Connect logical types into their database-specific datatypes rather than using the underlying internal datatypes. Currently, only the PostgresSqlDialect is supported. 

This handles issue https://github.com/confluentinc/kafka-connect-jdbc/issues/133.