### PR TITLE
Log out actual sql exceptions (fix for #291)

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -74,14 +74,18 @@ public class JdbcSinkTask extends SinkTask {
           remainingRetries,
           sqle
       );
+      String sqleAllMessages = "";
+      for (Throwable e : sqle) {
+        sqleAllMessages += e + System.lineSeparator();
+      }
       if (remainingRetries == 0) {
-        throw new ConnectException(sqle);
+        throw new ConnectException(sqleAllMessages);
       } else {
         writer.closeQuietly();
         initWriter();
         remainingRetries--;
         context.timeout(config.retryBackoffMs);
-        throw new RetriableException(sqle);
+        throw new RetriableException(sqleAllMessages);
       }
     }
     remainingRetries = config.maxRetries;

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -79,13 +79,13 @@ public class JdbcSinkTask extends SinkTask {
         sqleAllMessages += e + System.lineSeparator();
       }
       if (remainingRetries == 0) {
-        throw new ConnectException(sqleAllMessages);
+        throw new ConnectException(new SQLException(sqleAllMessages));
       } else {
         writer.closeQuietly();
         initWriter();
         remainingRetries--;
         context.timeout(config.retryBackoffMs);
-        throw new RetriableException(sqleAllMessages);
+        throw new RetriableException(new SQLException(sqleAllMessages));
       }
     }
     remainingRetries = config.maxRetries;


### PR DESCRIPTION
The original forked repo for #291 was deleted by accident so I cannot commit to that PR anymore. This PR is the final fix.

======== Original PR Note ========

Currently when there's error from db side, the error log shows as follow:
```
java.sql.BatchUpdateException: Batch entry 0 `INSERT INTO ....` was aborted.  Call getNextException to see the cause.
```

Instead, it should show the actual error that retrieved from `getNextException`.

This PR add that error message to log.