### PR TITLE
Fix issue #214: The data with same timestamp is segmented into two partitions, lead to data loss.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -210,7 +210,7 @@ public class JdbcSourceTask extends SourceTask {
         // Continue until all the data in the partition which parted by latest timestamp in current batch is read
         while (hadNext = querier.next()) {
           SourceRecord record = querier.extractRecord();
-          if(latestOffset == null || !latestOffset.equals(TimestampIncrementingOffset.fromMap(record.sourceOffset()))) {
+          if (latestOffset == null || !latestOffset.equals(TimestampIncrementingOffset.fromMap(record.sourceOffset()))) {
             break;
           }
           results.add(record);

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -92,6 +92,10 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     return resultSet.next();
   }
 
+  public boolean previous() throws SQLException {
+    return resultSet.previous();
+  }
+
   public abstract SourceRecord extractRecord() throws SQLException;
 
   public void reset(long now) {


### PR DESCRIPTION
When finished reading a batch, don't stop, continue reading until all the data in the partition which parted by latest timestamp in current batch is read.