### PR TITLE
JDBC Source Connector - Empty table list failing entire process

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -124,8 +124,8 @@ public class JdbcSourceConnector extends SourceConnector {
     } else {
       List<String> currentTables = tableMonitorThread.tables();
       int numGroups = Math.min(currentTables.size(), maxTasks);
-      if(numGroups <= 0){
-          return new ArrayList<>();
+      if (numGroups <= 0) {
+        return new ArrayList<>();
       }
       List<List<String>> tablesGrouped = ConnectorUtils.groupPartitions(currentTables, numGroups);
       List<Map<String, String>> taskConfigs = new ArrayList<>(tablesGrouped.size());

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -124,6 +124,9 @@ public class JdbcSourceConnector extends SourceConnector {
     } else {
       List<String> currentTables = tableMonitorThread.tables();
       int numGroups = Math.min(currentTables.size(), maxTasks);
+      if(numGroups <= 0){
+          return new ArrayList<>();
+      }
       List<List<String>> tablesGrouped = ConnectorUtils.groupPartitions(currentTables, numGroups);
       List<Map<String, String>> taskConfigs = new ArrayList<>(tablesGrouped.size());
       for (List<String> taskTables : tablesGrouped) {

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -156,6 +156,15 @@ public class JdbcSourceConnectorTest {
   }
 
   @Test
+  public void testPartitioningZeroTables() throws Exception {
+    connector.start(connProps);
+    List<Map<String, String>> configs = connector.taskConfigs(3);
+    assertEquals(0, configs.size());
+    assertTaskConfigsHaveParentConfigs(configs);
+    connector.stop();
+  }
+  
+  @Test
   public void testPartitioningQuery() throws Exception {
     // Tests "partitioning" when config specifies running a custom query
     db.createTable("test1", "id", "INT NOT NULL");


### PR DESCRIPTION
Proposed fix for #234 . Here instead of failing Task creation which subsequently stopping connector as well as entire worker, proceeding further without creating any task(s) for this JDBC connector.