### PR TITLE
MINOR: Increase PermSize for Surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
+                    <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=128m</argLine>
+                    <argLine>@{argLine} -Djava.awt.headless=true </argLine>
                     <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
+                    <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=128m</argLine>
                     <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
                 </configuration>
                 <executions>


### PR DESCRIPTION
This is a WIP. The purpose is to check the impact of perm size on Jenkins builds. 

Signed-off-by: Arjun Satish <arjun@confluent.io>