### PR TITLE
CC-1266: Corrected build by changing PowerMock uses

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -24,7 +24,12 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -37,13 +42,17 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Recommender.class})
+@PowerMockIgnore("javax.management.*")
 public class JdbcSourceConnectorConfigTest {
 
   private EmbeddedDerby db;
   private Map<String, String> props;
   private ConfigDef configDef;
   private List<ConfigValue> results;
-  private Recommender mockRecommender = PowerMock.createMock(Recommender.class);
+  @Mock
+  private Recommender mockRecommender;
   private MockTime time = new MockTime();
 
   @Before

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -19,9 +19,11 @@ package io.confluent.connect.jdbc.source;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.easymock.EasyMock;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -41,6 +43,12 @@ import static org.junit.Assert.assertEquals;
 @PowerMockIgnore("javax.management.*")
 public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
+  @Mock
+  private CachedConnectionProvider mockCachedConnectionProvider;
+
+  @Mock
+  private Connection conn;
+
   @Test(expected = ConnectException.class)
   public void testMissingParentConfig() {
     Map<String, String> props = singleTableConfig();
@@ -58,12 +66,10 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   @Test
   public void testStartStop() throws Exception {
     // Minimal start/stop functionality
-    CachedConnectionProvider mockCachedConnectionProvider = PowerMock.createMock(CachedConnectionProvider.class);
     PowerMock.expectNew(CachedConnectionProvider.class, db.getUrl(), null, null,
       JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT, JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT).andReturn(mockCachedConnectionProvider);
 
     // Should request a connection, then should close it on stop()
-    Connection conn = PowerMock.createMock(Connection.class);
     EasyMock.expect(mockCachedConnectionProvider.getValidConnection()).andReturn(conn);
 
     // Since we're just testing start/stop, we don't worry about the value here but need to stub

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -23,6 +23,7 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.easymock.annotation.Mock;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -63,15 +64,17 @@ public class JdbcSourceTaskTestBase {
   protected static final String TOPIC_PREFIX = "test-";
 
   protected Time time;
+  @Mock
   protected SourceTaskContext taskContext;
   protected JdbcSourceTask task;
   protected EmbeddedDerby db;
+  @Mock
+  private OffsetStorageReader reader;
 
   @Before
   public void setup() throws Exception {
     time = new MockTime();
     task = new JdbcSourceTask(time);
-    taskContext = PowerMock.createMock(SourceTaskContext.class);
     db = new EmbeddedDerby();
   }
 
@@ -101,7 +104,6 @@ public class JdbcSourceTaskTestBase {
   }
 
   protected <T> void expectInitialize(Collection<Map<String, T>> partitions, Map<Map<String, T>, Map<String, Object>> offsets) {
-    OffsetStorageReader reader = PowerMock.createMock(OffsetStorageReader.class);
     EasyMock.expect(taskContext.offsetStorageReader()).andReturn(reader);
     EasyMock.expect(reader.offsets(EasyMock.eq(partitions))).andReturn(offsets);
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -21,7 +21,11 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
@@ -32,11 +36,15 @@ import java.util.List;
 import java.util.Map;
 
 import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 
 // Tests of polling that return data updates, i.e. verifies the different behaviors for getting
 // incremental data updates from the database
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({JdbcSourceTask.class})
+@PowerMockIgnore("javax.management.*")
 public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   private static final Map<String, String> QUERY_SOURCE_PARTITION
       = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,


### PR DESCRIPTION
A [recent change to the Kafka dependencies](https://github.com/apache/kafka/pull/3881) included an upgrade of the PowerMock library to 2.0.0-beta5 for JDK9 reasons, but this appears to have broken several tests in this JDBC connector repository.

Apparently, with the new 2.0.0-beta5 version it is better to use `@Mock` annotations on member fields rather than to manually create the (local or member field) mock instances via `PowerMock.createMock(MyClass.class)`. Unfortunately this requires running the concrete test classes via `@RunWith(PowerMockRunner.class)` and several other class-level annotations, which is more verbose.