### PR TITLE
Update for issue #211 - get current timestamp on all DB2 versions

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -243,7 +243,7 @@ public class JdbcUtils {
     String dbProduct = conn.getMetaData().getDatabaseProductName();
     if ("Oracle".equals(dbProduct)) {
       query = "select CURRENT_TIMESTAMP from dual";
-    } else if ("Apache Derby".equals(dbProduct) || "DB2 UDB for AS/400".equals(dbProduct)) {
+    } else if ("Apache Derby".equals(dbProduct) || dbProduct.startsWith("DB2")) {
       query = "values(CURRENT_TIMESTAMP)";
     } else {
       query = "select CURRENT_TIMESTAMP;";


### PR DESCRIPTION
Target all product names starting with "DB2" regardless of platform.