### PR TITLE
CC-2139: Moved the call to set the fetch direction out of generic dialect

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -117,7 +117,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  private final Logger log = LoggerFactory.getLogger(GenericDatabaseDialect.class);
+  protected final Logger log = LoggerFactory.getLogger(getClass());
   protected final AbstractConfig config;
 
   /**
@@ -287,9 +287,24 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       Connection db,
       String query
   ) throws SQLException {
+    log.trace("Creating a PreparedStatement '{}'", query);
     PreparedStatement stmt = db.prepareStatement(query);
-    stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+    initializePreparedStatement(stmt);
     return stmt;
+  }
+
+  /**
+   * Perform any operations on a {@link PreparedStatement} before it is used. This is called from
+   * the {@link #createPreparedStatement(Connection, String)} method after the statement is
+   * created but before it is returned/used.
+   *
+   * <p>By default this method does nothing.
+   *
+   * @param stmt the prepared statement; never null
+   * @throws SQLException the error that might result from initialization
+   */
+  protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
+    // do nothing
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -22,6 +22,10 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Collection;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
@@ -57,6 +61,24 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    */
   public MySqlDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "`", "`"));
+  }
+
+  /**
+   * Perform any operations on a {@link PreparedStatement} before it is used. This is called from
+   * the {@link #createPreparedStatement(Connection, String)} method after the statement is
+   * created but before it is returned/used.
+   *
+   * <p>This method sets the {@link PreparedStatement#setFetchDirection(int) fetch direction}
+   * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver to allow it to
+   * scroll more efficiently through the result set and prevent out of memory errors.
+   *
+   * @param stmt the prepared statement; never null
+   * @throws SQLException the error that might result from initialization
+   */
+  @Override
+  protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
+    log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
+    stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -24,6 +24,10 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
 
@@ -67,6 +71,25 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   public PostgreSqlDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
+
+  /**
+   * Perform any operations on a {@link PreparedStatement} before it is used. This is called from
+   * the {@link #createPreparedStatement(Connection, String)} method after the statement is
+   * created but before it is returned/used.
+   *
+   * <p>This method sets the {@link PreparedStatement#setFetchDirection(int) fetch direction}
+   * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver to allow it to
+   * scroll more efficiently through the result set and prevent out of memory errors.
+   *
+   * @param stmt the prepared statement; never null
+   * @throws SQLException the error that might result from initialization
+   */
+  @Override
+  protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
+    log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
+    stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+  }
+
 
   @Override
   public String addFieldToSchema(


### PR DESCRIPTION
Setting the fetch direction does not work with some versions of SQLite and potentially other DBMSes. Since the 4.1.1 source connector did not use this method, the generic dialect should not set the fetch direction and instead only the PostgreSQL and MySQL dialects should do this since those drivers respect and use this to reduce memory problems.

The most straightforward way to handle this is to create a new protected method in `GenericDatabaseDialect` that is to perform any operations on a newly-created prepared statement, and by default to do nothing. Then the `PostgreSqlDatabaseDialect` and `MySqlDatabaseDialect` can override this and call the `setFetchDirection` method.