### PR TITLE
JDBC Sink Connector - Add insert.mode = UPDATE, that generates only update queries

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -68,7 +68,7 @@ public class BufferedRecords {
       log.debug("{} sql: {}", config.insertMode, insertSql);
       close();
       preparedStatement = connection.prepareStatement(insertSql);
-      preparedStatementBinder = new PreparedStatementBinder(preparedStatement, config.pkMode, schemaPair, fieldsMetadata);
+      preparedStatementBinder = new PreparedStatementBinder(preparedStatement, config.pkMode, schemaPair, fieldsMetadata, config.insertMode);
     }
 
     final List<SinkRecord> flushed;
@@ -111,7 +111,8 @@ public class BufferedRecords {
           throw new ConnectException(String.format("Update count (%d) did not sum up to total number of records inserted (%d)",
                                                    totalUpdateCount, records.size()));
         case UPSERT:
-          log.trace("Upserted records:{} resulting in in totalUpdateCount:{}", records.size(), totalUpdateCount);
+        case UPDATE:
+          log.trace(config.insertMode + " records:{} resulting in in totalUpdateCount:{}", records.size(), totalUpdateCount);
       }
     }
     if (successNoInfo) {
@@ -144,6 +145,8 @@ public class BufferedRecords {
           ));
         }
         return dbDialect.getUpsertQuery(tableName, fieldsMetadata.keyFieldNames, fieldsMetadata.nonKeyFieldNames);
