### PR TITLE
Pull fixed tableNamePattern to configuration

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -110,6 +110,7 @@ public class JdbcSourceConnector extends SourceConnector {
     }
     String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
     String schemaPattern = config.getString(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG);
+    String tableNamePattern = config.getString(JdbcSourceConnectorConfig.TABLE_NAME_PATTERN_CONFIG);
     if (!query.isEmpty()) {
       if (whitelistSet != null || blacklistSet != null) {
         throw new ConnectException(JdbcSourceConnectorConfig.QUERY_CONFIG + " may not be combined"
@@ -124,6 +125,7 @@ public class JdbcSourceConnector extends SourceConnector {
         cachedConnectionProvider,
         context,
         schemaPattern,
+        tableNamePattern,
         tablePollMs,
         whitelistSet,
         blacklistSet,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -155,6 +155,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "metadata would be fetched, regardless their schema.";
   private static final String SCHEMA_PATTERN_DISPLAY = "Schema pattern";
 
+  public static final String TABLE_NAME_PATTERN_CONFIG = "table.name.pattern";
+  private static final String TABLE_NAME_PATTERN_DOC =
+      "Table name pattern to fetch tables metadata from the database:\n"
+      + "  * % retrieves all"
+      + "  * %pattern% retrieves based on pattern.";
+  private static final String TABLE_NAME_PATTERN_DISPLAY = "Table name pattern";
+  private static final String TABLE_NAME_PATTERN_DEFAULT = "%";
+
   public static final String QUERY_CONFIG = "query";
   private static final String QUERY_DOC =
       "If specified, the query to perform to select new or updated rows. Use this setting if you "
@@ -312,6 +320,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         6,
         Width.SHORT,
         SCHEMA_PATTERN_DISPLAY
+    ).define(
+        TABLE_NAME_PATTERN_CONFIG,
+        Type.STRING,
+        TABLE_NAME_PATTERN_DEFAULT,
+        Importance.MEDIUM,
+        TABLE_NAME_PATTERN_DOC,
+        DATABASE_GROUP,
+        6,
+        Width.SHORT,
+        TABLE_NAME_PATTERN_DISPLAY
     ).define(
         NUMERIC_PRECISION_MAPPING_CONFIG,
         Type.BOOLEAN,
@@ -472,6 +490,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       String dbUser = (String) config.get(CONNECTION_USER_CONFIG);
       Password dbPassword = (Password) config.get(CONNECTION_PASSWORD_CONFIG);
       String schemaPattern = (String) config.get(JdbcSourceTaskConfig.SCHEMA_PATTERN_CONFIG);
+      String tableNamePattern = (String) config.get(JdbcSourceTaskConfig.TABLE_NAME_PATTERN_CONFIG);
       Set<String> tableTypes = new HashSet<>(
           (List<String>) config.get(JdbcSourceTaskConfig.TABLE_TYPE_CONFIG)
       );
@@ -480,7 +499,9 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       }
       String dbPasswordStr = dbPassword == null ? null : dbPassword.value();
       try (Connection db = DriverManager.getConnection(dbUrl, dbUser, dbPasswordStr)) {
-        return new LinkedList<Object>(JdbcUtils.getTables(db, schemaPattern, tableTypes));
+        return new LinkedList<Object>(
+                JdbcUtils.getTables(db, schemaPattern, tableNamePattern, tableTypes)
+        );
       } catch (SQLException e) {
         throw new ConfigException("Couldn't open connection to " + dbUrl, e);
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -41,6 +41,7 @@ public class TableMonitorThread extends Thread {
 
   private final CachedConnectionProvider cachedConnectionProvider;
   private final String schemaPattern;
+  private final String tableNamePattern;
   private final ConnectorContext context;
   private final CountDownLatch shutdownLatch;
   private final long pollMs;
@@ -53,6 +54,7 @@ public class TableMonitorThread extends Thread {
       CachedConnectionProvider cachedConnectionProvider,
       ConnectorContext context,
       String schemaPattern,
+      String tableNamePattern,
       long pollMs,
       Set<String> whitelist,
       Set<String> blacklist,
@@ -60,6 +62,7 @@ public class TableMonitorThread extends Thread {
   ) {
     this.cachedConnectionProvider = cachedConnectionProvider;
     this.schemaPattern = schemaPattern;
+    this.tableNamePattern = tableNamePattern;
     this.context = context;
     this.shutdownLatch = new CountDownLatch(1);
     this.pollMs = pollMs;
@@ -121,6 +124,7 @@ public class TableMonitorThread extends Thread {
       tables = JdbcUtils.getTables(
           cachedConnectionProvider.getValidConnection(),
           schemaPattern,
+          tableNamePattern,
           tableTypes
       );
       log.debug("Got the following tables: " + Arrays.toString(tables.toArray()));

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -66,8 +66,12 @@ public class JdbcUtils {
    * @return a list of tables; never null
    * @throws SQLException if there is an error with the database connection
    */
-  public static List<String> getTables(Connection conn, String schemaPattern) throws SQLException {
-    return getTables(conn, schemaPattern, DEFAULT_TABLE_TYPES);
+  public static List<String> getTables(
+      Connection conn,
+      String schemaPattern,
+      String tableNamePattern
+  ) throws SQLException {
+    return getTables(conn, schemaPattern, tableNamePattern, DEFAULT_TABLE_TYPES);
   }
 
   /**
@@ -81,12 +85,13 @@ public class JdbcUtils {
   public static List<String> getTables(
       Connection conn,
       String schemaPattern,
+      String tableNamePattern,
       Set<String> types
   ) throws SQLException {
     DatabaseMetaData metadata = conn.getMetaData();
     String[] tableTypes = types.isEmpty() ? null : getActualTableTypes(metadata, types);
 
-    try (ResultSet rs = metadata.getTables(null, schemaPattern, "%", tableTypes)) {
+    try (ResultSet rs = metadata.getTables(null, schemaPattern, tableNamePattern, tableTypes)) {
       List<String> tableNames = new ArrayList<>();
       while (rs.next()) {
         String colName = rs.getString(GET_TABLES_NAME_COLUMN);

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -62,6 +62,7 @@ public class JdbcSourceConnectorTest {
     connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
     connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
+    connProps.put(JdbcSourceConnectorConfig.TABLE_NAME_PATTERN_CONFIG, "%");
   }
 
   @After
@@ -186,9 +187,13 @@ public class JdbcSourceConnectorTest {
   @Test
   public void testSchemaPatternUsedForConfigValidation() throws Exception {
     connProps.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "SOME_SCHEMA");
+    connProps.put(JdbcSourceConnectorConfig.TABLE_NAME_PATTERN_CONFIG, "%");
 
     PowerMock.mockStatic(JdbcUtils.class);
-    EasyMock.expect(JdbcUtils.getTables(EasyMock.anyObject(Connection.class), EasyMock.eq("SOME_SCHEMA"),
+    EasyMock.expect(JdbcUtils.getTables(
+            EasyMock.anyObject(Connection.class),
+            EasyMock.eq("SOME_SCHEMA"),
+            EasyMock.eq("%"),
             EasyMock.eq(JdbcUtils.DEFAULT_TABLE_TYPES)))
       .andReturn(new ArrayList<String>())
       .atLeastOnce();

--- a/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/SqliteHelperTest.java
@@ -70,7 +70,7 @@ public class SqliteHelperTest {
     sqliteHelper.createTable(createNonPkTable);
 
     final Map<String, DbTable> tables = new HashMap<>();
-    for (String tableName : JdbcUtils.getTables(sqliteHelper.connection, null)) {
+    for (String tableName : JdbcUtils.getTables(sqliteHelper.connection, null, "%")) {
       tables.put(tableName, DbMetadataQueries.getTableMetadata(sqliteHelper.connection, tableName));
     }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcUtilsTest.java
@@ -49,27 +49,27 @@ public class JdbcUtilsTest {
 
   @Test
   public void testGetTablesEmpty() throws Exception {
-    assertEquals(Collections.emptyList(), JdbcUtils.getTables(db.getConnection(), null));
+    assertEquals(Collections.emptyList(), JdbcUtils.getTables(db.getConnection(), null, "%"));
   }
 
   @Test
   public void testGetTablesSingle() throws Exception {
     db.createTable("test", "id", "INT");
-    assertEquals(Arrays.asList("test"), JdbcUtils.getTables(db.getConnection(), null));
+    assertEquals(Arrays.asList("test"), JdbcUtils.getTables(db.getConnection(), null, "%"));
   }
 
   @Test
   public void testFindTablesWithKnownTableType() throws Exception {
     db.createTable("test", "id", "INT");
     Set<String> types = Collections.singleton("TABLE");
-    assertEquals(Arrays.asList("test"), JdbcUtils.getTables(db.getConnection(), null, types));
+    assertEquals(Arrays.asList("test"), JdbcUtils.getTables(db.getConnection(), null, "%", types));
   }
 
   @Test
   public void testNotFindTablesWithUnknownTableType() throws Exception {
     db.createTable("test", "id", "INT");
     Set<String> types = Collections.singleton("view");
-    assertEquals(Arrays.asList(), JdbcUtils.getTables(db.getConnection(), null, types));
+    assertEquals(Arrays.asList(), JdbcUtils.getTables(db.getConnection(), null, "%", types));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class JdbcUtilsTest {
     db.createTable("zab", "id", "INT");
     assertEquals(
         new HashSet<>(Arrays.asList("test", "foo", "zab")),
-        new HashSet<>(JdbcUtils.getTables(db.getConnection(), null)));
+        new HashSet<>(JdbcUtils.getTables(db.getConnection(), null, "%")));
   }
 
   @Test
@@ -99,22 +99,22 @@ public class JdbcUtilsTest {
 
     assertEquals(
       new HashSet<>(Arrays.asList("public_table")),
-      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PUBLIC_SCHEMA")));
+      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PUBLIC_SCHEMA", "%")));
     assertEquals(
       new HashSet<>(Arrays.asList("private_table", "another_private_table")),
-      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PRIVATE_SCHEMA")));
+      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PRIVATE_SCHEMA", "%")));
     assertEquals(
       new HashSet<>(Arrays.asList("some_table", "public_table", "private_table", "another_private_table")),
-      new HashSet<>(JdbcUtils.getTables(db.getConnection(), null)));
+      new HashSet<>(JdbcUtils.getTables(db.getConnection(), null, "%")));
     assertEquals(
       new HashSet<>(Arrays.asList("public_table")),
-      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PUBLIC_SCHEMA", types)));
+      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PUBLIC_SCHEMA", "%", types)));
     assertEquals(
       new HashSet<>(Arrays.asList("private_table", "another_private_table")),
-      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PRIVATE_SCHEMA", types)));
+      new HashSet<>(JdbcUtils.getTables(db.getConnection(), "PRIVATE_SCHEMA", "%", types)));
     assertEquals(
       new HashSet<>(Arrays.asList("some_table", "public_table", "private_table", "another_private_table")),
-      new HashSet<>(JdbcUtils.getTables(db.getConnection(), null, types)));
+      new HashSet<>(JdbcUtils.getTables(db.getConnection(), null, "%", types)));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
@@ -80,9 +80,9 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testSingleLookup() throws Exception {
-    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, "%", POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -101,10 +101,10 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testWhitelist() throws Exception {
-    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, POLL_INTERVAL,
+    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, "%", POLL_INTERVAL,
                                                 new HashSet<>(Arrays.asList("foo", "bar")), null, DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -123,10 +123,10 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testBlacklist() throws Exception {
-    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, POLL_INTERVAL,
+    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, "%", POLL_INTERVAL,
                                                 null, new HashSet<>(Arrays.asList("bar", "baz")), DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -145,11 +145,11 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testReconfigOnUpdate() throws Exception {
-    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, "%", POLL_INTERVAL, null, null, DEFAULT_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andReturn(FIRST_TOPIC_LIST);
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andReturn(FIRST_TOPIC_LIST);
     // Returning same list should not change results
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         assertEquals(FIRST_TOPIC_LIST, tableMonitorThread.tables());
@@ -157,11 +157,11 @@ public class TableMonitorThreadTest {
       }
     });
     // Changing the result should trigger a task reconfiguration
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andReturn(SECOND_TOPIC_LIST);
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andReturn(SECOND_TOPIC_LIST);
     context.requestTaskReconfiguration();
     PowerMock.expectLastCall();
     // Changing again should result in another update
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", DEFAULT_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         assertEquals(SECOND_TOPIC_LIST, tableMonitorThread.tables());
@@ -183,9 +183,9 @@ public class TableMonitorThreadTest {
 
   @Test
   public void testTableType() throws Exception {
-    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, POLL_INTERVAL, null, null, VIEW_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(cachedConnectionProvider, context, null, "%", POLL_INTERVAL, null, null, VIEW_TABLE_TYPES);
 
-    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, VIEW_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
+    EasyMock.expect(JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), null, "%", VIEW_TABLE_TYPES)).andAnswer(new IAnswer<List<String>>() {
       @Override
       public List<String> answer() throws Throwable {
         tableMonitorThread.shutdown();
@@ -207,7 +207,7 @@ public class TableMonitorThreadTest {
   @Test
   public void testInvalidConnection() throws Exception {
     CachedConnectionProvider provider = EasyMock.createMock(CachedConnectionProvider.class);
-    tableMonitorThread = new TableMonitorThread(provider, context, null, POLL_INTERVAL, null, null, VIEW_TABLE_TYPES);
+    tableMonitorThread = new TableMonitorThread(provider, context, null, "%", POLL_INTERVAL, null, null, VIEW_TABLE_TYPES);
 
     EasyMock.expect(provider.getValidConnection()).andAnswer(new IAnswer<Connection>() {
       @Override


### PR DESCRIPTION
`TableMonitorThread` calling the `getTables` method is causing dead lock on our database.
The instance of DB contains thousands o tables in one schema with many DML operations. 
Once getTables is called the MS JDBC driver calls sp_tables which ends in deadlock.

This pull request pulls `TableNamePattern` (which was originally flexed to `'%'`) to configuration to narrow the query. 