### PR TITLE
Custom dialects

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -234,7 +234,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionUrl;
   public final String connectionUser;
   public final String connectionPassword;
-  public final String connectionDialect;
+  public final Class connectionDialect;
   public final String tableNameFormat;
   public final int batchSize;
   public final int maxRetries;
@@ -251,7 +251,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
-    connectionDialect = getString(CONNECTION_DIALECT);
+    connectionDialect = getClass(CONNECTION_DIALECT);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
     maxRetries = getInt(MAX_RETRIES);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -67,6 +67,10 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
+  public static final String CONNECTION_DIALECT = "connection.dialect";
+  private static final String CONNECTION_DIALECT_DOC = "Custom io.confluent.connect.jdbc.sink.dialect.DbDialect class name";
+  private static final String CONNECTION_DIALECT_DISPLAY = "Custom Db Dialect class name";
+
   public static final String TABLE_NAME_FORMAT = "table.name.format";
   private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
   private static final String TABLE_NAME_FORMAT_DOC =
@@ -185,6 +189,9 @@ public class JdbcSinkConfig extends AbstractConfig {
       .define(CONNECTION_PASSWORD, ConfigDef.Type.PASSWORD, null,
               ConfigDef.Importance.HIGH, CONNECTION_PASSWORD_DOC,
               CONNECTION_GROUP, 3, ConfigDef.Width.MEDIUM, CONNECTION_PASSWORD_DISPLAY)
+      .define(CONNECTION_DIALECT, ConfigDef.Type.CLASS, null,
+              ConfigDef.Importance.LOW, CONNECTION_DIALECT_DOC,
+              CONNECTION_GROUP, 4, ConfigDef.Width.LONG, CONNECTION_DIALECT_DISPLAY)
       // Writes
       .define(INSERT_MODE, ConfigDef.Type.STRING, INSERT_MODE_DEFAULT,
               EnumValidator.in(InsertMode.values()),
@@ -226,6 +233,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionUrl;
   public final String connectionUser;
   public final String connectionPassword;
+  public final String connectionDialect;
   public final String tableNameFormat;
   public final int batchSize;
   public final int maxRetries;
@@ -236,12 +244,12 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final PrimaryKeyMode pkMode;
   public final List<String> pkFields;
   public final Set<String> fieldsWhitelist;
-
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
+    connectionDialect = getString(CONNECTION_DIALECT);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
     maxRetries = getInt(MAX_RETRIES);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -68,7 +68,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
   public static final String CONNECTION_DIALECT = "connection.dialect";
-  private static final String CONNECTION_DIALECT_DOC = "Custom io.confluent.connect.jdbc.sink.dialect.DbDialect class name";
+  private static final String CONNECTION_DIALECT_DOC =
+          "Custom io.confluent.connect.jdbc.sink.dialect.DbDialect class name";
   private static final String CONNECTION_DIALECT_DISPLAY = "Custom Db Dialect class name";
 
   public static final String TABLE_NAME_FORMAT = "table.name.format";
@@ -244,6 +245,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final PrimaryKeyMode pkMode;
   public final List<String> pkFields;
   public final Set<String> fieldsWhitelist;
+
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
     connectionUrl = getString(CONNECTION_URL);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -47,7 +47,12 @@ public class JdbcSinkTask extends SinkTask {
   }
 
   void initWriter() {
-    final DbDialect dbDialect = DbDialect.fromConnectionString(config.connectionUrl);
+    final DbDialect dbDialect;
+    if (config.connectionDialect != null) {
+      dbDialect = DbDialect.fromCustomDBDialect(config.connectionDialect);
+    } else {
+      dbDialect = DbDialect.fromConnectionString(config.connectionUrl);
+    }
     final DbStructure dbStructure = new DbStructure(dbDialect);
     log.info("Initializing writer using SQL dialect: {}", dbDialect.getClass().getSimpleName());
     writer = new JdbcDbWriter(config, dbDialect, dbStructure);

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -269,12 +269,14 @@ public abstract class DbDialect {
     return pks;
   }
 
-  public static DbDialect fromCustomDBDialect(final String dbDialectClass) {
+  public static DbDialect fromCustomDBDialect(final Class dbDialectClass) {
     try {
-      return (DbDialect) Class.forName(dbDialectClass).newInstance();
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+      return (DbDialect) dbDialectClass.newInstance();
+    } catch (IllegalAccessException | InstantiationException e) {
       throw new ConfigException(
-              String.format("Could not create class %s: %s", dbDialectClass, e.getMessage())
+              String.format(
+                      "Could not create instance for class %s: %s",
+                      dbDialectClass, e.getMessage())
       );
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -272,12 +272,13 @@ public abstract class DbDialect {
   public static DbDialect fromCustomDBDialect(final String dbDialectClass) {
     try {
       return (DbDialect) Class.forName(dbDialectClass).newInstance();
-    } catch(ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
       throw new ConfigException(
               String.format("Could not create class %s: %s", dbDialectClass, e.getMessage())
       );
     }
   }
+
   public static DbDialect fromConnectionString(final String url) {
     if (!url.startsWith("jdbc:")) {
       throw new ConnectException(String.format("Not a valid JDBC URL: %s", url));

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.sink.dialect;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -268,6 +269,15 @@ public abstract class DbDialect {
     return pks;
   }
 
+  public static DbDialect fromCustomDBDialect(final String dbDialectClass) {
+    try {
+      return (DbDialect) Class.forName(dbDialectClass).newInstance();
+    } catch(ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+      throw new ConfigException(
+              String.format("Could not create class %s: %s", dbDialectClass, e.getMessage())
+      );
+    }
+  }
   public static DbDialect fromConnectionString(final String url) {
     if (!url.startsWith("jdbc:")) {
       throw new ConnectException(String.format("Not a valid JDBC URL: %s", url));

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -1,0 +1,37 @@
+package io.confluent.connect.jdbc.sink;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class JdbcSinkConfigTest {
+    public static class FakeDialect {}
+    @Test
+    public void connectionParams() {
+
+        final Map<String, String> props = new HashMap<>();
+        final String fakeDialectClass = FakeDialect.class.getName();
+        final String fakeConnectionUrl = "custom://fake_url";
+        final String fakeUsername = "fake_username";
+        final String fakePassword = "fake_password";
+        props.put("connection.dialect", fakeDialectClass);
+        props.put("connection.url", fakeConnectionUrl);
+        props.put("connection.user", fakeUsername);
+        props.put("connection.password", fakePassword);
+        JdbcSinkConfig sut = new JdbcSinkConfig(props);
+        assertEquals(FakeDialect.class, sut.connectionDialect);
+        assertEquals(fakeConnectionUrl, sut.connectionUrl);
+        assertEquals(fakeUsername, sut.connectionUser);
+        assertEquals(fakePassword, sut.connectionPassword);
+
+        props.remove("connection.dialect");
+        sut = new JdbcSinkConfig(props);
+        assertNull(sut.connectionDialect);
+        assertEquals(fakeConnectionUrl, sut.connectionUrl);
+        assertEquals(fakeUsername, sut.connectionUser);
+        assertEquals(fakePassword, sut.connectionPassword);
+    }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import io.confluent.connect.jdbc.sink.dialect.SqliteDialect;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -242,4 +243,27 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     verifyAll();
   }
 
+
+  public static class CustomDialect extends SqliteDialect {
+      private static int CUSTOM_DIALECT_INSTANCES = 0;
+      public CustomDialect() {
+        super();
+        CUSTOM_DIALECT_INSTANCES++;
+      }
+  }
+
+  @Test
+  public void customDialect() throws Exception {
+    try {
+        assertEquals(0, CustomDialect.CUSTOM_DIALECT_INSTANCES);
+        Map<String, String> props = new HashMap<>();
+        props.put("connection.url", sqliteHelper.sqliteUri());
+        props.put("connection.dialect", CustomDialect.class.getName());
+        JdbcSinkTask task = new JdbcSinkTask();
+        task.start(props);
+        assertEquals(1, CustomDialect.CUSTOM_DIALECT_INSTANCES);
+    } finally {
+        CustomDialect.CUSTOM_DIALECT_INSTANCES = 0;
+    }
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
@@ -138,4 +138,20 @@ public class DbDialectTest {
     assertEquals(VerticaDialect.class, DbDialect.fromConnectionString("jdbc:vertica://host:5433/db").getClass());
   }
 
+  @Test
+  public void customDialect() {
+    final Class[] fixture = {
+            PostgreSqlDialect.class,
+            GenericDialect.class,
+            VerticaDialect.class,
+            SqlServerDialect.class,
+            MySqlDialect.class
+    };
+    for (Class clazz: fixture) {
+      assertEquals(
+              clazz,
+              DbDialect.fromCustomDBDialect(clazz.getName()).getClass());
+    }
+  }
+
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
@@ -150,7 +150,7 @@ public class DbDialectTest {
     for (Class clazz: fixture) {
       assertEquals(
               clazz,
-              DbDialect.fromCustomDBDialect(clazz.getName()).getClass());
+              DbDialect.fromCustomDBDialect(clazz).getClass());
     }
   }
 


### PR DESCRIPTION
This patch allows you to specify a custom dialect class for Jdbc Sink through configuration property 'connection.dialect': If present, it overrides the the 'connection.url'-based dialect autodetection and creates an instance of the specified class.
Any failed attempt to create an instance of a custom dialect will result in a failure. 
