### PR TITLE
Change default MySQL Schema.Type.TIMESTAMP mapping from TIMESTAMP to DATETIME

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
@@ -46,7 +46,7 @@ public class MySqlDialect extends DbDialect {
         case Time.LOGICAL_NAME:
           return "TIME(3)";
         case Timestamp.LOGICAL_NAME:
-          return "TIMESTAMP(3)";
+          return "DATETIME(3)";
       }
     }
     switch (type) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -49,7 +49,7 @@ public class MySqlDialectTest extends BaseDialectTest {
     verifyDataTypeMapping("DECIMAL(65,2)", Decimal.schema(2));
     verifyDataTypeMapping("DATE", Date.SCHEMA);
     verifyDataTypeMapping("TIME(3)", Time.SCHEMA);
-    verifyDataTypeMapping("TIMESTAMP(3)", Timestamp.SCHEMA);
+    verifyDataTypeMapping("DATETIME(3)", Timestamp.SCHEMA);
   }
 
   @Test


### PR DESCRIPTION
DATETIME supports a wider range by default, see http://dev.mysql.com/doc/refman/5.5/en/datetime.html