### PR TITLE
CC-1065 Source connector’s recommender uses table type filter and caches results

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -240,9 +240,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       throw new ConfigException("Query mode must be specified");
   }
 
-  /**
-   * A recommender for table names.
-   */
   private static class TableRecommender implements Recommender {
 
     @Override
@@ -269,7 +266,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   }
 
   /**
-   * A recommender for table names that caches the table names for the last configuration and for a specified maximum duration.
+   * A recommender that caches values returned by a delegate, where the cache remains valid for a specified duration
+   * and as long as the configuration remains unchanged.
    */
   static class CachingRecommender implements Recommender {
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -273,7 +273,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
     private final Time time;
     private final long cacheDurationInMillis;
-    private final AtomicReference<CachedTableValues> cachedValues = new AtomicReference<>(new CachedTableValues());
+    private final AtomicReference<CachedRecommenderValues> cachedValues = new AtomicReference<>(new CachedRecommenderValues());
     private final Recommender delegate;
 
     public CachingRecommender(Recommender delegate, Time time, long cacheDurationInMillis) {
@@ -292,7 +292,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       LOG.trace("Fetching table names");
       results = delegate.validValues(name, config);
       LOG.debug("Caching table names: {}", results);
-      cachedValues.set(new CachedTableValues(config, results, time.milliseconds() + cacheDurationInMillis));
+      cachedValues.set(new CachedRecommenderValues(config, results, time.milliseconds() + cacheDurationInMillis));
       return results;
     }
 
@@ -302,14 +302,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     }
   }
 
