### PR TITLE
fix "Support WHERE clauses in custom queries in incremental mode #112"

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -110,7 +110,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       //  timestamp 1235, id 22
       //  timestamp 1236, id 23
       // We should capture both id = 22 (an update) and id = 23 (a new row)
-      builder.append(" WHERE ");
+      if (query.indexOf("where") != -1) {
+        builder.append(" and ");
+      } else {
+        builder.append(" WHERE ");
+      }
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
       builder.append(" < ? AND ((");
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
@@ -126,14 +130,22 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
       builder.append(" ASC");
     } else if (incrementingColumn != null) {
-      builder.append(" WHERE ");
+      if (query.indexOf("where") != -1) {
+        builder.append(" and ");
+      } else {
+        builder.append(" WHERE ");
+      }
       builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
       builder.append(" > ?");
       builder.append(" ORDER BY ");
       builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
       builder.append(" ASC");
     } else if (timestampColumn != null) {
-      builder.append(" WHERE ");
+      if (query.indexOf("where") != -1) {
+        builder.append(" and ");
+      } else {
+        builder.append(" WHERE ");
+      }
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
       builder.append(" > ? AND ");
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));


### PR DESCRIPTION
This pull can easy solve this issue(https://github.com/confluentinc/kafka-connect-jdbc/issues/112). It allows people to add "where" condition in the query part of a jdbc source. So that, people can have any kind of offset for their jdbc source instead of querying data from the beginning of a table or view.
This change has been proved effective on our production environment.