### PR TITLE
Fix to call isValid connection only if necessary

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -222,7 +222,7 @@ public class JdbcSourceTask extends SourceTask {
       final List<SourceRecord> results = new ArrayList<>();
       try {
         log.debug("Checking for next block of results from {}", querier.toString());
-        querier.maybeStartQuery(cachedConnectionProvider.getValidConnection());
+        querier.maybeStartQuery(cachedConnectionProvider);
 
         int batchMaxRows = config.getInt(JdbcSourceTaskConfig.BATCH_MAX_ROWS_CONFIG);
         boolean hadNext = true;

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 
@@ -78,8 +79,9 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     return resultSet != null;
   }
 
-  public void maybeStartQuery(Connection db) throws SQLException {
+  public void maybeStartQuery(CachedConnectionProvider connectionProvider) throws SQLException {
     if (resultSet == null) {
+      Connection db = connectionProvider.getValidConnection();
       stmt = getOrCreatePreparedStatement(db);
       resultSet = executeQuery();
       schema = DataConverter.convertSchema(name, resultSet.getMetaData(), mapNumerics);


### PR DESCRIPTION
If call isValid in Ms Sql Server and has ResultSet is getting data in background jdbc driver has a problem. This solve a issue #361.

Call isValid only if need make a query.