### PR TITLE
#363 Sink connector MySQL dialect - Using data type TEXT

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
@@ -67,7 +67,7 @@ public class MySqlDialect extends DbDialect {
       case BOOLEAN:
         return "TINYINT";
       case STRING:
-        return "VARCHAR(256)";
+        return "TEXT";
       case BYTES:
         return "VARBINARY(1024)";
       default:

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -43,7 +43,7 @@ public class MySqlDialectTest extends BaseDialectTest {
     verifyDataTypeMapping("FLOAT", Schema.FLOAT32_SCHEMA);
     verifyDataTypeMapping("DOUBLE", Schema.FLOAT64_SCHEMA);
     verifyDataTypeMapping("TINYINT", Schema.BOOLEAN_SCHEMA);
-    verifyDataTypeMapping("VARCHAR(256)", Schema.STRING_SCHEMA);
+    verifyDataTypeMapping("TEXT", Schema.STRING_SCHEMA);
     verifyDataTypeMapping("VARBINARY(1024)", Schema.BYTES_SCHEMA);
     verifyDataTypeMapping("DECIMAL(65,0)", Decimal.schema(0));
     verifyDataTypeMapping("DECIMAL(65,2)", Decimal.schema(2));


### PR DESCRIPTION
Switched the column type of STRING from VARCHAR(256) to TEXT