+      case UPDATE:
+        return  dbDialect.getUpdate(tableName, fieldsMetadata.keyFieldNames, fieldsMetadata.nonKeyFieldNames);
       default:
         throw new ConnectException("Invalid insert mode");
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -34,7 +34,9 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   public enum InsertMode {
     INSERT,
-    UPSERT;
+    UPSERT,
+    UPDATE;
+
   }
 
   public enum PrimaryKeyMode {
@@ -106,7 +108,9 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "``insert``\n"
       + "    Use standard SQL ``INSERT`` statements.\n"
       + "``upsert``\n"
-      + "    Use the appropriate upsert semantics for the target database if it is supported by the connector, e.g. ``INSERT OR IGNORE``.";
+      + "    Use the appropriate upsert semantics for the target database if it is supported by the connector, e.g. ``INSERT OR IGNORE``."
+      + "``update``\n"
+      + "    Use the appropriate update semantics for the target database if it is supported by the connector, e.g. ``UPDATE``.";
   private static final String INSERT_MODE_DISPLAY = "Insert Mode";
 
   public static final String PK_FIELDS = "pk.fields";
@@ -158,23 +162,20 @@ public class JdbcSinkConfig extends AbstractConfig {
       .define(CONNECTION_URL, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
               ConfigDef.Importance.HIGH, CONNECTION_URL_DOC,
               CONNECTION_GROUP, 1, ConfigDef.Width.LONG, CONNECTION_URL_DISPLAY)
-      .define(CONNECTION_USER, ConfigDef.Type.STRING, null,
-              ConfigDef.Importance.HIGH, CONNECTION_USER_DOC,
+      .define(CONNECTION_USER, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CONNECTION_USER_DOC,
               CONNECTION_GROUP, 2, ConfigDef.Width.MEDIUM, CONNECTION_USER_DISPLAY)
       .define(CONNECTION_PASSWORD, ConfigDef.Type.PASSWORD, null,
               ConfigDef.Importance.HIGH, CONNECTION_PASSWORD_DOC,
               CONNECTION_GROUP, 3, ConfigDef.Width.MEDIUM, CONNECTION_PASSWORD_DISPLAY)
       // Writes
       .define(INSERT_MODE, ConfigDef.Type.STRING, INSERT_MODE_DEFAULT, EnumValidator.in(InsertMode.values()),
-              ConfigDef.Importance.HIGH, INSERT_MODE_DOC,
-              WRITES_GROUP, 1, ConfigDef.Width.MEDIUM, INSERT_MODE_DISPLAY)
+              ConfigDef.Importance.HIGH, INSERT_MODE_DOC, WRITES_GROUP, 1, ConfigDef.Width.MEDIUM, INSERT_MODE_DISPLAY)
       .define(BATCH_SIZE, ConfigDef.Type.INT, BATCH_SIZE_DEFAULT, NON_NEGATIVE_INT_VALIDATOR,
-              ConfigDef.Importance.MEDIUM, BATCH_SIZE_DOC,
-              WRITES_GROUP, 2, ConfigDef.Width.SHORT, BATCH_SIZE_DISPLAY)
+              ConfigDef.Importance.MEDIUM, BATCH_SIZE_DOC, WRITES_GROUP, 2, ConfigDef.Width.SHORT,
+              BATCH_SIZE_DISPLAY)
       // Data Mapping
-      .define(TABLE_NAME_FORMAT, ConfigDef.Type.STRING, TABLE_NAME_FORMAT_DEFAULT,
-              ConfigDef.Importance.MEDIUM, TABLE_NAME_FORMAT_DOC,
-              DATAMAPPING_GROUP, 1, ConfigDef.Width.LONG, TABLE_NAME_FORMAT_DISPLAY)
+      .define(TABLE_NAME_FORMAT, ConfigDef.Type.STRING, TABLE_NAME_FORMAT_DEFAULT, ConfigDef.Importance.MEDIUM,
+              TABLE_NAME_FORMAT_DOC, DATAMAPPING_GROUP, 1, ConfigDef.Width.LONG, TABLE_NAME_FORMAT_DISPLAY)
       .define(PK_MODE, ConfigDef.Type.STRING, PK_MODE_DEFAULT, EnumValidator.in(PrimaryKeyMode.values()),
               ConfigDef.Importance.HIGH, PK_MODE_DOC,
               DATAMAPPING_GROUP, 2, ConfigDef.Width.MEDIUM, PK_MODE_DISPLAY)

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -162,20 +162,23 @@ public class JdbcSinkConfig extends AbstractConfig {
       .define(CONNECTION_URL, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
               ConfigDef.Importance.HIGH, CONNECTION_URL_DOC,
               CONNECTION_GROUP, 1, ConfigDef.Width.LONG, CONNECTION_URL_DISPLAY)
-      .define(CONNECTION_USER, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, CONNECTION_USER_DOC,
+      .define(CONNECTION_USER, ConfigDef.Type.STRING, null,
+              ConfigDef.Importance.HIGH, CONNECTION_USER_DOC,
               CONNECTION_GROUP, 2, ConfigDef.Width.MEDIUM, CONNECTION_USER_DISPLAY)
       .define(CONNECTION_PASSWORD, ConfigDef.Type.PASSWORD, null,
               ConfigDef.Importance.HIGH, CONNECTION_PASSWORD_DOC,
               CONNECTION_GROUP, 3, ConfigDef.Width.MEDIUM, CONNECTION_PASSWORD_DISPLAY)
       // Writes
       .define(INSERT_MODE, ConfigDef.Type.STRING, INSERT_MODE_DEFAULT, EnumValidator.in(InsertMode.values()),
-              ConfigDef.Importance.HIGH, INSERT_MODE_DOC, WRITES_GROUP, 1, ConfigDef.Width.MEDIUM, INSERT_MODE_DISPLAY)
+              ConfigDef.Importance.HIGH, INSERT_MODE_DOC,
+              WRITES_GROUP, 1, ConfigDef.Width.MEDIUM, INSERT_MODE_DISPLAY)
       .define(BATCH_SIZE, ConfigDef.Type.INT, BATCH_SIZE_DEFAULT, NON_NEGATIVE_INT_VALIDATOR,
-              ConfigDef.Importance.MEDIUM, BATCH_SIZE_DOC, WRITES_GROUP, 2, ConfigDef.Width.SHORT,
-              BATCH_SIZE_DISPLAY)
+              ConfigDef.Importance.MEDIUM, BATCH_SIZE_DOC,
+              WRITES_GROUP, 2, ConfigDef.Width.SHORT, BATCH_SIZE_DISPLAY)
       // Data Mapping
-      .define(TABLE_NAME_FORMAT, ConfigDef.Type.STRING, TABLE_NAME_FORMAT_DEFAULT, ConfigDef.Importance.MEDIUM,
-              TABLE_NAME_FORMAT_DOC, DATAMAPPING_GROUP, 1, ConfigDef.Width.LONG, TABLE_NAME_FORMAT_DISPLAY)
+      .define(TABLE_NAME_FORMAT, ConfigDef.Type.STRING, TABLE_NAME_FORMAT_DEFAULT,
+              ConfigDef.Importance.MEDIUM, TABLE_NAME_FORMAT_DOC,
+              DATAMAPPING_GROUP, 1, ConfigDef.Width.LONG, TABLE_NAME_FORMAT_DISPLAY)
       .define(PK_MODE, ConfigDef.Type.STRING, PK_MODE_DEFAULT, EnumValidator.in(PrimaryKeyMode.values()),
               ConfigDef.Importance.HIGH, PK_MODE_DOC,
               DATAMAPPING_GROUP, 2, ConfigDef.Width.MEDIUM, PK_MODE_DISPLAY)
@@ -275,5 +278,4 @@ public class JdbcSinkConfig extends AbstractConfig {
   public static void main(String... args) {
     System.out.println(CONFIG_DEF.toEnrichedRst());
   }
-
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -60,6 +60,29 @@ public abstract class DbDialect {
     return builder.toString();
   }
 
+  public final String getUpdate(final String tableName, final Collection<String> keyColumns, final Collection<String> nonKeyColumns) {
+    StringBuilder builder = new StringBuilder("UPDATE ");
+    builder.append(escaped(tableName));
+    builder.append(" SET ");
+
+    Transform<String> updateTransformer = new Transform<String>() {
+      @Override public void apply(StringBuilder builder, String input) {
+        builder.append(escaped(input));
+        builder.append(" = ?");
+      }
+    };
+
+    joinToBuilder(builder, ", ", nonKeyColumns, updateTransformer);
+
+    if (!keyColumns.isEmpty()) {
+      builder.append(" WHERE ");
+    }
+
+    joinToBuilder(builder, ", ", keyColumns, updateTransformer);
+    return builder.toString();
+  }
+
+
   public String getUpsertQuery(final String table, final Collection<String> keyColumns, final Collection<String> columns) {
     throw new UnsupportedOperationException();
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -98,7 +98,8 @@ public class PreparedStatementBinderTest {
         statement,
         pkMode,
         schemaPair,
-        fieldsMetadata, JdbcSinkConfig.InsertMode.INSERT
+        fieldsMetadata,
+        JdbcSinkConfig.InsertMode.INSERT
     );
 
     binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 public class PreparedStatementBinderTest {
 
   @Test
-  public void bindRecord() throws SQLException, ParseException {
+  public void bindRecordInsert() throws SQLException, ParseException {
     Schema valueSchema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstName", Schema.STRING_SCHEMA)
         .field("lastName", Schema.STRING_SCHEMA)
@@ -98,7 +98,7 @@ public class PreparedStatementBinderTest {
         statement,
         pkMode,
         schemaPair,
-        fieldsMetadata
+        fieldsMetadata, JdbcSinkConfig.InsertMode.INSERT
     );
 
     binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -124,8 +124,85 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setObject(index++, null);
   }
 
+    @Test
+    public void bindRecordUpsertMode() throws SQLException, ParseException {
+        Schema valueSchema = SchemaBuilder.struct().name("com.example.Person")
+                .field("firstName", Schema.STRING_SCHEMA)
+                .field("long", Schema.INT64_SCHEMA)
+                .build();
 
-  @Test
+        Struct valueStruct = new Struct(valueSchema)
+                .put("firstName", "Alex")
+                .put("long", (long) 12425436);
+
+        SchemaPair schemaPair = new SchemaPair(null, valueSchema);
+
+        JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE;
+
+        List<String> pkFields = Collections.singletonList("long");
+
+        FieldsMetadata fieldsMetadata = FieldsMetadata.extract("people", pkMode, pkFields, Collections.<String>emptySet(), schemaPair);
+
+        PreparedStatement statement = mock(PreparedStatement.class);
+
+        PreparedStatementBinder binder = new PreparedStatementBinder(
+                statement,
+                pkMode,
+                schemaPair,
+                fieldsMetadata, JdbcSinkConfig.InsertMode.UPSERT
+        );
+
+        binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
+
+        int index = 1;
+        // key field first
+        verify(statement, times(1)).setLong(index++, valueStruct.getInt64("long"));
+        // rest in order of schema def
+        verify(statement, times(1)).setString(index++, valueStruct.getString("firstName"));
+    }
+
+    @Test
+    public void bindRecordUpdateMode() throws SQLException, ParseException {
+        Schema valueSchema = SchemaBuilder.struct().name("com.example.Person")
+                .field("firstName", Schema.STRING_SCHEMA)
+                .field("long", Schema.INT64_SCHEMA)
+                .build();
+
+        Struct valueStruct = new Struct(valueSchema)
+                .put("firstName", "Alex")
+                .put("long", (long) 12425436);
+
+        SchemaPair schemaPair = new SchemaPair(null, valueSchema);
+
+        JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE;
+
+        List<String> pkFields = Collections.singletonList("long");
+
+        FieldsMetadata fieldsMetadata = FieldsMetadata.extract("people", pkMode, pkFields,
+                Collections.<String>emptySet(), schemaPair);
+
+        PreparedStatement statement = mock(PreparedStatement.class);
+
+        PreparedStatementBinder binder = new PreparedStatementBinder(
+                statement,
+                pkMode,
+                schemaPair,
+                fieldsMetadata, JdbcSinkConfig.InsertMode.UPDATE
+        );
+
+        binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
+
+        int index = 1;
+
+        // non key first
+        verify(statement, times(1)).setString(index++, valueStruct.getString("firstName"));
+        // last the keys
+        verify(statement, times(1)).setLong(index++, valueStruct.getInt64("long"));
+    }
+
+
+
+    @Test
   public void bindFieldPrimitiveValues() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
     verifyBindField(++index, Schema.INT8_SCHEMA, (byte) 42).setByte(index, (byte) 42);

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -61,46 +61,38 @@ public class MySqlDialectTest extends BaseDialectTest {
 
   @Test
   public void createOneColOnePk() {
-    verifyCreateOneColOnePk(
-        "CREATE TABLE `test` (" + System.lineSeparator() +
-        "`pk1` INT NOT NULL," + System.lineSeparator() +
-        "PRIMARY KEY(`pk1`))");
+    verifyCreateOneColOnePk("CREATE TABLE `test` (" + System.lineSeparator() +
+                    "`pk1` INT NOT NULL," + System.lineSeparator() +
+                    "PRIMARY KEY(`pk1`))");
   }
 
   @Test
   public void createThreeColTwoPk() {
-    verifyCreateThreeColTwoPk(
-        "CREATE TABLE `test` (" + System.lineSeparator() +
-        "`pk1` INT NOT NULL," + System.lineSeparator() +
-        "`pk2` INT NOT NULL," + System.lineSeparator() +
-        "`col1` INT NOT NULL," + System.lineSeparator() +
-        "PRIMARY KEY(`pk1`,`pk2`))"
-    );
+    verifyCreateThreeColTwoPk("CREATE TABLE `test` (" + System.lineSeparator() +
+                    "`pk1` INT NOT NULL," + System.lineSeparator() +
+                    "`pk2` INT NOT NULL," + System.lineSeparator() +
+                    "`col1` INT NOT NULL," + System.lineSeparator() +
+                    "PRIMARY KEY(`pk1`,`pk2`))");
   }
 
   @Test
   public void alterAddOneCol() {
-    verifyAlterAddOneCol(
-        "ALTER TABLE `test` ADD `newcol1` INT NULL"
-    );
+    verifyAlterAddOneCol("ALTER TABLE `test` ADD `newcol1` INT NULL");
   }
 
   @Test
   public void alterAddTwoCol() {
     verifyAlterAddTwoCols(
-        "ALTER TABLE `test` " + System.lineSeparator()
-        + "ADD `newcol1` INT NULL," + System.lineSeparator()
-        + "ADD `newcol2` INT DEFAULT 42"
-    );
+            "ALTER TABLE `test` " + System.lineSeparator() + "ADD `newcol1` INT NULL," + System.lineSeparator()
+                    + "ADD `newcol2` INT DEFAULT 42");
   }
 
   @Test
   public void upsert() {
-    assertEquals(
-        "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
-        "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
-        dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score"))
-    );
+    assertEquals("insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) "
+                    + "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
+            dialect.getUpsertQuery("actor", Arrays.asList("actor_id"),
+                    Arrays.asList("first_name", "last_name", "score")));
   }
 
   @Test
@@ -120,4 +112,11 @@ public class MySqlDialectTest extends BaseDialectTest {
     );
   }
 
+  @Test
+  public void update() {
+    assertEquals(
+        "UPDATE `customers` SET `age` = ?, `firstName` = ?, `lastName` = ? WHERE `id` = ?",
+        dialect.getUpdate("customers", Arrays.asList("id"), Arrays.asList("age", "firstName", "lastName"))
+    );
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -62,42 +62,42 @@ public class MySqlDialectTest extends BaseDialectTest {
   @Test
   public void createOneColOnePk() {
     verifyCreateOneColOnePk(
-            "CREATE TABLE `test` (" + System.lineSeparator() +
-            "`pk1` INT NOT NULL," + System.lineSeparator() +
-            "PRIMARY KEY(`pk1`))");
+        "CREATE TABLE `test` (" + System.lineSeparator() +
+        "`pk1` INT NOT NULL," + System.lineSeparator() +
+        "PRIMARY KEY(`pk1`))");
   }
 
   @Test
   public void createThreeColTwoPk() {
     verifyCreateThreeColTwoPk(
-            "CREATE TABLE `test` (" + System.lineSeparator() +
-            "`pk1` INT NOT NULL," + System.lineSeparator() +
-            "`pk2` INT NOT NULL," + System.lineSeparator() +
-            "`col1` INT NOT NULL," + System.lineSeparator() +
-            "PRIMARY KEY(`pk1`,`pk2`))");
+         "CREATE TABLE `test` (" + System.lineSeparator() +
+         "`pk1` INT NOT NULL," + System.lineSeparator() +
+         "`pk2` INT NOT NULL," + System.lineSeparator() +
+         "`col1` INT NOT NULL," + System.lineSeparator() +
+         "PRIMARY KEY(`pk1`,`pk2`))");
   }
 
   @Test
   public void alterAddOneCol() {
      verifyAlterAddOneCol(
-             "ALTER TABLE `test` ADD `newcol1` INT NULL");
+         "ALTER TABLE `test` ADD `newcol1` INT NULL");
   }
 
   @Test
   public void alterAddTwoCol() {
     verifyAlterAddTwoCols(
-            "ALTER TABLE `test` " + System.lineSeparator()
-            + "ADD `newcol1` INT NULL," + System.lineSeparator()
-            + "ADD `newcol2` INT DEFAULT 42"
+         "ALTER TABLE `test` " + System.lineSeparator()
+         + "ADD `newcol1` INT NULL," + System.lineSeparator()
+         + "ADD `newcol2` INT DEFAULT 42"
     );
   }
 
   @Test
   public void upsert() {
     assertEquals(
-            "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
-            "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
-            dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score")));
+        "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
+        "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
+        dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score")));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -61,38 +61,43 @@ public class MySqlDialectTest extends BaseDialectTest {
 
   @Test
   public void createOneColOnePk() {
-    verifyCreateOneColOnePk("CREATE TABLE `test` (" + System.lineSeparator() +
-                    "`pk1` INT NOT NULL," + System.lineSeparator() +
-                    "PRIMARY KEY(`pk1`))");
+    verifyCreateOneColOnePk(
+            "CREATE TABLE `test` (" + System.lineSeparator() +
+            "`pk1` INT NOT NULL," + System.lineSeparator() +
+            "PRIMARY KEY(`pk1`))");
   }
 
   @Test
   public void createThreeColTwoPk() {
-    verifyCreateThreeColTwoPk("CREATE TABLE `test` (" + System.lineSeparator() +
-                    "`pk1` INT NOT NULL," + System.lineSeparator() +
-                    "`pk2` INT NOT NULL," + System.lineSeparator() +
-                    "`col1` INT NOT NULL," + System.lineSeparator() +
-                    "PRIMARY KEY(`pk1`,`pk2`))");
+    verifyCreateThreeColTwoPk(
+            "CREATE TABLE `test` (" + System.lineSeparator() +
+            "`pk1` INT NOT NULL," + System.lineSeparator() +
+            "`pk2` INT NOT NULL," + System.lineSeparator() +
+            "`col1` INT NOT NULL," + System.lineSeparator() +
+            "PRIMARY KEY(`pk1`,`pk2`))");
   }
 
   @Test
   public void alterAddOneCol() {
-    verifyAlterAddOneCol("ALTER TABLE `test` ADD `newcol1` INT NULL");
+     verifyAlterAddOneCol(
+             "ALTER TABLE `test` ADD `newcol1` INT NULL");
   }
 
   @Test
   public void alterAddTwoCol() {
     verifyAlterAddTwoCols(
-            "ALTER TABLE `test` " + System.lineSeparator() + "ADD `newcol1` INT NULL," + System.lineSeparator()
-                    + "ADD `newcol2` INT DEFAULT 42");
+            "ALTER TABLE `test` " + System.lineSeparator()
+            + "ADD `newcol1` INT NULL," + System.lineSeparator()
+            + "ADD `newcol2` INT DEFAULT 42"
+    );
   }
 
   @Test
   public void upsert() {
-    assertEquals("insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) "
-                    + "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
-            dialect.getUpsertQuery("actor", Arrays.asList("actor_id"),
-                    Arrays.asList("first_name", "last_name", "score")));
+    assertEquals(
+            "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
+            "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
+            dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score")));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -74,13 +74,15 @@ public class MySqlDialectTest extends BaseDialectTest {
         "`pk1` INT NOT NULL," + System.lineSeparator() +
         "`pk2` INT NOT NULL," + System.lineSeparator() +
         "`col1` INT NOT NULL," + System.lineSeparator() +
-        "PRIMARY KEY(`pk1`,`pk2`))");
+        "PRIMARY KEY(`pk1`,`pk2`))"
+    );
   }
 
   @Test
   public void alterAddOneCol() {
     verifyAlterAddOneCol(
-        "ALTER TABLE `test` ADD `newcol1` INT NULL");
+        "ALTER TABLE `test` ADD `newcol1` INT NULL"
+    );
   }
 
   @Test
@@ -97,7 +99,8 @@ public class MySqlDialectTest extends BaseDialectTest {
     assertEquals(
         "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
         "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
-        dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score")));
+        dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score"))
+    );
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -70,25 +70,25 @@ public class MySqlDialectTest extends BaseDialectTest {
   @Test
   public void createThreeColTwoPk() {
     verifyCreateThreeColTwoPk(
-         "CREATE TABLE `test` (" + System.lineSeparator() +
-         "`pk1` INT NOT NULL," + System.lineSeparator() +
-         "`pk2` INT NOT NULL," + System.lineSeparator() +
-         "`col1` INT NOT NULL," + System.lineSeparator() +
-         "PRIMARY KEY(`pk1`,`pk2`))");
+        "CREATE TABLE `test` (" + System.lineSeparator() +
+        "`pk1` INT NOT NULL," + System.lineSeparator() +
+        "`pk2` INT NOT NULL," + System.lineSeparator() +
+        "`col1` INT NOT NULL," + System.lineSeparator() +
+        "PRIMARY KEY(`pk1`,`pk2`))");
   }
 
   @Test
   public void alterAddOneCol() {
-     verifyAlterAddOneCol(
-         "ALTER TABLE `test` ADD `newcol1` INT NULL");
+    verifyAlterAddOneCol(
+        "ALTER TABLE `test` ADD `newcol1` INT NULL");
   }
 
   @Test
   public void alterAddTwoCol() {
     verifyAlterAddTwoCols(
-         "ALTER TABLE `test` " + System.lineSeparator()
-         + "ADD `newcol1` INT NULL," + System.lineSeparator()
-         + "ADD `newcol2` INT DEFAULT 42"
+        "ALTER TABLE `test` " + System.lineSeparator()
+        + "ADD `newcol1` INT NULL," + System.lineSeparator()
+        + "ADD `newcol2` INT DEFAULT 42"
     );
   }
 


### PR DESCRIPTION
I needed a way to just update existing records from tables, and I added this UPDATE mode for JDBC Sink Connector. This creates UPDATE queries based on the primary keys.
I think this could be useful for other as well.

Thank you,
Maria