### PR TITLE
Better Debezium data type integration

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -184,7 +184,8 @@ public class BufferedRecords {
         return dbDialect.getUpsertQuery(
             tableName,
             fieldsMetadata.keyFieldNames,
-            fieldsMetadata.nonKeyFieldNames
+            fieldsMetadata.nonKeyFieldNames,
+            fieldsMetadata
         );
       case UPDATE:
         return  dbDialect.getUpdate(

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -39,6 +39,19 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   }
 
+  public enum SqlDialects {
+    DEFAULT,
+    SQLITE,
+    ORACLE,
+    SAP,
+    HANA,
+    VERTICA,
+    SQLSERVER,
+    MARIADB,
+    MYSQL,
+    POSTGRESQL;
+  }
+
   public enum PrimaryKeyMode {
     NONE,
     KAFKA,
@@ -72,6 +85,13 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "For example, ``kafka_${topic}`` for the topic 'orders' will map to the table name "
       + "'kafka_orders'.";
   private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
+
+  public static final String SQL_DIALECT = "sql.dialect";
+  private static final String SQL_DIALECT_DEFAULT = "DEFAULT";
+  private static final String SQL_DIALECT_DOC =
+      "The SQL dialect to use for writes to the database.\n"
+      + "If empty, will automatically infer dialect based on the JDBC connection string";
+  private static final String SQL_DIALECT_DISPLAY = "Use SQL Dialect";
 
   public static final String MAX_RETRIES = "max.retries";
   private static final int MAX_RETRIES_DEFAULT = 10;
@@ -204,6 +224,10 @@ public class JdbcSinkConfig extends AbstractConfig {
       .define(FIELDS_WHITELIST, ConfigDef.Type.LIST, FIELDS_WHITELIST_DEFAULT,
               ConfigDef.Importance.MEDIUM, FIELDS_WHITELIST_DOC,
               DATAMAPPING_GROUP, 4, ConfigDef.Width.LONG, FIELDS_WHITELIST_DISPLAY)
+      .define(SQL_DIALECT, ConfigDef.Type.STRING, SQL_DIALECT_DEFAULT,
+              EnumValidator.in(SqlDialects.values()), ConfigDef.Importance.LOW,
+              SQL_DIALECT_DOC, DATAMAPPING_GROUP, 5,
+              ConfigDef.Width.MEDIUM, SQL_DIALECT_DISPLAY)
       // DDL
       .define(AUTO_CREATE, ConfigDef.Type.BOOLEAN, AUTO_CREATE_DEFAULT,
               ConfigDef.Importance.MEDIUM, AUTO_CREATE_DOC,
@@ -224,6 +248,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionUser;
   public final String connectionPassword;
   public final String tableNameFormat;
+  public final String sqlDialect;
   public final int batchSize;
   public final int maxRetries;
   public final int retryBackoffMs;
@@ -240,6 +265,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
+    sqlDialect = getString(SQL_DIALECT).trim();
     batchSize = getInt(BATCH_SIZE);
     maxRetries = getInt(MAX_RETRIES);
     retryBackoffMs = getInt(RETRY_BACKOFF_MS);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -49,6 +49,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     SQLSERVER,
     MARIADB,
     MYSQL,
+    DEBEZIUM,
     POSTGRESQL;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -47,7 +47,7 @@ public class JdbcSinkTask extends SinkTask {
   }
 
   void initWriter() {
-    final DbDialect dbDialect = DbDialect.fromConnectionString(config.connectionUrl);
+    final DbDialect dbDialect = DbDialect.fromConfig(config);
     final DbStructure dbStructure = new DbStructure(dbDialect);
     log.info("Initializing writer using SQL dialect: {}", dbDialect.getClass().getSimpleName());
     writer = new JdbcDbWriter(config, dbDialect, dbStructure);

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -314,6 +314,8 @@ public abstract class DbDialect {
         return new MySqlDialect();
       case("postgresql"):
         return new PostgreSqlDialect();
+      case("debezium"):
+        return new DebeziumMySqlDialect();
       default:
         throw new ConnectException(String.format("Not a valid SQL dialect name: %s", dialectName));
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -92,6 +92,19 @@ public abstract class DbDialect {
     return builder.toString();
   }
 
+  /**
+   * This function can be overwritten by all dialects that need additional metadata information.
+   *
+   * For dialects that don't need any additional data, this will dispatch to an implementation without FieldsMetadata.
+   */
+  public String getUpsertQuery(
+      final String table,
+      final Collection<String> keyColumns,
+      final Collection<String> columns,
+      final FieldsMetadata fieldsMetadata
+  ){
+    return getUpsertQuery(table, keyColumns, columns);
+  }
 
   public String getUpsertQuery(
       final String table,

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -16,6 +16,8 @@
 
 package io.confluent.connect.jdbc.sink.dialect;
 
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -266,6 +268,42 @@ public abstract class DbDialect {
       }
     }
     return pks;
+  }
+
+  public static DbDialect fromConfig(JdbcSinkConfig config){
+    if (config.sqlDialect.equalsIgnoreCase("default")){
+      return DbDialect.fromConnectionString(config.connectionUrl);
+    } else{
+      return DbDialect.fromDialectName(config.sqlDialect);
+    }
+  }
+
+  /**
+   * Return a DbDialect instance corresponsing to the value given in the sink config as "sql.dialect".
+   * @param dialectName
+   * @return
+   */
+  public static DbDialect fromDialectName(final String dialectName) {
+    switch(dialectName.toLowerCase()){
+      case("sqlite"):
+        return new SqliteDialect();
+      case("oracle"):
+        return new OracleDialect();
+      case("sap"):
+      case("hana"):
+        return new HanaDialect();
+      case("vertica"):
+        return new VerticaDialect();
+      case("sqlserver"):
+        return new SqlServerDialect();
+      case("mariadb"):
+      case("mysql"):
+        return new MySqlDialect();
+      case("postgresql"):
+        return new PostgreSqlDialect();
+      default:
+        throw new ConnectException(String.format("Not a valid SQL dialect name: %s", dialectName));
+    }
   }
 
   public static DbDialect fromConnectionString(final String url) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DebeziumMySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DebeziumMySqlDialect.java
@@ -27,7 +27,7 @@ public class DebeziumMySqlDialect extends DbDialect {
     SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.Json", "?");
     SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.Enum", "?");
     SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.EnumSet", "?");
-    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Date", "DAYS");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Date", "MAKEDATE(1970, ?)");
     SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Timestamp", "FROM_UNIXTIME(? / 1000)");
     SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.ZonedTimestamp", "?");
     SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.MicroTimestamp", "FROM_UNIXTIME(FLOOR(? / 1000))");
@@ -46,7 +46,7 @@ public class DebeziumMySqlDialect extends DbDialect {
     // constraint for enums is enforced by the source data
     SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.data.Enum", "TEXT");
     SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.data.EnumSet", "TEXT");
-    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Date", "DAYS");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Date", "DATE");
     SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Timestamp", "DATETIME");
     SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.ZonedTimestamp", "DATETIME");
     SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.MicroTimestamp", "DATETIME");

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DebeziumMySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DebeziumMySqlDialect.java
@@ -1,0 +1,135 @@
+package io.confluent.connect.jdbc.sink.dialect;
+
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import org.apache.kafka.common.protocol.types.SchemaException;
+import org.apache.kafka.connect.data.*;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.copiesToBuilder;
+import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
+
+
+public class DebeziumMySqlDialect extends DbDialect {
+
+  public DebeziumMySqlDialect() {
+    super("`", "`");
+  }
+
+  public static final HashMap<String, String> SCHEMA_NAME_CASTING_MAP;
+
+  static {
+    SCHEMA_NAME_CASTING_MAP = new HashMap<>();
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.Bits", "?");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.Json", "?");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.Enum", "?");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.data.EnumSet", "?");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Date", "DAYS");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Timestamp", "FROM_UNIXTIME(? / 1000)");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.ZonedTimestamp", "?");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.MicroTimestamp", "FROM_UNIXTIME(FLOOR(? / 1000))");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.MicroTime", "SEC_TO_TIME(FLOOR(? / 1000))");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Time", "SEC_TO_TIME(?)");
+    SCHEMA_NAME_CASTING_MAP.put("io.debezium.time.Year", "?");
+  }
+
+  public static final HashMap<String, String> SCHEMA_NAME_DATATYPE_MAP;
+
+  static {
+    // mappings were taken from the documentation at http://debezium.io/docs/connectors/mysql/
+    SCHEMA_NAME_DATATYPE_MAP = new HashMap<>();
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.data.Bits", "VARBINARY(1024)");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.data.Json", "TEXT");
+    // constraint for enums is enforced by the source data
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.data.Enum", "TEXT");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.data.EnumSet", "TEXT");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Date", "DAYS");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Timestamp", "DATETIME");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.ZonedTimestamp", "DATETIME");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.MicroTimestamp", "DATETIME");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.MicroTime", "TIME");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Time", "TIME");
+    SCHEMA_NAME_DATATYPE_MAP.put("io.debezium.time.Year", "YEAR");
+  }
+
+  @Override
+  protected String getSqlType(String schemaName, Map<String, String> parameters, Schema.Type type) {
+
+    if (schemaName != null && schemaName.startsWith("io.debezium")) {
+      // TODO maybe throw new SchemaException("There is no debezium data type mapping for schema name " + schemaName); ?
+      return SCHEMA_NAME_DATATYPE_MAP.get(schemaName);
+    }
+    return new MySqlDialect().getSqlType(schemaName, parameters, type);
+
+  }
+
+  private String makeUpsertPlaceholders(
+      final Collection<String> keyCols,
+      final Collection<String> cols,
+      final FieldsMetadata fieldsMetadata
+  ) {
+    final StringBuilder builder = new StringBuilder();
+    this.addUpsertPlaceholders(keyCols, fieldsMetadata, builder);
+    this.addUpsertPlaceholders(cols, fieldsMetadata, builder);
+    builder.setLength(builder.length() - 2); // remove trailing ", "
+    return builder.toString();
+  }
+
+  public void addUpsertPlaceholders(
+      final Collection<String> cols,
+      final FieldsMetadata fieldsMetadata,
+      StringBuilder builder
+  ) {
+    for (String col : cols) {
+      String schemaName = fieldsMetadata.allFields.get(col).schemaName();
+      if (schemaName == null) {
+        builder.append("?, ");
+        continue;
+      }
+      // FIXME are there schemata whose names don't start with io.debezium??
+      builder.append(SCHEMA_NAME_CASTING_MAP.get(schemaName));
+      builder.append(", ");
+    }
+  }
+
+
+  @Override
+  public String getUpsertQuery(
+      final String table,
+      final Collection<String> keyCols,
+      final Collection<String> cols,
+      final FieldsMetadata fieldsMetadata
+
+  ) {
+    //MySql doesn't support SQL 2003:merge so here how the upsert is handled
+
+    final StringBuilder builder = new StringBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(escaped(table));
+    builder.append("(");
+    joinToBuilder(builder, ",", keyCols, cols, escaper());
+    builder.append(") VALUES (");
+
+    builder.append(this.makeUpsertPlaceholders(keyCols, cols, fieldsMetadata));
+
+    builder.append(") ON DUPLICATE KEY UPDATE ");
+     // TODO FIXME: Do we also need to apply conversions to the ON DUPLICATE KEY statements or will they be taken from
+    // the initial columns we provide?
+    joinToBuilder(
+        builder,
+        ",",
+        cols.isEmpty() ? keyCols : cols,
+        new StringBuilderUtil.Transform<String>() {
+          @Override
+          public void apply(StringBuilder builder, String col) {
+            builder.append(escaped(col)).append("=VALUES(").append(escaped(col)).append(")");
+          }
+        }
+    );
+    return builder.toString();
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
@@ -67,7 +67,7 @@ public class MySqlDialect extends DbDialect {
       case BOOLEAN:
         return "TINYINT";
       case STRING:
-        return "VARCHAR(256)";
+        return "TEXT";
       case BYTES:
         return "VARBINARY(1024)";
       default:

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -43,7 +43,7 @@ public class MySqlDialectTest extends BaseDialectTest {
     verifyDataTypeMapping("FLOAT", Schema.FLOAT32_SCHEMA);
     verifyDataTypeMapping("DOUBLE", Schema.FLOAT64_SCHEMA);
     verifyDataTypeMapping("TINYINT", Schema.BOOLEAN_SCHEMA);
-    verifyDataTypeMapping("VARCHAR(256)", Schema.STRING_SCHEMA);
+    verifyDataTypeMapping("TEXT", Schema.STRING_SCHEMA);
     verifyDataTypeMapping("VARBINARY(1024)", Schema.BYTES_SCHEMA);
     verifyDataTypeMapping("DECIMAL(65,0)", Decimal.schema(0));
     verifyDataTypeMapping("DECIMAL(65,2)", Decimal.schema(2));


### PR DESCRIPTION
This is a very rough version of a better debezium data type integration to gauge if there is any interest in getting something like this into the mainline connector.

One of the main problems when using Debezium with the JDBC sink connector is that many data types in the source- and sink tables do not match at all. [Debezium reads the MySQL data types](http://debezium.io/docs/connectors/mysql/#data-types) and maps them into kafka data types, and the [JDBC sink connector re-maps those back into MySQL data types](https://docs.confluent.io/current/connect/connect-jdbc/docs/sink_connector.html#features).

Effectively, this causes issues such as TIMESTAMP columns in the source table turning into LONG tables in the sink table. 

The proposed solution contains two parts:
* Implementing a DebeziumMySQL dialect (heavily based on the basic MySQL dialect) that can correctly map the debezium-generated schema back into the corresponding MySQL data types and transform data if necessary. Currently, I have only implemented the "UPSERT" semantics of this dialect.
* Implementing an optional configuration flag that allows an user to override the dialect to be used. Users can set "sql.dialect=debezium" to use the debezium dialect. This is backwards compatible since it will default to reading the dialect from the JDBC string (the current behaviour). 

Again, this is only a rough first implementation. Please let me know if there is any interest in this feature and if the proposed approach (adding custom dialects) seems fine to you.

Cheers
Felix