### PR TITLE
Enable specification of timestamp and incrementing column alias

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -96,12 +96,24 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String INCREMENTING_COLUMN_NAME_DEFAULT = "";
   private static final String INCREMENTING_COLUMN_NAME_DISPLAY = "Incrementing Column Name";
 
+  public static final String INCREMENTING_COLUMN_ALIAS_CONFIG = "incrementing.column.alias";
+  private static final String INCREMENTING_COLUMN_ALIAS_DOC =
+      "The alias of the strictly incrementing column to use to detect new rows.";
+  public static final String INCREMENTING_COLUMN_ALIAS_DEFAULT = "";
+  private static final String INCREMENTING_COLUMN_ALIAS_DISPLAY = "Incrementing Column Alias";
+
   public static final String TIMESTAMP_COLUMN_NAME_CONFIG = "timestamp.column.name";
   private static final String TIMESTAMP_COLUMN_NAME_DOC =
       "The name of the timestamp column to use to detect new or modified rows. This column may "
       + "not be nullable.";
   public static final String TIMESTAMP_COLUMN_NAME_DEFAULT = "";
   private static final String TIMESTAMP_COLUMN_NAME_DISPLAY = "Timestamp Column Name";
+
+  public static final String TIMESTAMP_COLUMN_ALIAS_CONFIG = "timestamp.column.alias";
+  private static final String TIMESTAMP_COLUMN_ALIAS_DOC =
+      "The alias of the timestamp column to use to detect new or modified rows.";
+  public static final String TIMESTAMP_COLUMN_ALIAS_DEFAULT = "";
+  private static final String TIMESTAMP_COLUMN_ALIAS_DISPLAY = "Timestamp Column Alias";
 
   public static final String TABLE_POLL_INTERVAL_MS_CONFIG = "table.poll.interval.ms";
   private static final String TABLE_POLL_INTERVAL_MS_DOC =
@@ -204,14 +216,19 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                 TABLE_TYPE_DOC, CONNECTOR_GROUP, 4, Width.MEDIUM, TABLE_TYPE_DISPLAY)
         .define(NUMERIC_PRECISION_MAPPING_CONFIG, Type.BOOLEAN, NUMERIC_PRECISION_MAPPING_DEFAULT, Importance.LOW, NUMERIC_PRECISION_MAPPING_DOC, DATABASE_GROUP, 4, Width.SHORT, NUMERIC_PRECISION_MAPPING_DISPLAY)
         .define(MODE_CONFIG, Type.STRING, MODE_UNSPECIFIED, ConfigDef.ValidString.in(MODE_UNSPECIFIED, MODE_BULK, MODE_TIMESTAMP, MODE_INCREMENTING, MODE_TIMESTAMP_INCREMENTING),
-                Importance.HIGH, MODE_DOC, MODE_GROUP, 1, Width.MEDIUM, MODE_DISPLAY, Arrays.asList(INCREMENTING_COLUMN_NAME_CONFIG, TIMESTAMP_COLUMN_NAME_CONFIG, VALIDATE_NON_NULL_CONFIG))
+                Importance.HIGH, MODE_DOC, MODE_GROUP, 1, Width.MEDIUM, MODE_DISPLAY,
+                Arrays.asList(INCREMENTING_COLUMN_NAME_CONFIG, INCREMENTING_COLUMN_ALIAS_CONFIG, TIMESTAMP_COLUMN_NAME_CONFIG, TIMESTAMP_COLUMN_ALIAS_CONFIG, VALIDATE_NON_NULL_CONFIG))
         .define(INCREMENTING_COLUMN_NAME_CONFIG, Type.STRING, INCREMENTING_COLUMN_NAME_DEFAULT, Importance.MEDIUM, INCREMENTING_COLUMN_NAME_DOC, MODE_GROUP, 2, Width.MEDIUM, INCREMENTING_COLUMN_NAME_DISPLAY,
                 MODE_DEPENDENTS_RECOMMENDER)
