### PR TITLE
Declaring SimpleDateFormat as thread-local

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -41,31 +41,31 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBui
 import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesToBuilder;
 
 public abstract class DbDialect {
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   protected static final ThreadLocal<SimpleDateFormat> DATE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
     protected SimpleDateFormat initialValue() {
-      return new SimpleDateFormat("yyyy-MM-dd");
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+      sdf.setTimeZone(UTC);
+      return sdf;
     }
   };
 
   protected static final ThreadLocal<SimpleDateFormat> TIME_FORMAT = new ThreadLocal<SimpleDateFormat>() {
     protected SimpleDateFormat initialValue() {
-      return new SimpleDateFormat("HH:mm:ss.SSS");
+      SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
+      sdf.setTimeZone(UTC);
+      return sdf;
     }
   };
 
   protected static final ThreadLocal<SimpleDateFormat> TIMESTAMP_FORMAT = new ThreadLocal<SimpleDateFormat>() {
     protected SimpleDateFormat initialValue() {
-      return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      sdf.setTimeZone(UTC);
+      return sdf;
     }
   };
-
-  static {
-    final TimeZone utc = TimeZone.getTimeZone("UTC");
-    DATE_FORMAT.get().setTimeZone(utc);
-    TIME_FORMAT.get().setTimeZone(utc);
-    TIMESTAMP_FORMAT.get().setTimeZone(utc);
-  }
 
   private final String escapeStart;
   private final String escapeEnd;

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -42,15 +42,29 @@ import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.nCopiesTo
 
 public abstract class DbDialect {
 
-  protected static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-  protected static final SimpleDateFormat TIME_FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
-  protected static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  protected static final ThreadLocal<SimpleDateFormat> DATE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+    protected SimpleDateFormat initialValue() {
+      return new SimpleDateFormat("yyyy-MM-dd");
+    }
+  };
+
+  protected static final ThreadLocal<SimpleDateFormat> TIME_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+    protected SimpleDateFormat initialValue() {
+      return new SimpleDateFormat("HH:mm:ss.SSS");
+    }
+  };
+
+  protected static final ThreadLocal<SimpleDateFormat> TIMESTAMP_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+    protected SimpleDateFormat initialValue() {
+      return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    }
+  };
 
   static {
     final TimeZone utc = TimeZone.getTimeZone("UTC");
-    DATE_FORMAT.setTimeZone(utc);
-    TIME_FORMAT.setTimeZone(utc);
-    TIMESTAMP_FORMAT.setTimeZone(utc);
+    DATE_FORMAT.get().setTimeZone(utc);
+    TIME_FORMAT.get().setTimeZone(utc);
+    TIMESTAMP_FORMAT.get().setTimeZone(utc);
   }
 
   private final String escapeStart;
@@ -144,13 +158,13 @@ public abstract class DbDialect {
           builder.append(value);
           return;
         case Date.LOGICAL_NAME:
-          builder.append("'").append(DATE_FORMAT.format((java.util.Date) value)).append("'");
+          builder.append("'").append(DATE_FORMAT.get().format((java.util.Date) value)).append("'");
           return;
         case Time.LOGICAL_NAME:
-          builder.append("'").append(TIME_FORMAT.format((java.util.Date) value)).append("'");
+          builder.append("'").append(TIME_FORMAT.get().format((java.util.Date) value)).append("'");
           return;
         case Timestamp.LOGICAL_NAME:
-          builder.append("'").append(TIMESTAMP_FORMAT.format((java.util.Date) value)).append("'");
+          builder.append("'").append(TIMESTAMP_FORMAT.get().format((java.util.Date) value)).append("'");
           return;
       }
     }


### PR DESCRIPTION
SimpleDateFormat is not thread-safe and this flow runs inside the sink tasks which run concurrently with each other, so this may incur in concurrency issues. 3 options for this would be 1) create a separate instance each time, 2) synchronise the access to the formatter 3) declare it as thread local.

I'm suggesting option 3) in this PR, as from past experience it's the one from the above with less performance impacts.

There are 2 more options, both are thread-safe but require an extra dependency to be added: 4) joda-time DateTimeFormatter, 5) commons-lang FastDateFormat.

Any feedback is welcome.