### PR TITLE
add rpm build to lifecycle 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
         <commons-io.version>2.4</commons-io.version>
         <mockito.version>1.10.19</mockito.version>
         <slf4j.version>1.7.5</slf4j.version>
-	<licenses.name>Apache License 2.0</licenses.name>
+		<licenses.name>Apache License 2.0</licenses.name>
         <licenses.version>${project.version}</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	<project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
+		<project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
@@ -236,34 +236,35 @@
 						<configuration>
 							<group>Applications/Internet</group>
 							<packager>Confluent Packaging</packager>
+							<license>${licenses.name}</license>
 							<needarch>false</needarch>
 							<requires>
 								<require>confluent-common</require>
 							</requires>
 							<mappings>
 								<mapping>
-									<directory>/usr/share/java/</directory>
+									<directory>/usr/share/java/${project.artifactId}</directory>
 									<sources>
 										<source>
-											<location>${project.package.home}/share/java</location>
+											<location>${project.package.home}/share/java/${project.artifactId}</location>
 										</source>
 									</sources>
 								</mapping>
 								<mapping>
 									<configuration>true</configuration>
-									<directory>/etc</directory>
+									<directory>/etc/${project.artifactId}</directory>
 									<sources>
 										<source>
-											<location>${project.package.home}/etc/</location>
+											<location>${project.package.home}/etc/${project.artifactId}</location>
 										</source>
 									</sources>
 								</mapping>
 								<mapping>
 									<documentation>true</documentation>
-									<directory>/usr/share/doc/</directory>
+									<directory>/usr/share/doc/${project.artifactId}</directory>
 									<sources>
 										<source>
-											<location>${project.package.home}/share/doc</location>
+											<location>${project.package.home}/share/doc/${project.artifactId}</location>
 										</source>
 									</sources>
 								</mapping>
@@ -338,8 +339,8 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>licenses-source</id>
+		<profile>
+			<id>licenses-source</id>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
 							<needarch>noarch</needarch>
 							<targetOS>linux</targetOS>
 							<requires>
-								<require>confluent-common</require>
+								<require>confluent-common &gt;= ${project.version}</require>
 							</requires>
 							<mappings>
 								<mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </organization>
     <url>http://confluent.io</url>
     <description>
-        A Kafka Connect JDBC connector for copying data between databases and Kafka.
+       A Kafka Connect JDBC connector for copying data between databases and Kafka.
     </description>
 
     <licenses>
@@ -341,7 +341,7 @@
             </build>
         </profile>
 	<profile>
-		<id>licenses-source</id>
+        <id>licenses-source</id>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -206,55 +206,6 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>rpm-maven-plugin</artifactId>
-				<version>2.1.5</version>
-				<executions>
-					<execution>
-						<id>generate-rpm</id>
-						<goals>
-							<goal>rpm</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<group>Applications/Internet</group>
-					<packager>Confluent Packaging</packager>
-					<needarch>false</needarch>
-					<requires>
-  						<require>confluent-common</require>
-					</requires>
-					<mappings>
-						<mapping>
-							<directory>/usr/share/java/</directory>
-							<sources>
-								<source>
-									<location>${project.package.home}/share/java</location>
-								</source>
-							</sources>
-						</mapping>
-						<mapping>
-							<configuration>true</configuration>
-							<directory>/etc</directory>
-							<sources>
-								<source>
-									<location>${project.package.home}/etc/</location>
-								</source>
-							</sources>
-						</mapping>
-						<mapping>
-							<documentation>true</documentation>
-							<directory>/usr/share/doc/</directory>
-							<sources>
-								<source>
-									<location>${project.package.home}/share/doc</location>
-								</source>
-							</sources>
-						</mapping>
-					</mappings>
-				</configuration>
-			</plugin>
         </plugins>
         <resources>
             <resource>
@@ -265,6 +216,62 @@
     </build>
 
     <profiles>
+		<profile>
+			<id>rpm</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>rpm-maven-plugin</artifactId>
+						<version>2.1.5</version>
+						<executions>
+							<execution>
+								<id>attach-rpm</id>
+								<goals>
+									<goal>attached-rpm</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<group>Applications/Internet</group>
+							<packager>Confluent Packaging</packager>
+							<needarch>false</needarch>
+							<requires>
+								<require>confluent-common</require>
+							</requires>
+							<mappings>
+								<mapping>
+									<directory>/usr/share/java/</directory>
+									<sources>
+										<source>
+											<location>${project.package.home}/share/java</location>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
+									<configuration>true</configuration>
+									<directory>/etc</directory>
+									<sources>
+										<source>
+											<location>${project.package.home}/etc/</location>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
+									<documentation>true</documentation>
+									<directory>/usr/share/doc/</directory>
+									<sources>
+										<source>
+											<location>${project.package.home}/share/doc</location>
+										</source>
+									</sources>
+								</mapping>
+							</mappings>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
         <profile>
             <id>standalone</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
                             <needarch>noarch</needarch>
                             <targetOS>linux</targetOS>
                             <requires>
