### PR TITLE
Statement.SUCCESS_NO_INFO should be treated in BufferedRecords.flush

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -116,7 +116,7 @@ public class BufferedRecords {
     }
     if (successNoInfo) {
       log.info(
-              "Insert records:{} , but no count of the number of rows it affected is available",
+              config.insertMode + " records:{} , but no count of the number of rows it affected is available",
               records.size());
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -114,7 +114,7 @@ public class BufferedRecords {
           log.trace("Upserted records:{} resulting in in totalUpdateCount:{}", records.size(), totalUpdateCount);
       }
     }
-    if( successNoInfo ){
+    if (successNoInfo) {
       log.info(
               "Insert records:{} , but no count of the number of rows it affected is available",
               records.size());

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -96,10 +97,15 @@ public class BufferedRecords {
       preparedStatementBinder.bindRecord(record);
     }
     int totalUpdateCount = 0;
+    boolean successNoInfo = false;
     for (int updateCount : preparedStatement.executeBatch()) {
+      if (updateCount == Statement.SUCCESS_NO_INFO) {
+        successNoInfo = true;
+        continue;
+      }
       totalUpdateCount += updateCount;
     }
-    if (totalUpdateCount != records.size()) {
+    if (totalUpdateCount != records.size() && !successNoInfo) {
       switch (config.insertMode) {
         case INSERT:
           throw new ConnectException(String.format("Update count (%d) did not sum up to total number of records inserted (%d)",
@@ -108,6 +114,12 @@ public class BufferedRecords {
           log.trace("Upserted records:{} resulting in in totalUpdateCount:{}", records.size(), totalUpdateCount);
       }
     }
+    if( successNoInfo ){
+      log.info(
+              "Insert records:{} , but no count of the number of rows it affected is available",
+              records.size());
+    }
+
 
     final List<SinkRecord> flushedRecords = records;
     records = new ArrayList<>();


### PR DESCRIPTION
Fix for the issue discribed in https://groups.google.com/forum/#!topic/confluent-platform/nP34b-P2JVA.

JDBC allows returning a value of -2 (Statement.SUCCESS_NO_INFO) when executing a batch insert/update, which means that operation was successful but number of rows returned is unknown.