### PR TITLE
CC-1366: close ResultSets and Statements during shutdown

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -243,14 +243,21 @@ public class JdbcSourceTask extends SourceTask {
 
         log.debug("Returning {} records for {}", results.size(), querier.toString());
         return results;
-      } catch (SQLException e) {
-        log.error("Failed to run query for table {}: {}", querier.toString(), e);
+      } catch (SQLException sqle) {
+        log.error("Failed to run query for table {}: {}", querier.toString(), sqle);
         resetAndRequeueHead(querier);
         return null;
+      } catch (Exception e) {
+        resetAndRequeueHead(querier);
+        throw e;
       }
     }
 
     // Only in case of shutdown
+    final TableQuerier querier = tableQueue.peek();
+    if (querier != null) {
+      resetAndRequeueHead(querier);
+    }
     return null;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -247,9 +247,9 @@ public class JdbcSourceTask extends SourceTask {
         log.error("Failed to run query for table {}: {}", querier.toString(), sqle);
         resetAndRequeueHead(querier);
         return null;
-      } catch (Exception e) {
+      } catch (Throwable t) {
         resetAndRequeueHead(querier);
-        throw e;
+        throw t;
       }
     }
 


### PR DESCRIPTION
I went through the code to find possible places where a ResultSet might not be closed.  The only case seems to be in poll(), when either an exception occurs or the task is shutdown.    According to https://stackoverflow.com/questions/4507440/must-jdbc-resultsets-and-statements-be-closed-separately-although-the-connection, ResultSets should be closed even if the Connection is subsequently closed.  Again, this seems to be the only place where a ResultSet could go unclosed.