-  static class CachedTableValues {
+  static class CachedRecommenderValues {
     private final Map<String, Object> lastConfig;
     private final List<Object> results;
     private final long expiryTimeInMillis;
-    public CachedTableValues() {
+    public CachedRecommenderValues() {
       this(null, null, 0L);
     }
-    public CachedTableValues(Map<String, Object> lastConfig, List<Object> results, long expiryTimeInMillis) {
+    public CachedRecommenderValues(Map<String, Object> lastConfig, List<Object> results, long expiryTimeInMillis) {
       this.lastConfig = lastConfig;
       this.results = results;
       this.expiryTimeInMillis = expiryTimeInMillis;

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -186,7 +186,8 @@ public class JdbcSourceConnectorTest {
     connProps.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "SOME_SCHEMA");
 
     PowerMock.mockStatic(JdbcUtils.class);
-    EasyMock.expect(JdbcUtils.getTables(EasyMock.anyObject(Connection.class), EasyMock.eq("SOME_SCHEMA")))
+    EasyMock.expect(JdbcUtils.getTables(EasyMock.anyObject(Connection.class), EasyMock.eq("SOME_SCHEMA"),
+            EasyMock.eq(JdbcUtils.DEFAULT_TABLE_TYPES)))
       .andReturn(new ArrayList<String>())
       .atLeastOnce();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -15,7 +15,7 @@
  **/
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CachedTableValues;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CachedRecommenderValues;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CachingRecommender;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Recommender;
@@ -129,7 +129,7 @@ public class JdbcSourceConnectorConfigTest {
   @Test
   public void testDefaultConstructedCachedTableValuesReturnsNull() {
     Map<String, Object> config = Collections.singletonMap("k", (Object) "v");
-    CachedTableValues cached = new CachedTableValues();
+    CachedRecommenderValues cached = new CachedRecommenderValues();
     assertNull(cached.cachedValue(config, 20L));
   }
 
@@ -139,7 +139,7 @@ public class JdbcSourceConnectorConfigTest {
     Map<String, Object> config2 = Collections.singletonMap("k", (Object) "v");
     List<Object> results = Collections.singletonList((Object) "xyz");
     long expiry = 20L;
-    CachedTableValues cached = new CachedTableValues(config1, results, expiry);
+    CachedRecommenderValues cached = new CachedRecommenderValues(config1, results, expiry);
     assertSame(results, cached.cachedValue(config2, expiry - 1L));
   }
 
@@ -149,7 +149,7 @@ public class JdbcSourceConnectorConfigTest {
     Map<String, Object> config2 = Collections.singletonMap("k", (Object) "v");
     List<Object> results = Collections.singletonList((Object) "xyz");
     long expiry = 20L;
-    CachedTableValues cached = new CachedTableValues(config1, results, expiry);
+    CachedRecommenderValues cached = new CachedRecommenderValues(config1, results, expiry);
     assertNull(cached.cachedValue(config2, expiry));
     assertNull(cached.cachedValue(config2, expiry + 1L));
   }
@@ -160,7 +160,7 @@ public class JdbcSourceConnectorConfigTest {
     Map<String, Object> config2 = Collections.singletonMap("k", (Object) "zed");
     List<Object> results = Collections.singletonList((Object) "xyz");
     long expiry = 20L;
-    CachedTableValues cached = new CachedTableValues(config1, results, expiry);
+    CachedRecommenderValues cached = new CachedRecommenderValues(config1, results, expiry);
     assertNull(cached.cachedValue(config2, expiry - 1L));
     assertNull(cached.cachedValue(config2, expiry));
     assertNull(cached.cachedValue(config2, expiry + 1L));

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.connect.jdbc.source;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcSourceConnectorConfigTest {
+
+  private EmbeddedDerby db;
+  private Map<String, String> props;
+  private ConfigDef configDef;
+  private List<ConfigValue> results;
+
+  @Before
+  public void setup() throws Exception {
+    props = new HashMap<>();
+    configDef = null;
+    results = null;
+
+    db = new EmbeddedDerby();
+    db.createTable("some_table", "id", "INT");
+
+    db.execute("CREATE SCHEMA PUBLIC_SCHEMA");
+    db.execute("SET SCHEMA PUBLIC_SCHEMA");
+    db.createTable("public_table", "id", "INT");
+
+    db.execute("CREATE SCHEMA PRIVATE_SCHEMA");
+    db.execute("SET SCHEMA PRIVATE_SCHEMA");
+    db.createTable("private_table", "id", "INT");
+    db.createTable("another_private_table", "id", "INT");
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    db.close();
+    db.dropDatabase();
+  }
+
+  @Test
+  public void testConfigTableNameRecommenderWithoutSchemaOrTableTypes() throws Exception {
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    configDef = JdbcSourceConnectorConfig.baseConfigDef();
+    results = configDef.validate(props);
+    assertWhitelistRecommendations("some_table", "public_table", "private_table", "another_private_table");
+    assertBlacklistRecommendations("some_table", "public_table", "private_table", "another_private_table");
+  }
+
+  @Test
+  public void testConfigTableNameRecommenderWitSchemaAndWithoutTableTypes() throws Exception {
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "PRIVATE_SCHEMA");
+    configDef = JdbcSourceConnectorConfig.baseConfigDef();
+    results = configDef.validate(props);
+    assertWhitelistRecommendations("private_table", "another_private_table");
+    assertBlacklistRecommendations("private_table", "another_private_table");
+  }
+
+  @Test
+  public void testConfigTableNameRecommenderWithSchemaAndTableTypes() throws Exception {
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "PRIVATE_SCHEMA");
+    props.put(JdbcSourceConnectorConfig.TABLE_TYPE_CONFIG, "VIEW");
+    configDef = JdbcSourceConnectorConfig.baseConfigDef();
+    results = configDef.validate(props);
+    assertWhitelistRecommendations();
+    assertBlacklistRecommendations();
+  }
+
+  protected <T> void assertContains(Collection<T> actual, T... expected) {
+    assertEquals(expected.length, actual.size());
+    for (T e : expected) {
+      assertTrue(actual.contains(e));
+    }
+  }
+
+  protected ConfigValue namedValue(List<ConfigValue> values, String name) {
+    for (ConfigValue value : values) {
+      if (value.name().equals(name)) return value;
+    }
+    return null;
+  }
+
+  protected <T> void assertRecommendedValues(ConfigValue value, T... recommendedValues) {
+    assertContains(value.recommendedValues(), recommendedValues);
+  }
+
+  protected <T> void assertWhitelistRecommendations(T... recommendedValues) {
+    assertContains(namedValue(results, JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG).recommendedValues(), recommendedValues);
+  }
+
+  protected <T> void assertBlacklistRecommendations(T... recommendedValues) {
+    assertContains(namedValue(results, JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG).recommendedValues(), recommendedValues);
+  }
+}


### PR DESCRIPTION
The JDBC source connector’s recommender for table names can take a long time when the database has a large number of tables. And, the recommender is used for both the table whitelist and blacklist properties.

This PR makes a number of improvements. First, the recommender now uses the table types to reduce the number of results that must be processed when determining the names of the available tables. This may help to reduce the number of tables returned by the recommender if a different set of tables is required. For example, if only views are to be used, then the table types property can be set to `VIEW` and the recommender will correctly return only the available views.

Secondly and more importantly, the table name recommender used for both the whitelist and blacklist properties will now cache results so that the list of table names need only be performed once. To accomplish this, the class no longer uses a static recommender but instead creates a new caching recommender each time a ConfigDef instance is returned by the connector. This change alone will effectively halve the time required for the recommender to be used during configuration validation.