### PR TITLE
Allow setting of message key

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -36,8 +36,8 @@ import io.confluent.connect.jdbc.util.JdbcUtils;
 public class BulkTableQuerier extends TableQuerier {
   private static final Logger log = LoggerFactory.getLogger(BulkTableQuerier.class);
 
-  public BulkTableQuerier(QueryMode mode, String name, String schemaPattern, String topicPrefix) {
-    super(mode, name, topicPrefix, schemaPattern);
+  public BulkTableQuerier(QueryMode mode, String name, String key, String schemaPattern, String topicPrefix) {
+    super(mode, name, key, topicPrefix, schemaPattern);
   }
 
   @Override
@@ -80,7 +80,12 @@ public class BulkTableQuerier extends TableQuerier {
       default:
         throw new ConnectException("Unexpected query mode: " + mode);
     }
-    return new SourceRecord(partition, null, topic, record.schema(), record);
+
+    if (key == null) {
+      return new SourceRecord(partition, null, topic, record.schema(), record);
+    } else {
+      return new SourceRecord(partition, null, topic, record.schema(), record.get(key), record.schema(), record);
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -137,6 +137,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String QUERY_DEFAULT = "";
   private static final String QUERY_DISPLAY = "Query";
 
+  public static final String KEY_CONFIG = "key";
+  private static final String KEY_DOC =
+      "If specified, sets the message key to the value of the field in the record.\n"
+      + "For example, with a record of {id=123, name=Smith, country=GB}, a key of 'country' will \n"
+      + "result in a message key of 'GB'.\n"
+      + "Note that the key applies to the record returned by the query, not to the row itself. For "
+      + "example, a query of 'SELECT country AS country_code FROM users' would require a key of 'country_code'.";
+  public static final String KEY_DEFAULT = null;
+  private static final String KEY_DISPLAY = "Key";
+
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
       "Prefix to prepend to table names to generate the name of the Kafka topic to publish data "
@@ -209,7 +219,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         .define(BATCH_MAX_ROWS_CONFIG, Type.INT, BATCH_MAX_ROWS_DEFAULT, Importance.LOW, BATCH_MAX_ROWS_DOC, CONNECTOR_GROUP, 2, Width.SHORT, BATCH_MAX_ROWS_DISPLAY)
         .define(TABLE_POLL_INTERVAL_MS_CONFIG, Type.LONG, TABLE_POLL_INTERVAL_MS_DEFAULT, Importance.LOW, TABLE_POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 3, Width.SHORT, TABLE_POLL_INTERVAL_MS_DISPLAY)
         .define(TOPIC_PREFIX_CONFIG, Type.STRING, Importance.HIGH, TOPIC_PREFIX_DOC, CONNECTOR_GROUP, 4, Width.MEDIUM, TOPIC_PREFIX_DISPLAY)
-        .define(TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, Type.LONG, TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT, Importance.HIGH, TIMESTAMP_DELAY_INTERVAL_MS_DOC, CONNECTOR_GROUP, 5, Width.MEDIUM, TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);
+        .define(TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, Type.LONG, TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT, Importance.HIGH, TIMESTAMP_DELAY_INTERVAL_MS_DOC, CONNECTOR_GROUP, 5, Width.MEDIUM, TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY)
+        .define(KEY_CONFIG, Type.STRING, KEY_DEFAULT, Importance.LOW, KEY_DOC, MODE_GROUP, 6, Width.SHORT, KEY_DISPLAY);
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -118,6 +118,8 @@ public class JdbcSourceTask extends SourceTask {
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+    String key
+        = config.getString(JdbcSourceTaskConfig.KEY_CONFIG);
 
     for (String tableOrQuery : tablesOrQuery) {
       final Map<String, String> partition;
@@ -141,16 +143,16 @@ public class JdbcSourceTask extends SourceTask {
       String topicPrefix = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
-        tableQueue.add(new BulkTableQuerier(queryMode, tableOrQuery, schemaPattern, topicPrefix));
+        tableQueue.add(new BulkTableQuerier(queryMode, tableOrQuery, key, schemaPattern, topicPrefix));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset, timestampDelayInterval, schemaPattern));
+            queryMode, tableOrQuery, topicPrefix, key, null, incrementingColumn, offset, timestampDelayInterval, schemaPattern));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset, timestampDelayInterval, schemaPattern));
+            queryMode, tableOrQuery, topicPrefix, key, timestampColumn, null, offset, timestampDelayInterval, schemaPattern));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn, offset, timestampDelayInterval, schemaPattern));
+            queryMode, tableOrQuery, topicPrefix, key, timestampColumn, incrementingColumn, offset, timestampDelayInterval, schemaPattern));
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -39,6 +39,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected final String schemaPattern;
   protected final String name;
   protected final String query;
+  protected final String key;
   protected final String topicPrefix;
 
   // Mutable state
@@ -47,11 +48,12 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected ResultSet resultSet;
   protected Schema schema;
 
-  public TableQuerier(QueryMode mode, String nameOrQuery, String topicPrefix, String schemaPattern) {
+  public TableQuerier(QueryMode mode, String nameOrQuery, String key, String topicPrefix, String schemaPattern) {
     this.mode = mode;
     this.schemaPattern = schemaPattern;
     this.name = mode.equals(QueryMode.TABLE) ? nameOrQuery : null;
     this.query = mode.equals(QueryMode.QUERY) ? nameOrQuery : null;
+    this.key = key;
     this.topicPrefix = topicPrefix;
     this.lastUpdate = 0;
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -70,7 +70,7 @@ public class TimestampIncrementingTableQuerierTest {
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {
-    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null);
+    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", "example-key", null, "id", Collections.<String, Object>emptyMap(), 0L, null);
   }
 
 }


### PR DESCRIPTION
Fulfils #28 

It will (naturally) only work if the key converter is set to the string converter in the source connector config. I don't know if that explicitly needs to be called out.

For testing, the existing unit tests still pass. I didn't see anywhere that I could add a more meaningful test, given the tight coupling with Kafka Connect itself. For integration testing, I have tested that the entire stack works locally (like a charm).

