### PR TITLE
Add timestamp.column.type configuration, to support various data types of timestamp column.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -125,6 +125,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String TIMESTAMP_COLUMN_NAME_DEFAULT = "";
   private static final String TIMESTAMP_COLUMN_NAME_DISPLAY = "Timestamp Column Name";
 
+  public static final String TIMESTAMP_COLUMN_TYPE_CONFIG = "timestamp.column.type";
+  private static final String TIMESTAMP_COLUMN_TYPE_DOC =
+      "The type of the timestamp column to use to set parameters in query.\n"
+      + "  * TIMESTAMP - data type is timestamp. Default value.\n"
+      + "  * DATE - data type is date.";
+  public static final String TIMESTAMP_COLUMN_TYPE_DEFAULT = "TIMESTAMP";
+  private static final String TIMESTAMP_COLUMN_TYPE_DISPLAY = "Timestamp Column Type";
+
   public static final String TABLE_POLL_INTERVAL_MS_CONFIG = "table.poll.interval.ms";
   private static final String TABLE_POLL_INTERVAL_MS_DOC =
       "Frequency in ms to poll for new or removed tables, which may result in updated task "
@@ -368,6 +376,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         3,
         Width.MEDIUM,
         TIMESTAMP_COLUMN_NAME_DISPLAY,
+        MODE_DEPENDENTS_RECOMMENDER
+    ).define(
+        TIMESTAMP_COLUMN_TYPE_CONFIG,
+        Type.STRING,
+        TIMESTAMP_COLUMN_TYPE_DEFAULT,
+        Importance.MEDIUM,
+        TIMESTAMP_COLUMN_TYPE_DOC,
+        MODE_GROUP,
+        4,
+        Width.MEDIUM,
+        TIMESTAMP_COLUMN_TYPE_DISPLAY,
         MODE_DEPENDENTS_RECOMMENDER
     ).define(
         VALIDATE_NON_NULL_CONFIG,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -117,6 +117,8 @@ public class JdbcSourceTask extends SourceTask {
         = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
     String timestampColumn
         = config.getString(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+    String timestampColumnType
+        = config.getString(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_TYPE_CONFIG);
     Long timestampDelayInterval
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
@@ -156,16 +158,16 @@ public class JdbcSourceTask extends SourceTask {
                 topicPrefix, mapNumerics));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+            queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, null,
+                offset, timestampDelayInterval, schemaPattern, mapNumerics));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
-            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+            queryMode, tableOrQuery, topicPrefix, timestampColumn, null, timestampColumnType,
+                offset, timestampDelayInterval, schemaPattern, mapNumerics));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn,
-                offset, timestampDelayInterval, schemaPattern, mapNumerics));
+                timestampColumnType, offset, timestampDelayInterval, schemaPattern, mapNumerics));
       }
     }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -70,7 +70,7 @@ public class TimestampIncrementingTableQuerierTest {
   }
 
   private TimestampIncrementingTableQuerier newQuerier() {
-    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", Collections.<String, Object>emptyMap(), 0L, null, false);
+    return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id", null, Collections.<String, Object>emptyMap(), 0L, null, false);
   }
 
 }


### PR DESCRIPTION
#340   Add `timestamp.column.type` configuration. When set a column with `date` type as timestamp column, use `stmt.setDate` instead of `stmt.setTimestamp`, to speed up the query.