### PR TITLE
fix "Support WHERE clauses in custom queries in incremental mode #112…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -72,6 +72,14 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
   }
+  
+  private void ifWhereIncluded(StringBuilder builder, String query){
+    if (query.toLowerCase().indexOf("where") != -1) {
+      builder.append(" and ");
+    } else {
+      builder.append(" where ");
+    }
+  }
 
   @Override
   protected void createPreparedStatement(Connection db) throws SQLException {
@@ -110,7 +118,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       //  timestamp 1235, id 22
       //  timestamp 1236, id 23
       // We should capture both id = 22 (an update) and id = 23 (a new row)
-      builder.append(" WHERE ");
+      ifWhereIncluded(builder,query);
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
       builder.append(" < ? AND ((");
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
@@ -126,14 +134,14 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
       builder.append(" ASC");
     } else if (incrementingColumn != null) {
-      builder.append(" WHERE ");
+      ifWhereIncluded(builder,query);
       builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
       builder.append(" > ?");
       builder.append(" ORDER BY ");
       builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
       builder.append(" ASC");
     } else if (timestampColumn != null) {
-      builder.append(" WHERE ");
+      ifWhereIncluded(builder,query);
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
       builder.append(" > ? AND ");
       builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));


### PR DESCRIPTION
…" #191

This pull can easy solve this issue. It allows people to add "where" condition in the query part of a jdbc sink. So that, people can have any kind of offset for their jdbc sink instead of querying data from the beginning of a table or view.