-        .define(TIMESTAMP_COLUMN_NAME_CONFIG, Type.STRING, TIMESTAMP_COLUMN_NAME_DEFAULT, Importance.MEDIUM, TIMESTAMP_COLUMN_NAME_DOC, MODE_GROUP, 3, Width.MEDIUM, TIMESTAMP_COLUMN_NAME_DISPLAY,
+        .define(INCREMENTING_COLUMN_ALIAS_CONFIG, Type.STRING, INCREMENTING_COLUMN_ALIAS_DEFAULT, Importance.LOW, INCREMENTING_COLUMN_ALIAS_DOC, MODE_GROUP, 3, Width.SHORT, INCREMENTING_COLUMN_ALIAS_DISPLAY,
                 MODE_DEPENDENTS_RECOMMENDER)
-        .define(VALIDATE_NON_NULL_CONFIG, Type.BOOLEAN, VALIDATE_NON_NULL_DEFAULT, Importance.LOW, VALIDATE_NON_NULL_DOC, MODE_GROUP, 4, Width.SHORT, VALIDATE_NON_NULL_DISPLAY,
+        .define(TIMESTAMP_COLUMN_NAME_CONFIG, Type.STRING, TIMESTAMP_COLUMN_NAME_DEFAULT, Importance.MEDIUM, TIMESTAMP_COLUMN_NAME_DOC, MODE_GROUP, 4, Width.MEDIUM, TIMESTAMP_COLUMN_NAME_DISPLAY,
                 MODE_DEPENDENTS_RECOMMENDER)
-        .define(QUERY_CONFIG, Type.STRING, QUERY_DEFAULT, Importance.MEDIUM, QUERY_DOC, MODE_GROUP, 5, Width.SHORT, QUERY_DISPLAY)
+        .define(TIMESTAMP_COLUMN_ALIAS_CONFIG, Type.STRING, TIMESTAMP_COLUMN_ALIAS_DEFAULT, Importance.LOW, TIMESTAMP_COLUMN_ALIAS_DOC, MODE_GROUP, 5, Width.SHORT, TIMESTAMP_COLUMN_ALIAS_DISPLAY,
+                MODE_DEPENDENTS_RECOMMENDER)
+        .define(VALIDATE_NON_NULL_CONFIG, Type.BOOLEAN, VALIDATE_NON_NULL_DEFAULT, Importance.LOW, VALIDATE_NON_NULL_DOC, MODE_GROUP, 6, Width.SHORT, VALIDATE_NON_NULL_DISPLAY,
+                MODE_DEPENDENTS_RECOMMENDER)
+        .define(QUERY_CONFIG, Type.STRING, QUERY_DEFAULT, Importance.MEDIUM, QUERY_DOC, MODE_GROUP, 7, Width.SHORT, QUERY_DISPLAY)
         .define(POLL_INTERVAL_MS_CONFIG, Type.INT, POLL_INTERVAL_MS_DEFAULT, Importance.HIGH, POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 1, Width.SHORT, POLL_INTERVAL_MS_DISPLAY)
         .define(BATCH_MAX_ROWS_CONFIG, Type.INT, BATCH_MAX_ROWS_DEFAULT, Importance.LOW, BATCH_MAX_ROWS_DOC, CONNECTOR_GROUP, 2, Width.SHORT, BATCH_MAX_ROWS_DISPLAY)
         .define(TABLE_POLL_INTERVAL_MS_CONFIG, Type.LONG, TABLE_POLL_INTERVAL_MS_DEFAULT, Importance.LOW, TABLE_POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 3, Width.SHORT, TABLE_POLL_INTERVAL_MS_DISPLAY)
@@ -268,11 +285,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         case MODE_BULK:
           return false;
         case MODE_TIMESTAMP:
-          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
+          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(TIMESTAMP_COLUMN_ALIAS_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_INCREMENTING:
-          return name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
+          return name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_ALIAS_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_TIMESTAMP_INCREMENTING:
-          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
+          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(TIMESTAMP_COLUMN_ALIAS_CONFIG) || name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_ALIAS_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_UNSPECIFIED:
           throw new ConfigException("Query mode must be specified");
         default:

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -116,8 +116,12 @@ public class JdbcSourceTask extends SourceTask {
         = config.getString(JdbcSourceTaskConfig.SCHEMA_PATTERN_CONFIG);
     String incrementingColumn
         = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+    String incrementingColumnAlias
+        = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_ALIAS_CONFIG);
     String timestampColumn
         = config.getString(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+    String timestampColumnAlias
+        = config.getString(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_ALIAS_CONFIG);
     Long timestampDelayInterval
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
@@ -150,15 +154,15 @@ public class JdbcSourceTask extends SourceTask {
                 topicPrefix, mapNumerics));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+                queryMode, tableOrQuery, topicPrefix, null, null, incrementingColumn, incrementingColumnAlias,
+                offset, timestampDelayInterval, schemaPattern, mapNumerics));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+                queryMode, tableOrQuery, topicPrefix, timestampColumn, timestampColumnAlias, null, null,
+                offset, timestampDelayInterval, schemaPattern, mapNumerics));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn,
+                queryMode, tableOrQuery, topicPrefix, timestampColumn, timestampColumnAlias, incrementingColumn, incrementingColumnAlias,
                 offset, timestampDelayInterval, schemaPattern, mapNumerics));
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -268,7 +268,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
     String result = "";
 
     if (!columnAlias.isEmpty()) {
-      result += JdbcUtils.quoteString(timestampColumnAlias, quoteString) + ".";
+      result += JdbcUtils.quoteString(columnAlias, quoteString) + ".";
     }
 
     return result + JdbcUtils.quoteString(columnName, quoteString);

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -16,20 +16,43 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.JdbcUtils;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
 
