### PR TITLE
Features for MySQL: Allowing to disable field name quoting, using MySQL LIMIT to prevent OOM exceptions and allowing specification of incrementing column label

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -118,6 +118,15 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String INCREMENTING_COLUMN_NAME_DEFAULT = "";
   private static final String INCREMENTING_COLUMN_NAME_DISPLAY = "Incrementing Column Name";
 
+  public static final String INCREMENTING_COLUMN_LABEL_CONFIG = "incrementing.column.label";
+  private static final String INCREMENTING_COLUMN_LABEL_DOC =
+      "The label ('AS column_label' in the SELECT statement) of the strictly incrementing column to use to detect new rows. Any empty value "
+      + "indicates that the value defined by INCREMENTING_COLUMN_NAME_CONFIG is used to derive the field name in the source record "
+      + "and it's schema. This config option is useful for MySQL where you cannot use column labels in where clauses but you need a unique "
+      + "label for this field in the kafka record";
+  public static final String INCREMENTING_COLUMN_LABEL_DEFAULT = "";
+  private static final String INCREMENTING_COLUMN_LABEL_DISPLAY = "Incrementing Column Label";
+
   public static final String TIMESTAMP_COLUMN_NAME_CONFIG = "timestamp.column.name";
   private static final String TIMESTAMP_COLUMN_NAME_DOC =
       "The name of the timestamp column to use to detect new or modified rows. This column may "
@@ -231,6 +240,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                 Importance.HIGH, MODE_DOC, MODE_GROUP, 1, Width.MEDIUM, MODE_DISPLAY, Arrays.asList(INCREMENTING_COLUMN_NAME_CONFIG, TIMESTAMP_COLUMN_NAME_CONFIG, VALIDATE_NON_NULL_CONFIG))
         .define(INCREMENTING_COLUMN_NAME_CONFIG, Type.STRING, INCREMENTING_COLUMN_NAME_DEFAULT, Importance.MEDIUM, INCREMENTING_COLUMN_NAME_DOC, MODE_GROUP, 2, Width.MEDIUM, INCREMENTING_COLUMN_NAME_DISPLAY,
                 MODE_DEPENDENTS_RECOMMENDER)
