### PR TITLE
correct version added for kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <confluent.version>${project.version}</confluent.version>
-        <kafka.version>0.11.0.0-SNAPSHOT</kafka.version>
+        <kafka.version>0.10.2.0</kafka.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.0</easymock.version>
         <powermock.version>1.6.2</powermock.version>


### PR DESCRIPTION
Correct version added for Kafka version in POM. With the previous version Kafka-connect-JDBC was not able to build.