-                                <require>confluent-common &gt;= ${project.version}</require>
+                                <require>confluent-common = ${project.version}</require>
                             </requires>
                             <mappings>
                                 <mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <licenses.version>3.3.0-SNAPSHOT</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+		<project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
     </properties>
 
     <repositories>
@@ -205,8 +206,56 @@
                     </execution>
                 </executions>
             </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>rpm-maven-plugin</artifactId>
+				<version>2.1.5</version>
+				<executions>
+					<execution>
+						<id>generate-rpm</id>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<group>Applications/Internet</group>
+					<packager>Confluent Packaging</packager>
+					<needarch>false</needarch>
+					<requires>
+  						<require>confluent-common</require>
+					</requires>
+					<mappings>
+						<mapping>
+							<directory>/usr/share/java/</directory>
+							<sources>
+								<source>
+									<location>${project.package.home}/share/java</location>
+								</source>
+							</sources>
+						</mapping>
+						<mapping>
+							<configuration>true</configuration>
+							<directory>/etc</directory>
+							<sources>
+								<source>
+									<location>${project.package.home}/etc/</location>
+								</source>
+							</sources>
+						</mapping>
+						<mapping>
+							<documentation>true</documentation>
+							<directory>/usr/share/doc/</directory>
+							<sources>
+								<source>
+									<location>${project.package.home}/share/doc</location>
+								</source>
+							</sources>
+						</mapping>
+					</mappings>
+				</configuration>
+			</plugin>
         </plugins>
-
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,8 @@
 							<group>Applications/Internet</group>
 							<packager>Confluent Packaging</packager>
 							<license>${licenses.name}</license>
-							<needarch>false</needarch>
+							<needarch>noarch</needarch>
+							<targetOS>linux</targetOS>
 							<requires>
 								<require>confluent-common</require>
 							</requires>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
         <commons-io.version>2.4</commons-io.version>
         <mockito.version>1.10.19</mockito.version>
         <slf4j.version>1.7.5</slf4j.version>
-	<licenses.name>Apache License 2.0</licenses.name>
+        <licenses.name>Apache License 2.0</licenses.name>
         <licenses.version>${project.version}</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	<project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
+        <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
@@ -217,64 +217,64 @@
     </build>
 
     <profiles>
-		<profile>
-			<id>rpm</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>rpm-maven-plugin</artifactId>
-						<version>2.1.5</version>
-						<executions>
-							<execution>
-								<id>generate-rpm</id>
-								<goals>
-									<goal>rpm</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<group>Applications/Internet</group>
-							<packager>Confluent Packaging</packager>
-							<license>${licenses.name}</license>
-							<needarch>noarch</needarch>
-							<targetOS>linux</targetOS>
-							<requires>
-								<require>confluent-common &gt;= ${project.version}</require>
-							</requires>
-							<mappings>
-								<mapping>
-									<directory>/usr/share/java/${project.artifactId}</directory>
-									<sources>
-										<source>
-											<location>${project.package.home}/share/java/${project.artifactId}</location>
-										</source>
-									</sources>
-								</mapping>
-								<mapping>
-									<configuration>true</configuration>
-									<directory>/etc/${project.artifactId}</directory>
-									<sources>
-										<source>
-											<location>${project.package.home}/etc/${project.artifactId}</location>
-										</source>
-									</sources>
-								</mapping>
-								<mapping>
-									<documentation>true</documentation>
-									<directory>/usr/share/doc/${project.artifactId}</directory>
-									<sources>
-										<source>
-											<location>${project.package.home}/share/doc/${project.artifactId}</location>
-										</source>
-									</sources>
-								</mapping>
-							</mappings>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+        <profile>
+            <id>rpm</id>
+            <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>rpm-maven-plugin</artifactId>
+                    <version>2.1.5</version>
+                    <executions>
+                        <execution>
+                            <id>generate-rpm</id>
+                            <goals>
+                                <goal>rpm</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                        <configuration>
+                            <group>Applications/Internet</group>
+                            <packager>Confluent Packaging</packager>
+                            <license>${licenses.name}</license>
+                            <needarch>noarch</needarch>
+                            <targetOS>linux</targetOS>
+                            <requires>
+                                <require>confluent-common &gt;= ${project.version}</require>
+                            </requires>
+                            <mappings>
+                                <mapping>
+                                    <directory>/usr/share/java/${project.artifactId}</directory>
+                                    <sources>
+                                        <source>
+                                            <location>${project.package.home}/share/java/${project.artifactId}</location>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                                <mapping>
+                                    <configuration>true</configuration>
+                                    <directory>/etc/${project.artifactId}</directory>
+                                    <sources>
+                                        <source>
+                                            <location>${project.package.home}/etc/${project.artifactId}</location>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                                <mapping>
+                                    <documentation>true</documentation>
+                                    <directory>/usr/share/doc/${project.artifactId}</directory>
+                                    <sources>
+                                        <source>
+                                            <location>${project.package.home}/share/doc/${project.artifactId}</location>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                            </mappings>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>standalone</id>
             <build>


### PR DESCRIPTION
The current process for building rpm's is kind of a pain. Especially for something small like back porting a fix. Also RPM based hot fixes are a preferred distribution method over one off jars for quick fixes.  

There is also a deb plugin which can be utilized for the same. 