+        .define(INCREMENTING_COLUMN_LABEL_CONFIG, Type.STRING, INCREMENTING_COLUMN_LABEL_DEFAULT, Importance.LOW, INCREMENTING_COLUMN_LABEL_DOC, MODE_GROUP, 2, Width.MEDIUM, INCREMENTING_COLUMN_LABEL_DISPLAY,
+                MODE_DEPENDENTS_RECOMMENDER)
         .define(TIMESTAMP_COLUMN_NAME_CONFIG, Type.STRING, TIMESTAMP_COLUMN_NAME_DEFAULT, Importance.MEDIUM, TIMESTAMP_COLUMN_NAME_DOC, MODE_GROUP, 3, Width.MEDIUM, TIMESTAMP_COLUMN_NAME_DISPLAY,
                 MODE_DEPENDENTS_RECOMMENDER)
         .define(VALIDATE_NON_NULL_CONFIG, Type.BOOLEAN, VALIDATE_NON_NULL_DEFAULT, Importance.LOW, VALIDATE_NON_NULL_DOC, MODE_GROUP, 4, Width.SHORT, VALIDATE_NON_NULL_DISPLAY,
@@ -296,9 +307,9 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         case MODE_TIMESTAMP:
           return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_INCREMENTING:
-          return name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
+          return name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_LABEL_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_TIMESTAMP_INCREMENTING:
-          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
+          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_NAME_CONFIG) || name.equals(INCREMENTING_COLUMN_LABEL_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_UNSPECIFIED:
           throw new ConfigException("Query mode must be specified");
         default:

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -77,6 +77,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final boolean QUERY_QUOTE_FIELDNAMES_DEFAULT = true;
   private static final String QUERY_QUOTE_FIELDNAMES_DISPLAY = "Quote field names in query mode";
 
+  public static final String USE_MYSQL_LIMIT_CONFIG = "mysql.use.limit";
+  private static final String USE_MYSQL_LIMIT_DOC =
+      "Use the MySQL LIMIT clause with the BATCH_MAX_ROWS value to prevent OOM Exceptions for big queries";
+  public static final boolean USE_MYSQL_LIMIT_DEFAULT = false;
+  private static final String USE_MYSQL_LIMIT_DISPLAY = "Use the MySQL LIMIT clause with BATCH_MAX_ROWS";
+
   public static final String NUMERIC_PRECISION_MAPPING_CONFIG = "numeric.precision.mapping";
   private static final String NUMERIC_PRECISION_MAPPING_DOC =
           "Whether or not to attempt mapping NUMERIC values by precision to integral types";
@@ -233,6 +239,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         .define(QUERY_QUOTE_FIELDNAMES_CONFIG, Type.BOOLEAN, QUERY_QUOTE_FIELDNAMES_DEFAULT, Importance.LOW, QUERY_QUOTE_FIELDNAMES_DOC, CONNECTOR_GROUP, 5, Width.SHORT, QUERY_QUOTE_FIELDNAMES_DISPLAY)
         .define(POLL_INTERVAL_MS_CONFIG, Type.INT, POLL_INTERVAL_MS_DEFAULT, Importance.HIGH, POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 1, Width.SHORT, POLL_INTERVAL_MS_DISPLAY)
         .define(BATCH_MAX_ROWS_CONFIG, Type.INT, BATCH_MAX_ROWS_DEFAULT, Importance.LOW, BATCH_MAX_ROWS_DOC, CONNECTOR_GROUP, 2, Width.SHORT, BATCH_MAX_ROWS_DISPLAY)
+        .define(USE_MYSQL_LIMIT_CONFIG, Type.BOOLEAN, USE_MYSQL_LIMIT_DEFAULT, Importance.LOW, USE_MYSQL_LIMIT_DOC, CONNECTOR_GROUP, 2, Width.SHORT, USE_MYSQL_LIMIT_DISPLAY)
         .define(TABLE_POLL_INTERVAL_MS_CONFIG, Type.LONG, TABLE_POLL_INTERVAL_MS_DEFAULT, Importance.LOW, TABLE_POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 3, Width.SHORT, TABLE_POLL_INTERVAL_MS_DISPLAY)
         .define(TOPIC_PREFIX_CONFIG, Type.STRING, Importance.HIGH, TOPIC_PREFIX_DOC, CONNECTOR_GROUP, 4, Width.MEDIUM, TOPIC_PREFIX_DISPLAY)
         .define(TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, Type.LONG, TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT, Importance.HIGH, TIMESTAMP_DELAY_INTERVAL_MS_DOC, CONNECTOR_GROUP, 5, Width.MEDIUM, TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -71,6 +71,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final int BATCH_MAX_ROWS_DEFAULT = 100;
   private static final String BATCH_MAX_ROWS_DISPLAY = "Max Rows Per Batch";
 
+  public static final String QUERY_QUOTE_FIELDNAMES_CONFIG = "query.quote.fieldnames";
+  private static final String QUERY_QUOTE_FIELDNAMES_DOC =
+          "Specifies if the field names are quoted in QUERY mode";
+  public static final boolean QUERY_QUOTE_FIELDNAMES_DEFAULT = true;
+  private static final String QUERY_QUOTE_FIELDNAMES_DISPLAY = "Quote field names in query mode";
+
   public static final String NUMERIC_PRECISION_MAPPING_CONFIG = "numeric.precision.mapping";
   private static final String NUMERIC_PRECISION_MAPPING_DOC =
           "Whether or not to attempt mapping NUMERIC values by precision to integral types";
@@ -224,6 +230,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         .define(VALIDATE_NON_NULL_CONFIG, Type.BOOLEAN, VALIDATE_NON_NULL_DEFAULT, Importance.LOW, VALIDATE_NON_NULL_DOC, MODE_GROUP, 4, Width.SHORT, VALIDATE_NON_NULL_DISPLAY,
                 MODE_DEPENDENTS_RECOMMENDER)
         .define(QUERY_CONFIG, Type.STRING, QUERY_DEFAULT, Importance.MEDIUM, QUERY_DOC, MODE_GROUP, 5, Width.SHORT, QUERY_DISPLAY)
+        .define(QUERY_QUOTE_FIELDNAMES_CONFIG, Type.BOOLEAN, QUERY_QUOTE_FIELDNAMES_DEFAULT, Importance.LOW, QUERY_QUOTE_FIELDNAMES_DOC, CONNECTOR_GROUP, 5, Width.SHORT, QUERY_QUOTE_FIELDNAMES_DISPLAY)
         .define(POLL_INTERVAL_MS_CONFIG, Type.INT, POLL_INTERVAL_MS_DEFAULT, Importance.HIGH, POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 1, Width.SHORT, POLL_INTERVAL_MS_DISPLAY)
         .define(BATCH_MAX_ROWS_CONFIG, Type.INT, BATCH_MAX_ROWS_DEFAULT, Importance.LOW, BATCH_MAX_ROWS_DOC, CONNECTOR_GROUP, 2, Width.SHORT, BATCH_MAX_ROWS_DISPLAY)
         .define(TABLE_POLL_INTERVAL_MS_CONFIG, Type.LONG, TABLE_POLL_INTERVAL_MS_DEFAULT, Importance.LOW, TABLE_POLL_INTERVAL_MS_DOC, CONNECTOR_GROUP, 3, Width.SHORT, TABLE_POLL_INTERVAL_MS_DISPLAY)

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -148,6 +148,8 @@ public class JdbcSourceTask extends SourceTask {
       String topicPrefix = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
       boolean mapNumerics = config.getBoolean(JdbcSourceTaskConfig.NUMERIC_PRECISION_MAPPING_CONFIG);
       boolean quoteFieldnames = config.getBoolean(JdbcSourceTaskConfig.QUERY_QUOTE_FIELDNAMES_CONFIG);
+      boolean useMySqlLimit = config.getBoolean(JdbcSourceTaskConfig.USE_MYSQL_LIMIT_CONFIG);
+      int batchMaxRows = config.getInt(JdbcSourceTaskConfig.BATCH_MAX_ROWS_CONFIG);
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(new BulkTableQuerier(queryMode, tableOrQuery, schemaPattern,
@@ -155,15 +157,15 @@ public class JdbcSourceTask extends SourceTask {
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames));
+                timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames, useMySqlLimit, batchMaxRows));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames));
+                timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames, useMySqlLimit, batchMaxRows));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn,
-                offset, timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames));
+                offset, timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames, useMySqlLimit, batchMaxRows));
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -147,6 +147,7 @@ public class JdbcSourceTask extends SourceTask {
 
       String topicPrefix = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
       boolean mapNumerics = config.getBoolean(JdbcSourceTaskConfig.NUMERIC_PRECISION_MAPPING_CONFIG);
+      boolean quoteFieldnames = config.getBoolean(JdbcSourceTaskConfig.QUERY_QUOTE_FIELDNAMES_CONFIG);
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(new BulkTableQuerier(queryMode, tableOrQuery, schemaPattern,
@@ -154,15 +155,15 @@ public class JdbcSourceTask extends SourceTask {
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+                timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+                timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn,
-                offset, timestampDelayInterval, schemaPattern, mapNumerics));
+                offset, timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames));
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -119,6 +119,8 @@ public class JdbcSourceTask extends SourceTask {
         = config.getString(JdbcSourceTaskConfig.SCHEMA_PATTERN_CONFIG);
     String incrementingColumn
         = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+    String incrementingColumnLabel
+        = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_LABEL_CONFIG);
     String timestampColumn
         = config.getString(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
     Long timestampDelayInterval
@@ -156,15 +158,15 @@ public class JdbcSourceTask extends SourceTask {
                 topicPrefix, mapNumerics));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset,
