### PR TITLE
Adding support for unsigned tinyint values

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -289,7 +289,10 @@ public class DataConverter {
 
       // 8 bits int
       case Types.TINYINT: {
-        colValue = resultSet.getByte(col);
+        if (resultSet.getShort(col) > Byte.MAX_VALUE)
+          colValue = resultSet.getShort(col);
+        else
+          colValue = resultSet.getByte(col);
         break;
       }
 


### PR DESCRIPTION
Based upon the theory provided in the official jdbc documentation, I have added a condition to include both Short and Byte as INT8 types in ConnectSchema.

Here's the doc:

8.3.5 SMALLINT

The JDBC type SMALLINT represents a 16-bit signed integer value between -32768 and 32767.

The corresponding SQL type, SMALLINT, is defined in SQL-92 and is supported by all the major databases. The SQL-92 standard leaves the precision of SMALLINT up to the implementation, but in practice, all the major databases support at least 16 bits.

The recommended Java mapping for the JDBC SMALLINT type is as a Java short.
This would allow kafka-connect-jdbc to allow both signed and unsigned values. Currently it fails for unsigned values(i.e values > 127). In this PR, if the value of tinyint value received from DB is greater than 127, then it converts to a short otherwise byte. This has been taken care of in the kafka project and schema-registry project.
