### PR TITLE
CC-1064 Corrected the table name recommender to always close the JDBC connection

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -239,9 +239,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       if (dbUrl == null) {
         throw new ConfigException(CONNECTION_URL_CONFIG + " cannot be null.");
       }
-      Connection db;
-      try {
-        db = DriverManager.getConnection(dbUrl, dbUser, dbPassword == null ? null : dbPassword.value());
+      try (Connection db = DriverManager.getConnection(dbUrl, dbUser, dbPassword == null ? null : dbPassword.value())) {
         return new LinkedList<Object>(JdbcUtils.getTables(db, schemaPattern));
       } catch (SQLException e) {
         throw new ConfigException("Couldn't open connection to " + dbUrl, e);


### PR DESCRIPTION
Used try-with-resources to ensure the JDBC connection is always closed.

This fix is based on the `3.3.x` branch so that it will be included in the next 3.3.x release.