+            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, incrementingColumnLabel, offset,
                 timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames, useMySqlLimit, batchMaxRows));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset,
+            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, null, offset,
                 timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames, useMySqlLimit, batchMaxRows));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn,
+            queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn, incrementingColumnLabel,
                 offset, timestampDelayInterval, schemaPattern, mapNumerics, quoteFieldnames, useMySqlLimit, batchMaxRows));
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -59,6 +59,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
   private String timestampColumn;
   private String incrementingColumn;
+  private String incrementingColumnLabel;
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
   private boolean quoteFieldnames;
@@ -67,6 +68,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
                                            String timestampColumn, String incrementingColumn,
+                                           String incrementingColumnLabel,
                                            Map<String, Object> offsetMap, Long timestampDelay,
                                            String schemaPattern, boolean mapNumerics,
                                            boolean quoteFieldnames,
@@ -74,6 +76,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
     super(mode, name, topicPrefix, schemaPattern, mapNumerics);
     this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
+    this.incrementingColumnLabel = incrementingColumnLabel;
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
     this.quoteFieldnames = quoteFieldnames;
@@ -225,8 +228,15 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
     final Long extractedId;
     if (incrementingColumn != null) {
-      final Schema incrementingColumnSchema = schema.field(incrementingColumn).schema();
-      final Object incrementingColumnValue = record.get(incrementingColumn);
+      final Schema incrementingColumnSchema;
+      final Object incrementingColumnValue;
+      if (incrementingColumnLabel != null && !incrementingColumnLabel.equals("")) {
+        incrementingColumnSchema = schema.field(incrementingColumnLabel).schema();
+        incrementingColumnValue = record.get(incrementingColumnLabel);
+      } else {
+        incrementingColumnSchema = schema.field(incrementingColumn).schema();
+        incrementingColumnValue = record.get(incrementingColumn);
+      }
       if (incrementingColumnValue == null) {
         throw new ConnectException("Null value for incrementing column of type: " + incrementingColumnSchema.type());
       } else if (isIntegralPrimitiveType(incrementingColumnValue)) {
@@ -270,6 +280,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
            ", topicPrefix='" + topicPrefix + '\'' +
            ", timestampColumn='" + timestampColumn + '\'' +
            ", incrementingColumn='" + incrementingColumn + '\'' +
+           ", incrementingColumnLabel='" + incrementingColumnLabel + '\'' +
+           ", useMySqlLimit='" + useMySqlLimit + '\'' +
+           ", batchMaxRows='" + batchMaxRows + '\'' +
            '}';
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -62,17 +62,23 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
   private boolean quoteFieldnames;
+  private boolean useMySqlLimit;
+  private int batchMaxRows;
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
                                            String timestampColumn, String incrementingColumn,
                                            Map<String, Object> offsetMap, Long timestampDelay,
-                                           String schemaPattern, boolean mapNumerics, boolean quoteFieldnames) {
+                                           String schemaPattern, boolean mapNumerics,
+                                           boolean quoteFieldnames,
+                                           boolean useMySqlLimit, int batchMaxRows) {
     super(mode, name, topicPrefix, schemaPattern, mapNumerics);
     this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
     this.quoteFieldnames = quoteFieldnames;
+    this.useMySqlLimit = useMySqlLimit;
+    this.batchMaxRows = batchMaxRows;
   }
 
   @Override
@@ -148,6 +154,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       builder.append(" ASC");
     }
     String queryString = builder.toString();
