### PR TITLE
Add upsert mode for the Vertica dialect

### DIFF
--- a/docs/sink_connector.rst
+++ b/docs/sink_connector.rst
@@ -147,6 +147,7 @@ Oracle          `MERGE ..`
 PostgreSQL      `INSERT .. ON CONFLICT .. DO UPDATE SET ..`
 SQLite          `INSERT OR REPLACE ..`
 SQL Server      `MERGE ..`
+Vertica         `MERGE ..`
 Other           *not supported*
 ===========     ================================================
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -184,7 +184,8 @@ public class BufferedRecords {
         return dbDialect.getUpsertQuery(
             tableName,
             fieldsMetadata.keyFieldNames,
-            fieldsMetadata.nonKeyFieldNames
+            fieldsMetadata.nonKeyFieldNames,
+            fieldsMetadata.allFields
         );
       case UPDATE:
         return  dbDialect.getUpdate(

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -94,7 +94,8 @@ public abstract class DbDialect {
   public String getUpsertQuery(
       final String table,
       final Collection<String> keyColumns,
-      final Collection<String> columns
+      final Collection<String> columns,
+      final Map<String, SinkRecordField> allFields
   ) {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/GenericDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/GenericDialect.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc.sink.dialect;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 
@@ -41,9 +42,10 @@ public class GenericDialect extends DbDialect {
 
   @Override
   public String getUpsertQuery(
-      String table,
-      Collection<String> keyColumns,
-      Collection<String> columns
+      final String table,
+      final Collection<String> keyColumns,
+      final Collection<String> columns,
+      final Map<String, SinkRecordField> allFields
   ) {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/HanaDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/HanaDialect.java
@@ -98,8 +98,9 @@ public class HanaDialect extends DbDialect {
   @Override
   public String getUpsertQuery(
       final String table,
-      Collection<String> keyCols,
-      Collection<String> cols
+      final Collection<String> keyCols,
+      final Collection<String> cols,
+      final Map<String, SinkRecordField> allFields
   ) {
     // https://help.sap.com/hana_one/html/sql_replace_upsert.html
     StringBuilder builder = new StringBuilder("UPSERT ");

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialect.java
@@ -25,6 +25,8 @@ import org.apache.kafka.connect.data.Timestamp;
 import java.util.Collection;
 import java.util.Map;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
 import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.copiesToBuilder;
 
@@ -79,7 +81,8 @@ public class MySqlDialect extends DbDialect {
   public String getUpsertQuery(
       final String table,
       final Collection<String> keyCols,
-      final Collection<String> cols
+      final Collection<String> cols,
+      final Map<String, SinkRecordField> allFields
   ) {
     //MySql doesn't support SQL 2003:merge so here how the upsert is handled
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/OracleDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/OracleDialect.java
@@ -89,8 +89,9 @@ public class OracleDialect extends DbDialect {
   @Override
   public String getUpsertQuery(
       final String table,
-      Collection<String> keyCols,
-      Collection<String> cols
+      final Collection<String> keyCols,
+      final Collection<String> cols,
+      final Map<String, SinkRecordField> allFields
   ) {
     // https://blogs.oracle.com/cmar/entry/using_merge_to_do_an
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
@@ -25,6 +25,8 @@ import org.apache.kafka.connect.data.Timestamp;
 import java.util.Collection;
 import java.util.Map;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.copiesToBuilder;
 import static io.confluent.connect.jdbc.sink.dialect.StringBuilderUtil.joinToBuilder;
 
@@ -78,7 +80,8 @@ public class PostgreSqlDialect extends DbDialect {
   public String getUpsertQuery(
       final String table,
       final Collection<String> keyCols,
-      final Collection<String> cols
+      final Collection<String> cols,
+      final Map<String, SinkRecordField> allFields
   ) {
     final StringBuilder builder = new StringBuilder();
     builder.append("INSERT INTO ");

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialect.java
@@ -87,7 +87,12 @@ public class SqlServerDialect extends DbDialect {
   }
 
   @Override
-  public String getUpsertQuery(String table, Collection<String> keyCols, Collection<String> cols) {
+  public String getUpsertQuery(
+      final String table,
+      final Collection<String> keyCols,
+      final Collection<String> cols,
+      final Map<String, SinkRecordField> allFields
+  ) {
     final StringBuilder builder = new StringBuilder();
     builder.append("merge into ");
     String tableName = escaped(table);

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialect.java
@@ -102,7 +102,12 @@ public class SqliteDialect extends DbDialect {
   }
 
   @Override
-  public String getUpsertQuery(String table, Collection<String> keyCols, Collection<String> cols) {
+  public String getUpsertQuery(
+      final String table,
+      final Collection<String> keyCols,
+      final Collection<String> cols,
+      final Map<String, SinkRecordField> allFields
+  ) {
     StringBuilder builder = new StringBuilder();
     builder.append("INSERT OR REPLACE INTO ");
     builder.append(escaped(table)).append("(");

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/HanaDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/HanaDialectTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 public class HanaDialectTest extends BaseDialectTest {
 
   public HanaDialectTest() {
@@ -98,7 +100,12 @@ public class HanaDialectTest extends BaseDialectTest {
   public void upsert() {
     assertEquals(
         "UPSERT \"tableA\"(\"col1\",\"col2\",\"col3\",\"col4\") VALUES(?,?,?,?) WITH PRIMARY KEY",
-        dialect.getUpsertQuery("tableA", Collections.singletonList("col1"), Arrays.asList("col2", "col3", "col4"))
+        dialect.getUpsertQuery(
+            "tableA",
+            Collections.singletonList("col1"),
+            Arrays.asList("col2", "col3", "col4"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/MySqlDialectTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 public class MySqlDialectTest extends BaseDialectTest {
 
   public MySqlDialectTest() {
@@ -99,7 +101,12 @@ public class MySqlDialectTest extends BaseDialectTest {
     assertEquals(
         "insert into `actor`(`actor_id`,`first_name`,`last_name`,`score`) " +
         "values(?,?,?,?) on duplicate key update `first_name`=values(`first_name`),`last_name`=values(`last_name`),`score`=values(`score`)",
-        dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Arrays.asList("first_name", "last_name", "score"))
+        dialect.getUpsertQuery(
+            "actor",
+            Arrays.asList("actor_id"),
+            Arrays.asList("first_name", "last_name", "score"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 
@@ -108,7 +115,12 @@ public class MySqlDialectTest extends BaseDialectTest {
     assertEquals(
         "insert into `actor`(`actor_id`) " +
         "values(?) on duplicate key update `actor_id`=values(`actor_id`)",
-        dialect.getUpsertQuery("actor", Arrays.asList("actor_id"), Collections.<String>emptyList())
+        dialect.getUpsertQuery(
+            "actor",
+            Arrays.asList("actor_id"),
+            Collections.<String>emptyList(),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/OracleDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/OracleDialectTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 public class OracleDialectTest extends BaseDialectTest {
 
   public OracleDialectTest() {
@@ -104,7 +106,12 @@ public class OracleDialectTest extends BaseDialectTest {
         "when matched then update set \"ARTICLE\".\"body\"=incoming.\"body\" " +
         "when not matched then insert(\"ARTICLE\".\"body\",\"ARTICLE\".\"title\",\"ARTICLE\".\"author\") " +
         "values(incoming.\"body\",incoming.\"title\",incoming.\"author\")",
-        dialect.getUpsertQuery("ARTICLE", Arrays.asList("title", "author"), Collections.singletonList("body"))
+        dialect.getUpsertQuery(
+            "ARTICLE",
+            Arrays.asList("title", "author"),
+            Collections.singletonList("body"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 public class PostgreSqlDialectTest extends BaseDialectTest {
 
   public PostgreSqlDialectTest() {
@@ -98,7 +100,12 @@ public class PostgreSqlDialectTest extends BaseDialectTest {
     assertEquals(
         "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") "
         + "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\",\"salary\"=EXCLUDED.\"salary\",\"address\"=EXCLUDED.\"address\"",
-        dialect.getUpsertQuery("Customer", Collections.singletonList("id"), Arrays.asList("name", "salary", "address"))
+        dialect.getUpsertQuery(
+            "Customer",
+            Collections.singletonList("id"),
+            Arrays.asList("name", "salary", "address"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqlServerDialectTest.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+
 public class SqlServerDialectTest extends BaseDialectTest {
 
   public SqlServerDialectTest() {
@@ -102,7 +104,12 @@ public class SqlServerDialectTest extends BaseDialectTest {
         + "AS incoming on (target.[id]=incoming.[id]) when matched then update set "
         + "[name]=incoming.[name],[salary]=incoming.[salary],[address]=incoming.[address] when not matched then insert "
         + "([name], [salary], [address], [id]) values (incoming.[name],incoming.[salary],incoming.[address],incoming.[id]);",
-        dialect.getUpsertQuery("Customer", Collections.singletonList("id"), Arrays.asList("name", "salary", "address"))
+        dialect.getUpsertQuery(
+            "Customer",
+            Collections.singletonList("id"),
+            Arrays.asList("name", "salary", "address"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 
@@ -114,7 +121,12 @@ public class SqlServerDialectTest extends BaseDialectTest {
         + " when matched then update set [ISBN]=incoming.[ISBN],[year]=incoming.[year],[pages]=incoming.[pages] when not "
         + "matched then insert ([ISBN], [year], [pages], [author], [title]) values (incoming.[ISBN],incoming.[year],"
         + "incoming.[pages],incoming.[author],incoming.[title]);",
-        dialect.getUpsertQuery("Book", Arrays.asList("author", "title"), Arrays.asList("ISBN", "year", "pages"))
+        dialect.getUpsertQuery(
+            "Book",
+            Arrays.asList("author", "title"),
+            Arrays.asList("ISBN", "year", "pages"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/SqliteDialectTest.java
@@ -24,8 +24,11 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 
 public class SqliteDialectTest extends BaseDialectTest {
 
@@ -95,7 +98,12 @@ public class SqliteDialectTest extends BaseDialectTest {
   public void upsert() {
     assertEquals(
         "INSERT OR REPLACE INTO `Book`(`author`,`title`,`ISBN`,`year`,`pages`) VALUES(?,?,?,?,?)",
-        dialect.getUpsertQuery("Book", Arrays.asList("author", "title"), Arrays.asList("ISBN", "year", "pages"))
+        dialect.getUpsertQuery(
+            "Book",
+            Arrays.asList("author", "title"),
+            Arrays.asList("ISBN", "year", "pages"),
+            Collections.<String, SinkRecordField>emptyMap()
+        )
     );
   }
 


### PR DESCRIPTION
When in `upsert` mode generate `MERGE` statements for the Vertica dialect of the form
```sql
MERGE INTO "table" AS target USING (
  SELECT ?::INT AS "id", ?::VARCHAR AS "name"
) AS incoming 
ON (target."id"=incoming."id")
WHEN MATCHED THEN UPDATE SET "name"=incoming."name","id"=incoming."id"
WHEN NOT MATCHED THEN INSERT ("name","id")
VALUES (incoming."name",incoming."id")
```
Unfortunately omitting the types from the `SELECT` statement and having non-varchar values makes Vertica error out with
```
com.vertica.support.exceptions.ErrorException: 
[Vertica][VJDBC](3376) ERROR: Failed to find conversion function from unknown to int
```
thus I had to somehow get the column type information passed to `getUpsertQuery()` - I'm open to suggestions as to how to do it otherwise (should I maybe rebase this on top of 
#333? or wait until it's merged?).

Casting to un-sized types since the destination table might be pre-created with differently sized types compared to the default ones, thus casting to explicit sizes might truncate values.

Note that the `WHEN MATCHED` branch includes key columns as advised by the Vertica [documentation](https://my.vertica.com/docs/9.1.x/HTML/index.htm#Authoring/AdministratorsGuide/Tables/MergeTables/OptimizedVsNonOptimizedMerge.htm).