+import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JdbcUtils.class)
 public class TimestampIncrementingTableQuerierTest {
+
+  private Connection connection;
+
+  @Before
+  public void setUp() throws SQLException {
+    connection = mock(Connection.class);
+
+    PowerMock.mockStatic(JdbcUtils.class);
+
+    expect(JdbcUtils.getIdentifierQuoteString(connection)).andReturn("");
+  }
 
   @Test
   public void extractIntOffset() throws SQLException {
@@ -67,6 +90,107 @@ public class TimestampIncrementingTableQuerierTest {
     final Schema schema = SchemaBuilder.struct().field("id", decimalSchema).build();
     final Struct record = new Struct(schema).put("id", new BigDecimal("42.42"));
     newQuerier().extractOffset(schema, record).getIncrementingOffset();
+  }
+
+  @Test
+  public void createAutoIncrementingPreparedStatement() throws SQLException {
+    final TimestampIncrementingTableQuerier querier = new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, "table", "", null, null, "", "", Collections.<String, Object>emptyMap(), 0L, null, false);
+
+    expect(JdbcUtils.getAutoincrementColumn(connection, null, "table")).andReturn("id");
+
+    expect(JdbcUtils.quoteString("table", "")).andReturn("table");
+    expect(JdbcUtils.quoteString("id", "")).andReturn("id");
+
+    PowerMock.replay(JdbcUtils.class);
+
+    querier.getOrCreatePreparedStatement(connection);
+
+    verify(connection).prepareStatement("SELECT * FROM table WHERE id > ? ORDER BY id ASC");
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void createIncrementingAliasPreparedStatement() throws SQLException {
+    final TimestampIncrementingTableQuerier querier = new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.QUERY, "query", "", null, null, "id", "t", Collections.<String, Object>emptyMap(), 0L, null, false);
+
+    expect(JdbcUtils.quoteString("t", "")).andReturn("t");
+    expect(JdbcUtils.quoteString("id", "")).andReturn("id");
+
+    PowerMock.replayAll();
+
+    querier.getOrCreatePreparedStatement(connection);
+
+    verify(connection).prepareStatement("query WHERE t.id > ? ORDER BY t.id ASC");
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void createTimestampPreparedStatement() throws SQLException {
+    final TimestampIncrementingTableQuerier querier = new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, "table", "", "updated_at", "", null, null, Collections.<String, Object>emptyMap(), 0L, null, false);
+
+    expect(JdbcUtils.quoteString("table", "")).andReturn("table");
+    expect(JdbcUtils.quoteString("updated_at", "")).andReturn("updated_at");
+
+    PowerMock.replay(JdbcUtils.class);
+
+    querier.getOrCreatePreparedStatement(connection);
+
+    verify(connection).prepareStatement("SELECT * FROM table WHERE updated_at > ? AND updated_at < ? ORDER BY updated_at ASC");
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void createTimestampAliasPreparedStatement() throws SQLException {
+    final TimestampIncrementingTableQuerier querier = new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.QUERY, "query", "", "updated_at", "t", null, null, Collections.<String, Object>emptyMap(), 0L, null, false);
+
+    expect(JdbcUtils.quoteString("t", "")).andReturn("t");
+    expect(JdbcUtils.quoteString("updated_at", "")).andReturn("updated_at");
+
+    PowerMock.replay(JdbcUtils.class);
+
+    querier.getOrCreatePreparedStatement(connection);
+
+    verify(connection).prepareStatement("query WHERE t.updated_at > ? AND t.updated_at < ? ORDER BY t.updated_at ASC");
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void createTimestampIncrementingPreparedStatement() throws SQLException {
+    final TimestampIncrementingTableQuerier querier = new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, "table", "", "updated_at", "", "id", "", Collections.<String, Object>emptyMap(), 0L, null, false);
+
+    expect(JdbcUtils.quoteString("table", "")).andReturn("table");
+    expect(JdbcUtils.quoteString("id", "")).andReturn("id");
+    expect(JdbcUtils.quoteString("updated_at", "")).andReturn("updated_at");
+
+    PowerMock.replay(JdbcUtils.class);
+
+    querier.getOrCreatePreparedStatement(connection);
+
+    verify(connection).prepareStatement("SELECT * FROM table WHERE updated_at < ? AND ((updated_at = ? AND id > ?) OR updated_at > ?) ORDER BY updated_at,id ASC");
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void createTimestampAliasIncrementingAliasPreparedStatement() throws SQLException {
+    final TimestampIncrementingTableQuerier querier = new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.QUERY, "query", "", "updated_at", "t", "id", "i", Collections.<String, Object>emptyMap(), 0L, null, false);
+
+    expect(JdbcUtils.quoteString("t", "")).andReturn("t");
+    expect(JdbcUtils.quoteString("i", "")).andReturn("i");
+    expect(JdbcUtils.quoteString("id", "")).andReturn("id");
+    expect(JdbcUtils.quoteString("updated_at", "")).andReturn("updated_at");
+
+    PowerMock.replay(JdbcUtils.class);
+
+    querier.getOrCreatePreparedStatement(connection);
+
+    verify(connection).prepareStatement("query WHERE t.updated_at < ? AND ((t.updated_at = ? AND i.id > ?) OR t.updated_at > ?) ORDER BY t.updated_at,i.id ASC");
+
+    PowerMock.verifyAll();
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -70,7 +70,7 @@ public class TimestampIncrementingTableQuerierTest {
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {
-    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false);
+    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, null, "id", "", Collections.<String, Object>emptyMap(), 0L, null, false);
   }
 
 }


### PR DESCRIPTION
This is useful when specifying a custom query and there are columns across multiple tables with the same name. Including column aliases for specificity is currently less than ideal due to the way the column names are quoted.