+    if (useMySqlLimit) queryString = queryString + " LIMIT " + batchMaxRows;
     log.debug("{} prepared SQL query: {}", this, queryString);
     stmt = db.prepareStatement(queryString);
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -61,16 +61,18 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   private String incrementingColumn;
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
+  private boolean quoteFieldnames;
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
                                            String timestampColumn, String incrementingColumn,
                                            Map<String, Object> offsetMap, Long timestampDelay,
-                                           String schemaPattern, boolean mapNumerics) {
+                                           String schemaPattern, boolean mapNumerics, boolean quoteFieldnames) {
     super(mode, name, topicPrefix, schemaPattern, mapNumerics);
     this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
+    this.quoteFieldnames = quoteFieldnames;
   }
 
   @Override
@@ -80,7 +82,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       incrementingColumn = JdbcUtils.getAutoincrementColumn(db, schemaPattern, name);
     }
 
-    String quoteString = JdbcUtils.getIdentifierQuoteString(db);
+    String quoteString;
+    if (quoteFieldnames)
+      quoteString = JdbcUtils.getIdentifierQuoteString(db);
+    else
+      quoteString = "";
 
     StringBuilder builder = new StringBuilder();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -70,7 +70,7 @@ public class TimestampIncrementingTableQuerierTest {
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {
-    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false, true);
+    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false, true, false, 100);
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -70,7 +70,7 @@ public class TimestampIncrementingTableQuerierTest {
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {
-    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false, true, false, 100);
+    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", "", Collections.<String, Object>emptyMap(), 0L, null, false, true, false, 100);
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -70,7 +70,7 @@ public class TimestampIncrementingTableQuerierTest {
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {
-    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false);
+    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false, true);
   }
 
 }


### PR DESCRIPTION
3 Features to make the JDBC connector more valuable for MySQL:

* Allowing to disable field name quoting
* allowing specification of incrementing column label
* using MySQL LIMIT to prevent OOM exceptions 

* Allowing to disable field name quoting:
MySQL does not allow aliases/labels for columns (i.e. 'AS alias' in SELECT) to be used in WHERE clauses. So if you want query mode and you join two tables with identical field names (e.g. 'id') you need to fully qualify the field name with the table name: table.column. But if you quote that it will not work.

* allowing specification of incrementing column label
If you need to fully qualify your incrementing column name ('table.column') then you need an additional alias ('AS alias') for the field name in the Kafka source record, because dots are not allowed.  This alias/label must be the same as in the SELECT statements 'AS alias'.

* using MySQL LIMIT to prevent OOM exceptions 
The MySQL JDBC driver per default fetches all rows. This makes it impossible to use with big tables because you will get OutOfMemoryExceptions