### PR TITLE
getObject() instead of getBytes()

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -438,7 +438,7 @@ public class DataConverter {
       case Types.BINARY:
       case Types.VARBINARY:
       case Types.LONGVARBINARY: {
-        colValue = resultSet.getBytes(col);
+        colValue = resultSet.getObject(col);
         break;
       }
 


### PR DESCRIPTION
mysql-connector's implementation of getObject() - https://github.com/mysql/mysql-connector-j/blob/6.0.6/src/main/java/com/mysql/cj/jdbc/result/ResultSetImpl.java#L1222

Seems like we should be be using `getObject()` for this SQL data type.