### PR TITLE
CC-45: Added support for multiple timestamp columns

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -360,7 +360,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         MODE_DEPENDENTS_RECOMMENDER
     ).define(
         TIMESTAMP_COLUMN_NAME_CONFIG,
-        Type.STRING,
+        Type.LIST,
         TIMESTAMP_COLUMN_NAME_DEFAULT,
         Importance.MEDIUM,
         TIMESTAMP_COLUMN_NAME_DOC,

--- a/src/main/java/io/confluent/connect/jdbc/source/MultiColumnTimestampHelper.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/MultiColumnTimestampHelper.java
@@ -1,0 +1,69 @@
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
+import io.confluent.connect.jdbc.util.StringUtils;
+import java.sql.Timestamp;
+import java.util.List;
+import org.apache.kafka.connect.data.Struct;
+
+public class MultiColumnTimestampHelper implements TimestampHelper {
+
+  private List<String> timestampColumns;
+
+  public MultiColumnTimestampHelper(List<String> timestampColumns) {
+    this.timestampColumns = timestampColumns;
+  }
+
+  @Override
+  public void incrementingWhereClauseBuilder(StringBuilder builder,
+      String incrementingColumn, String quoteString) {
+    List<String> quotedList = JdbcUtils.quoteList(timestampColumns, quoteString);
+    String quotedTimestampColumn = StringUtils.join(quotedList, ",");
+    builder.append(" WHERE COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append(") < ? AND ((COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append(") = ? AND ");
+    builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
+    builder.append(" > ?");
+    builder.append(") OR COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append(") > ?)");
+    builder.append(" ORDER BY COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append("),");
+    builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
+    builder.append(" ASC");
+  }
+
+  @Override
+  public void buildWhereClause(StringBuilder builder, String quoteString) {
+    List<String> quotedList = JdbcUtils.quoteList(timestampColumns, quoteString);
+    String quotedTimestampColumn = StringUtils.join(quotedList, ",");
+    builder.append(" WHERE COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append(") > ? AND COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append(") < ? ORDER BY COALESCE(");
+    builder.append(quotedTimestampColumn);
+    builder.append(") ASC");
+  }
+
+  @Override
+  public Timestamp extractOffset(Struct record) {
+    for (String timestampColumn: timestampColumns) {
+      Timestamp timestampOffset = (Timestamp) record.getWithoutDefault(timestampColumn);
+      if (timestampOffset != null) {
+        return timestampOffset;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "MultiColumnTimestampHelper{" +
+        "timestampColumns=" + timestampColumns +
+        '}';
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/SingleColumnTimestampHelper.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/SingleColumnTimestampHelper.java
@@ -1,0 +1,57 @@
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.util.JdbcUtils;
+import java.sql.Timestamp;
+import org.apache.kafka.connect.data.Struct;
+
+public class SingleColumnTimestampHelper implements TimestampHelper {
+
+  private String timestampColumn;
+
+  public SingleColumnTimestampHelper(String timestampColumn) {
+    this.timestampColumn = timestampColumn;
+  }
+
+  @Override
+  public void incrementingWhereClauseBuilder(StringBuilder builder, String incrementingColumn, String quoteString) {
+    builder.append(" WHERE ");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(" < ? AND ((");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(" = ? AND ");
+    builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
+    builder.append(" > ?");
+    builder.append(") OR ");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(" > ?)");
+    builder.append(" ORDER BY ");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(",");
+    builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
+    builder.append(" ASC");
+  }
+
+  @Override
+  public void buildWhereClause(StringBuilder builder, String quoteString) {
+    builder.append(" WHERE ");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(" > ? AND ");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(" < ? ORDER BY ");
+    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
+    builder.append(" ASC");
+  }
+
+  @Override
+  public Timestamp extractOffset(Struct record) {
+    return (Timestamp) record.get(timestampColumn);
+  }
+
+  @Override
+  public String toString() {
+    return "SingleColumnTimestampHelper{" +
+        "timestampColumn='" + timestampColumn + '\'' +
+        '}';
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampHelper.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampHelper.java
@@ -1,0 +1,14 @@
+package io.confluent.connect.jdbc.source;
+
+import java.sql.Timestamp;
+import org.apache.kafka.connect.data.Struct;
+
+public interface TimestampHelper {
+
+  public void incrementingWhereClauseBuilder(StringBuilder builder, String incrementingColumn, String quoteString);
+
+  public void buildWhereClause(StringBuilder builder, String quoteString);
+
+  public Timestamp extractOffset(Struct record);
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.List;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -59,20 +60,20 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
   private static final BigDecimal LONG_MAX_VALUE_AS_BIGDEC = new BigDecimal(Long.MAX_VALUE);
 
-  private String timestampColumn;
   private String incrementingColumn;
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
+  private TimestampHelper timestampHelper;
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
-                                           String timestampColumn, String incrementingColumn,
+                                           TimestampHelper timestampHelper, String incrementingColumn,
                                            Map<String, Object> offsetMap, Long timestampDelay,
                                            String schemaPattern, boolean mapNumerics) {
     super(mode, name, topicPrefix, schemaPattern, mapNumerics);
-    this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
+    this.timestampHelper = timestampHelper;
   }
 
   @Override
@@ -98,11 +99,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
         throw new ConnectException("Unknown mode encountered when preparing query: " + mode);
     }
 
-    if (incrementingColumn != null && timestampColumn != null) {
+    if (incrementingColumn != null && timestampHelper != null) {
       timestampIncrementingWhereClause(builder, quoteString);
     } else if (incrementingColumn != null) {
       incrementingWhereClause(builder, quoteString);
-    } else if (timestampColumn != null) {
+    } else if (timestampHelper != null) {
       timestampWhereClause(builder, quoteString);
     }
     String queryString = builder.toString();
@@ -124,21 +125,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
     //  timestamp 1235, id 22
     //  timestamp 1236, id 23
     // We should capture both id = 22 (an update) and id = 23 (a new row)
-    builder.append(" WHERE ");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(" < ? AND ((");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(" = ? AND ");
-    builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
-    builder.append(" > ?");
-    builder.append(") OR ");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(" > ?)");
-    builder.append(" ORDER BY ");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(",");
-    builder.append(JdbcUtils.quoteString(incrementingColumn, quoteString));
-    builder.append(" ASC");
+    timestampHelper.incrementingWhereClauseBuilder(builder, incrementingColumn, quoteString);
   }
 
   private void incrementingWhereClause(StringBuilder builder, String quoteString) {
@@ -151,18 +138,12 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   }
 
   private void timestampWhereClause(StringBuilder builder, String quoteString) {
-    builder.append(" WHERE ");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(" > ? AND ");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(" < ? ORDER BY ");
-    builder.append(JdbcUtils.quoteString(timestampColumn, quoteString));
-    builder.append(" ASC");
+    timestampHelper.buildWhereClause(builder, quoteString);
   }
 
   @Override
   protected ResultSet executeQuery() throws SQLException {
-    if (incrementingColumn != null && timestampColumn != null) {
+    if (incrementingColumn != null && timestampHelper != null) {
       Timestamp tsOffset = offset.getTimestampOffset();
       Long incOffset = offset.getIncrementingOffset();
       final long currentDbTime = JdbcUtils.getCurrentTimeOnDB(
@@ -185,7 +166,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       Long incOffset = offset.getIncrementingOffset();
       stmt.setLong(1, incOffset);
       log.debug("Executing prepared statement with incrementing value = {}", incOffset);
-    } else if (timestampColumn != null) {
+    } else if (timestampHelper != null) {
       Timestamp tsOffset = offset.getTimestampOffset();
       final long currentDbTime = JdbcUtils.getCurrentTimeOnDB(
           stmt.getConnection(),
@@ -227,8 +208,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   // Visible for testing
   TimestampIncrementingOffset extractOffset(Schema schema, Struct record) {
     final Timestamp extractedTimestamp;
-    if (timestampColumn != null) {
-      extractedTimestamp = (Timestamp) record.get(timestampColumn);
+    if (timestampHelper != null) {
+      extractedTimestamp = timestampHelper.extractOffset(record);
       Timestamp timestampOffset = offset.getTimestampOffset();
       assert timestampOffset != null && timestampOffset.compareTo(extractedTimestamp) <= 0;
     } else {
@@ -259,7 +240,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       Long incrementingOffset = offset.getIncrementingOffset();
       assert incrementingOffset == -1L
              || extractedId > incrementingOffset
-             || timestampColumn != null;
+             || timestampHelper != null;
     } else {
       extractedId = null;
     }
@@ -289,12 +270,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
 
   @Override
   public String toString() {
-    return "TimestampIncrementingTableQuerier{"
-           + "name='" + name + '\''
-           + ", query='" + query + '\''
-           + ", topicPrefix='" + topicPrefix + '\''
-           + ", timestampColumn='" + timestampColumn + '\''
-           + ", incrementingColumn='" + incrementingColumn + '\''
-           + '}';
+    return "TimestampIncrementingTableQuerier{" +
+        "incrementingColumn='" + incrementingColumn + '\'' +
+        ", timestampDelay=" + timestampDelay +
+        ", offset=" + offset +
+        ", timestampHelper=" + timestampHelper +
+        '}';
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -202,6 +202,20 @@ public class JdbcUtils {
     return false;
   }
 
+  public static boolean areAllColumnsNullable(
+      Connection conn,
+      String schemaPattern,
+      String table,
+      List<String> columns
+  ) throws SQLException {
+    for (String column: columns) {
+      if (!isColumnNullable(conn, schemaPattern, table, column)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Get the string used for quoting identifiers in this database's SQL dialect.
    * @param connection the database connection
@@ -222,6 +236,14 @@ public class JdbcUtils {
    */
   public static String quoteString(String orig, String quote) {
     return quote + orig + quote;
+  }
+
+  public static List<String> quoteList(List<String> origs, String quote) {
+    List<String> quotedOrigs = new ArrayList<>();
+    for (String orig: origs) {
+      quotedOrigs.add(quoteString(orig, quote));
+    }
+    return quotedOrigs;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
@@ -140,6 +140,19 @@ public class JdbcUtilsTest {
   }
 
   @Test
+  public void testAreColumnsNullable() throws Exception {
+    db.createTable("tstest", "ts", "TIMESTAMP NOT NULL", "tsdefault", "TIMESTAMP",
+        "tsnull", "TIMESTAMP DEFAULT NULL");
+    assertFalse(JdbcUtils.areAllColumnsNullable(db.getConnection(), null,
+        "tstest", Arrays.asList("ts", "tsdefault", "tsnull")));
+
+    db.createTable("tstestnull", "tsdefault", "TIMESTAMP",
+        "tsnull", "TIMESTAMP");
+    assertTrue(JdbcUtils.areAllColumnsNullable(db.getConnection(), null,
+        "tstestnull", Arrays.asList("tsdefault", "tsnull")));
+  }
+
+  @Test
   public void testIsColumnNullable() throws Exception {
     db.createTable("test", "id", "INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY", "bar", "INTEGER");
     assertFalse(JdbcUtils.isColumnNullable(db.getConnection(), null, "test", "id"));


### PR DESCRIPTION
With this PR, users can specify multiple timestamp columns to address the scenario where they may have "modified" and "created" timestamp columns. They will need to list the column names in the order of priority. 
For e.g.
modified, created - will look at modified column first and only if that column is null, it will proceed to created

There are checks in place to ensure that **_at least_** one of the timestamp column is not null.

Finally, added tests to validate the changes made. 