### PR TITLE
Fix duplicate messages due to incorrect table metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Documentation for this connector can be found [here](http://docs.confluent.io/cu
 To build a development version you'll need a recent version of Kafka. You can build
 kafka-connect-jdbc with Maven using the standard lifecycle phases.
 
+# Testing
+
+You'll need Derby installed.
+
+`mvn test` will run all tests.
 
 # Contribute
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,27 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
+        </repository>
+        <repository>
+            <id>confluent-snapshots</id>
+            <url>https://s3-us-west-2.amazonaws.com/confluent-snapshots/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluent</id>
+            <url>http://packages.confluent.io/maven/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>confluent-snapshots</id>
+            <url>https://s3-us-west-2.amazonaws.com/confluent-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -86,7 +86,10 @@ public class JdbcUtils {
     DatabaseMetaData metadata = conn.getMetaData();
     String[] tableTypes = types.isEmpty() ? null : getActualTableTypes(metadata, types);
 
-    try (ResultSet rs = metadata.getTables(null, schemaPattern, "%", tableTypes)) {
+    // Respect the catalog passed in the connection string, if available.
+    String catalog = conn.getCatalog() == "" ? null : conn.getCatalog();
+
+    try (ResultSet rs = metadata.getTables(catalog, schemaPattern, "%", tableTypes)) {
       List<String> tableNames = new ArrayList<>();
       while (rs.next()) {
         String colName = rs.getString(GET_TABLES_NAME_COLUMN);


### PR DESCRIPTION
## Summary / TL;DR

Tables in separate [catalogs](https://stackoverflow.com/questions/7022755/whats-the-difference-between-a-catalog-and-a-schema-in-a-relational-database) are being picked up by table metadata calls despite the database connection string being explicit about using a particular catalog. This results in duplicate tables being registered with the connector should that table name exist in other catalogs and thus duplicate messages when running the connector. 

## Details

Using the JDBC source connector, we noticed that for every table write, we saw three (3) identical messages arrive into Kafka. 

JDBC source connector configuration: 
```
{
      "name": "mysql-jdbc-esc",
      "config": {
        "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
        "connection.url": "jdbc:mysql://mysql:3306/zendesk_development_shard_1?user=admin&password=123456",
        "table.whitelist":"classic_kafka_messages",
        "table.types": "TABLE",
        "topic.prefix": "esc_",
        "mode": "timestamp+incrementing",
        "incrementing.column.name": "id",
        "timestamp.column.name": "created_at",
        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
        "poll.interval.ms": 1000
      }
    }
``` 

On closer inspection with a `DEBUG` log level it was clear that JDBC source connector tasks were being created with a set of duplicate tables.

```
[2018-01-05 18:32:17,391] INFO JdbcSourceTaskConfig values:
batch.max.rows = 100 
connection.password = null 
connection.url = jdbc:mysql://mysql:3306/zendesk_development_shard_1?user=admin&password=123456 
connection.user = null 
incrementing.column.name = id 
mode = timestamp+incrementing 
numeric.precision.mapping = false 
poll.interval.ms = 1000 
query = 
schema.pattern = null 
table.blacklist = [] 
table.poll.interval.ms = 60000 
table.types = [TABLE] 
table.whitelist = [classic_kafka_messages] 
tables = [classic_kafka_messages, classic_kafka_messages, classic_kafka_messages] 
timestamp.column.name = created_at 
timestamp.delay.interval.ms = 0 
topic.prefix = esc_ 
validate.non.null = true 
(io.confluent.connect.jdbc.source.JdbcSourceTaskConfig) 
```

In particular notice the line: 

```
tables = [classic_kafka_messages, classic_kafka_messages, classic_kafka_messages]
```

I created a sample project to debug this, and I was able to reproduce the issue. The problem with this line of code: 

https://github.com/confluentinc/kafka-connect-jdbc/blob/13ab2446b1b40a94d447d5f19089bea7ba18bda4/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java#L85

Especially: 

```
ResultSet rs = metadata.getTables(null, schemaPattern, "%", tableTypes)
```

Fetching the metadata for the table does not respect the connection’s catalog (i.e. `zendesk_development_shard_1`). As such it will return meta data for *all* catalogs it can find in the database. In our case we had a total of three catalogs which contained a table of the same name. All were returned and all were matched by the whitelist leading to the table name duplicated three times. This mis-configuration was resulted in the connector trying to fetch a message from the same table 3 times, each attempt no doubt racing with the others. 

A simple solution would be to change the line above to: 
```
ResultSet rs = metadata.getTables(conn.getCatalog() == "" ? null : conn.getCatalog(), schemaPattern, "%", tableTypes)
```
This would respect the catalog passed in the connection string which I believe is the intent, but otherwise return all tables in all catalogs — which always happens in the current implementation now, and hence leading to the problem described. 

## Versions

MySQL version:
```
5.6.33-0ubuntu0.14.04.1-log (Ubuntu)
```

Docker image: 
```
confluentinc/cp-kafka-connect:3.3.1
````

Jar version: 
```
[2018-01-05 18:32:17,228] INFO Instantiated connector mysql-jdbc-esc with version 3.3.1 of type class io.confluent.connect.jdbc.JdbcSourceConnector (org.apache.kafka.connect.runtime.Worker)
```

This is also an issue on `4.0.0` of the confluent platform. 

## Next steps

* I'd like to write tests for this fix if there is an indication it will be accepted though I am unsure if this can be reproduced using Derby. I'd be happy to write a MySQL integration test, though I am unsure how these tests are run, and if we can expect there to be a local MySQL to use (e.g. Travis will provide one). 
* Generally I might be missing a contribution guide to help ensure this PR is accepted. Any pointers in this direction are appreciated. 

