### PR TITLE
CC-2116: Fix offsets compatibility

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -19,7 +19,7 @@
               files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>
 
     <suppress checks="MethodLength"
-              files="(DataConverter|GenericDatabaseDialect).java"/>
+              files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
               files="(ColumnDefinition|GenericDatabaseDialect).java"/>

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -20,4 +20,5 @@ public class JdbcSourceConnectorConstants {
   public static final String TABLE_NAME_KEY = "table";
   public static final String QUERY_NAME_KEY = "query";
   public static final String QUERY_NAME_VALUE = "query";
+  public static final String OFFSET_PROTOCOL_VERSION = "version";
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -20,6 +20,6 @@ public class JdbcSourceConnectorConstants {
   public static final String TABLE_NAME_KEY = "table";
   public static final String QUERY_NAME_KEY = "query";
   public static final String QUERY_NAME_VALUE = "query";
-  public static final String OFFSET_PROTOCOl_VERSION_KEY = "version";
+  public static final String OFFSET_PROTOCOL_VERSION_KEY = "version";
   public static final String PROTOCOL_VERSION_ONE = "1";
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -21,4 +21,6 @@ public class JdbcSourceConnectorConstants {
   public static final String QUERY_NAME_KEY = "query";
   public static final String QUERY_NAME_VALUE = "query";
   public static final String OFFSET_PROTOCOL_VERSION = "version";
+  public static final String PROTOCOL_VERSION_ZERO = "0";
+  public static final String PROTOCOL_VERSION_ONE = "1";
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -22,5 +22,4 @@ public class JdbcSourceConnectorConstants {
   public static final String QUERY_NAME_VALUE = "query";
   public static final String OFFSET_PROTOCOl_VERSION_KEY = "version";
   public static final String PROTOCOL_VERSION_ONE = "1";
-  public static final String TOPIC_NAME_KEY = "topic";
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -20,6 +20,6 @@ public class JdbcSourceConnectorConstants {
   public static final String TABLE_NAME_KEY = "table";
   public static final String QUERY_NAME_KEY = "query";
   public static final String QUERY_NAME_VALUE = "query";
-  public static final String OFFSET_PROTOCOL_VERSION_KEY = "version";
+  public static final String OFFSET_PROTOCOL_VERSION_KEY = "protocol";
   public static final String PROTOCOL_VERSION_ONE = "1";
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConstants.java
@@ -20,7 +20,7 @@ public class JdbcSourceConnectorConstants {
   public static final String TABLE_NAME_KEY = "table";
   public static final String QUERY_NAME_KEY = "query";
   public static final String QUERY_NAME_VALUE = "query";
-  public static final String OFFSET_PROTOCOL_VERSION = "version";
-  public static final String PROTOCOL_VERSION_ZERO = "0";
+  public static final String OFFSET_PROTOCOl_VERSION_KEY = "version";
   public static final String PROTOCOL_VERSION_ONE = "1";
+  public static final String TOPIC_NAME_KEY = "topic";
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -107,6 +107,7 @@ public class JdbcSourceTask extends SourceTask {
                                  ? Collections.singletonList(query) : tables;
 
     String mode = config.getString(JdbcSourceTaskConfig.MODE_CONFIG);
+    log.debug("Starting task with mode {} ",mode);
     Map<Map<String, String>, Map<String, Object>> offsets = null;
     if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)
         || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -21,6 +21,7 @@ import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.Version;
 import org.apache.kafka.common.config.ConfigException;
@@ -156,10 +157,11 @@ public class JdbcSourceTask extends SourceTask {
               JdbcSourceConnectorConstants.TABLE_NAME_KEY,
               tableId.tableName()
           );
-          Map<String, String> partitionWithProtocolVer = new HashMap<>();
-          partitionWithProtocolVer.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, tableOrQuery);
-          partitionWithProtocolVer.put(JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION, "1");
-          partitions.add(partitionWithProtocolVer);
+          String fqn = ExpressionBuilder.create().append(tableId, false).toString();
+          Map<String, String> partitionWithFqn = new HashMap<>();
+          partitionWithFqn.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
+          partitionWithFqn.put(JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION, "1");
+          partitions.add(partitionWithFqn);
           partitions.add(partition);
           break;
         case QUERY:

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -240,8 +240,8 @@ public class JdbcSourceTask extends SourceTask {
     partitionWithFqn.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
     partitionWithFqn.put(
         JdbcSourceConnectorConstants.OFFSET_PROTOCOl_VERSION_KEY,
-        JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE)
-    ;
+        JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
+    );
 
     Map<String, String> partition = Collections.singletonMap(
         JdbcSourceConnectorConstants.TABLE_NAME_KEY,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -170,12 +170,14 @@ public class JdbcSourceTask extends SourceTask {
           throw new ConnectException("Unexpected query mode: " + queryMode);
       }
 
+      //select the first matching offset
+      // This helps in handling any backward compatible offset changes
       Map<String, Object> offset = null;
       if (offsets != null) {
         for (Map<String, String> toCheckPartition : tablePartitionsToCheck) {
           offset = offsets.get(toCheckPartition);
           if (offset != null) {
-            log.debug("Found non-null offset {} for partition {}", offsets, toCheckPartition);
+            log.debug("Found offset {} for partition {}", offsets, toCheckPartition);
             break;
           }
         }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -16,14 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
-import io.confluent.connect.jdbc.dialect.DatabaseDialects;
-import io.confluent.connect.jdbc.util.CachedConnectionProvider;
-import io.confluent.connect.jdbc.util.ColumnDefinition;
-import io.confluent.connect.jdbc.util.ColumnId;
-import io.confluent.connect.jdbc.util.ExpressionBuilder;
-import io.confluent.connect.jdbc.util.TableId;
-import io.confluent.connect.jdbc.util.Version;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -46,6 +38,15 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.dialect.DatabaseDialects;
+import io.confluent.connect.jdbc.util.CachedConnectionProvider;
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.Version;
 
 /**
  * JdbcSourceTask is a Kafka Connect SourceTask implementation that reads from JDBC databases and
@@ -241,7 +242,7 @@ public class JdbcSourceTask extends SourceTask {
     Map<String, String> partitionWithFqn = new HashMap<>();
     partitionWithFqn.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
     partitionWithFqn.put(
-        JdbcSourceConnectorConstants.OFFSET_PROTOCOl_VERSION_KEY,
+        JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION_KEY,
         JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
     );
 

--- a/src/main/java/io/confluent/connect/jdbc/source/OffsetProtocols.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/OffsetProtocols.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OffsetProtocols {
+
+  public static Map<String, String> sourcePartitionForProtocolV1(TableId tableId) {
+    String fqn = ExpressionBuilder.create().append(tableId, false).toString();
+    Map<String, String> partitionForV1 = new HashMap<>();
+    partitionForV1.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
+    partitionForV1.put(
+        JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION_KEY,
+        JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
+    );
+    return partitionForV1;
+  }
+
+  public static Map<String, String> sourcePartitionForProtocolV0(TableId tableId) {
+    return Collections.singletonMap(
+        JdbcSourceConnectorConstants.TABLE_NAME_KEY,
+        tableId.tableName()
+    );
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/OffsetProtocols.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/OffsetProtocols.java
@@ -23,8 +23,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Provides helper methods to get partition map for different protocol versions.
+ */
 public class OffsetProtocols {
 
+  /**
+   * Provides the partition map for V1 protocol. The table name included is fully qualified
+   * and there is also an explicit protocol key.
+   * @param tableId the tableId that requires partition keys
+   * @return the partition map for V1 protocol
+   */
   public static Map<String, String> sourcePartitionForProtocolV1(TableId tableId) {
     String fqn = ExpressionBuilder.create().append(tableId, false).toString();
     Map<String, String> partitionForV1 = new HashMap<>();
@@ -36,6 +45,12 @@ public class OffsetProtocols {
     return partitionForV1;
   }
 
+  /**
+   * Provides the partition map for V0 protocol. The table name included is unqualified
+   * and there is no explicit protocol key.
+   * @param tableId the tableId that requires partition keys
+   * @return the partition map for V0 protocol
+   */
   public static Map<String, String> sourcePartitionForProtocolV0(TableId tableId) {
     return Collections.singletonMap(
         JdbcSourceConnectorConstants.TABLE_NAME_KEY,

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -29,7 +29,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -174,13 +173,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       case TABLE:
         String name = tableId.tableName();
         topic = topicPrefix + name;// backward compatible
-        String fqn = ExpressionBuilder.create().append(tableId, false).toString();
-        partition = new HashMap<>();
-        partition.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
-        partition.put(
-            JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION_KEY,
-            JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
-        );
+        partition = OffsetProtocols.sourcePartitionForProtocolV1(tableId);
         break;
       case QUERY:
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -16,13 +16,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
-import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
-import io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.CriteriaValues;
-import io.confluent.connect.jdbc.util.ColumnDefinition;
-import io.confluent.connect.jdbc.util.ColumnId;
-import io.confluent.connect.jdbc.util.DateTimeUtils;
-import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -39,6 +32,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
+import io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.CriteriaValues;
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
 
 /**
  * <p>
@@ -68,7 +69,6 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
   private TimestampIncrementingCriteria criteria;
-  private boolean useFqn;
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
                                            String topicPrefix,
@@ -81,6 +81,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                 ? timestampColumnNames : Collections.<String>emptyList();
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
+
     this.timestampColumns = new ArrayList<>();
     for (String timestampColumn : this.timestampColumnNames) {
       if (timestampColumn != null && !timestampColumn.isEmpty()) {
@@ -177,7 +178,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
         partition = new HashMap<>();
         partition.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
         partition.put(
-            JdbcSourceConnectorConstants.OFFSET_PROTOCOl_VERSION_KEY,
+            JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION_KEY,
             JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
         );
         break;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -68,6 +68,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
   private TimestampIncrementingCriteria criteria;
+  private final Map<String, String> partition;
+  private final String topic;
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
                                            String topicPrefix,
@@ -86,6 +88,21 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       if (timestampColumn != null && !timestampColumn.isEmpty()) {
         timestampColumns.add(new ColumnId(tableId, timestampColumn));
       }
+    }
+
+    switch (mode) {
+      case TABLE:
+        String tableName = tableId.tableName();
+        topic = topicPrefix + tableName;// backward compatible
+        partition = OffsetProtocols.sourcePartitionForProtocolV1(tableId);
+        break;
+      case QUERY:
+        partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
+            JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
+        topic = topicPrefix;
+        break;
+      default:
+        throw new ConnectException("Unexpected query mode: " + mode);
     }
   }
 
@@ -163,26 +180,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
         log.warn("Ignoring record due to SQL error:", e);
       }
     }
-
     offset = criteria.extractValues(schemaMapping.schema(), record, offset);
-
-    // TODO: Key?
-    final String topic;
-    final Map<String, String> partition;
-    switch (mode) {
-      case TABLE:
-        String name = tableId.tableName();
-        topic = topicPrefix + name;// backward compatible
-        partition = OffsetProtocols.sourcePartitionForProtocolV1(tableId);
-        break;
-      case QUERY:
-        partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-                                             JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
-        topic = topicPrefix;
-        break;
-      default:
-        throw new ConnectException("Unexpected query mode: " + mode);
-    }
     return new SourceRecord(partition, offset.toMap(), topic, record.schema(), record);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -43,7 +43,7 @@ public class JdbcSourceTaskTestBase {
         SINGLE_TABLE_NAME
     );
     SINGLE_TABLE_PARTITION_WITH_VERSION.put(
-        JdbcSourceConnectorConstants.OFFSET_PROTOCOl_VERSION_KEY,
+        JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION_KEY,
         JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -34,9 +34,16 @@ public class JdbcSourceTaskTestBase {
 
   protected static String SINGLE_TABLE_NAME = "test";
   protected static Map<String, Object> SINGLE_TABLE_PARTITION = new HashMap<>();
+  protected static Map<String, Object> SINGLE_TABLE_PARTITION_WITH_VERSION = new HashMap<>();
 
   static {
     SINGLE_TABLE_PARTITION.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME);
+    SINGLE_TABLE_PARTITION_WITH_VERSION.put(
+        JdbcSourceConnectorConstants.TABLE_NAME_KEY,
+        SINGLE_TABLE_NAME);
+    SINGLE_TABLE_PARTITION_WITH_VERSION.put(
+        JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION,
+        "1");
   }
 
   protected static EmbeddedDerby.TableName SINGLE_TABLE

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -42,7 +42,7 @@ public class JdbcSourceTaskTestBase {
         JdbcSourceConnectorConstants.TABLE_NAME_KEY,
         SINGLE_TABLE_NAME);
     SINGLE_TABLE_PARTITION_WITH_VERSION.put(
-        JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION,
+        JdbcSourceConnectorConstants.OFFSET_PROTOCOl_VERSION_KEY,
         "1");
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.TableId;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
@@ -33,20 +34,11 @@ import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.Numeric
 public class JdbcSourceTaskTestBase {
 
   protected static String SINGLE_TABLE_NAME = "test";
-  protected static Map<String, Object> SINGLE_TABLE_PARTITION = new HashMap<>();
-  protected static Map<String, Object> SINGLE_TABLE_PARTITION_WITH_VERSION = new HashMap<>();
-
-  static {
-    SINGLE_TABLE_PARTITION.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME);
-    SINGLE_TABLE_PARTITION_WITH_VERSION.put(
-        JdbcSourceConnectorConstants.TABLE_NAME_KEY,
-        SINGLE_TABLE_NAME
-    );
-    SINGLE_TABLE_PARTITION_WITH_VERSION.put(
-        JdbcSourceConnectorConstants.OFFSET_PROTOCOL_VERSION_KEY,
-        JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
-    );
-  }
+  protected static TableId SINGLE_TABLE_ID = new TableId(null, null, SINGLE_TABLE_NAME);
+  protected static Map<String, String> SINGLE_TABLE_PARTITION =
+      OffsetProtocols.sourcePartitionForProtocolV0(SINGLE_TABLE_ID);
+  protected static Map<String, String> SINGLE_TABLE_PARTITION_WITH_VERSION =
+      OffsetProtocols.sourcePartitionForProtocolV1(SINGLE_TABLE_ID);
 
   protected static EmbeddedDerby.TableName SINGLE_TABLE
       = new EmbeddedDerby.TableName(SINGLE_TABLE_NAME);

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -40,10 +40,12 @@ public class JdbcSourceTaskTestBase {
     SINGLE_TABLE_PARTITION.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, SINGLE_TABLE_NAME);
     SINGLE_TABLE_PARTITION_WITH_VERSION.put(
         JdbcSourceConnectorConstants.TABLE_NAME_KEY,
-        SINGLE_TABLE_NAME);
+        SINGLE_TABLE_NAME
+    );
     SINGLE_TABLE_PARTITION_WITH_VERSION.put(
         JdbcSourceConnectorConstants.OFFSET_PROTOCOl_VERSION_KEY,
-        "1");
+        JdbcSourceConnectorConstants.PROTOCOL_VERSION_ONE
+    );
   }
 
   protected static EmbeddedDerby.TableName SINGLE_TABLE

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -322,17 +322,42 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testManualIncrementingRestoreOffset() throws Exception {
+  public void testManualIncrementingRestoreNoVersionOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    testManualIncrementingRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testManualIncrementingRestoreVersionOneOffset() throws Exception {
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    testManualIncrementingRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testManualIncrementingRestoreOffset() throws Exception {
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
+    offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    testManualIncrementingRestoreOffset(offsets);
+  }
+
+  private void testManualIncrementingRestoreOffset(
+      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
     expectInitialize(
         Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+        offsets
     );
 
     PowerMock.replayAll();
 
     db.createTable(SINGLE_TABLE_NAME,
-                   "id", "INT NOT NULL");
+        "id", "INT NOT NULL");
     db.insert(SINGLE_TABLE_NAME, "id", 1);
     db.insert(SINGLE_TABLE_NAME, "id", 2);
     db.insert(SINGLE_TABLE_NAME, "id", 3);
@@ -346,11 +371,37 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testAutoincrementRestoreOffset() throws Exception {
+  public void testAutoincrementRestoreNoVersionOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    testAutoincrementRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testAutoincrementRestoreVersionOneOffset() throws Exception {
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    testAutoincrementRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testAutoincrementRestoreOffset() throws Exception {
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
+    offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    testAutoincrementRestoreOffset(offsets);
+  }
+
+  private void testAutoincrementRestoreOffset(
+      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
+
     expectInitialize(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+        offsets
     );
 
     PowerMock.replayAll();
@@ -373,11 +424,37 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testTimestampRestoreOffset() throws Exception {
+  public void testTimestampRestoreNoVersionOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
+    testTimestampRestoreOffset(Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+  }
+
+  @Test
+  public void testTimestampRestoreVersionOneOffset() throws Exception {
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
+    testTimestampRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testTimestampRestore() throws Exception {
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(
+        new Timestamp(8L),
+        null
+    );
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
+    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
+    offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    testTimestampRestoreOffset(offsets);
+  }
+
+  private void testTimestampRestoreOffset(
+      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
     expectInitialize(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+        offsets
     );
 
     PowerMock.replayAll();
@@ -400,11 +477,36 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testTimestampAndIncrementingRestoreOffset() throws Exception {
+  public void testTimestampAndIncrementingRestoreNoVersionOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
+    testTimestampAndIncrementingRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testTimestampAndIncrementingRestoreVersionOneOffset() throws Exception {
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
+    testTimestampAndIncrementingRestoreOffset(
+        Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
+    );
+  }
+
+  @Test
+  public void testTimestampAndIncrementingRestoreOffset() throws Exception {
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(new Timestamp(10L), 2L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
+    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
+    offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    testTimestampAndIncrementingRestoreOffset(offsets);
+  }
+
+  private void testTimestampAndIncrementingRestoreOffset(
+      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
     expectInitialize(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+        offsets
     );
 
     PowerMock.replayAll();
@@ -427,6 +529,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
     PowerMock.verifyAll();
   }
+
 
   @Test
   public void testCustomQueryBulk() throws Exception {

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -356,8 +356,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
     PowerMock.replayAll();
 
-    db.createTable(SINGLE_TABLE_NAME,
-        "id", "INT NOT NULL");
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT NOT NULL");
     db.insert(SINGLE_TABLE_NAME, "id", 1);
     db.insert(SINGLE_TABLE_NAME, "id", 2);
     db.insert(SINGLE_TABLE_NAME, "id", 3);

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -341,14 +341,14 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testManualIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
     testManualIncrementingRestoreOffset(offsets);
   }
 
   private void testManualIncrementingRestoreOffset(
-      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
+      Map<Map<String, String>, Map<String, Object>> offsets) throws Exception {
     expectInitialize(
         Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
         offsets
@@ -389,14 +389,14 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testAutoincrementRestoreOffset() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
     testAutoincrementRestoreOffset(offsets);
   }
 
   private void testAutoincrementRestoreOffset(
-      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
+      Map<Map<String, String>, Map<String, Object>> offsets) throws Exception {
 
     expectInitialize(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
@@ -443,14 +443,14 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
         null
     );
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
-    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
     testTimestampRestoreOffset(offsets);
   }
 
   private void testTimestampRestoreOffset(
-      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
+      Map<Map<String, String>, Map<String, Object>> offsets) throws Exception {
     expectInitialize(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
         offsets
@@ -495,14 +495,14 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testTimestampAndIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(new Timestamp(10L), 2L);
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
-    Map<Map<String, Object>, Map<String, Object>> offsets = new HashMap<>();
+    Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
     testTimestampAndIncrementingRestoreOffset(offsets);
   }
 
   private void testTimestampAndIncrementingRestoreOffset(
-      Map<Map<String, Object>, Map<String, Object>> offsets) throws Exception {
+      Map<Map<String, String>, Map<String, Object>> offsets) throws Exception {
     expectInitialize(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
         offsets

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.DateTimeUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -34,8 +35,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import io.confluent.connect.jdbc.util.DateTimeUtils;
 
 import static org.junit.Assert.assertEquals;
 
@@ -88,9 +87,11 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test(expected = ConnectException.class)
   public void testIncrementingInvalidColumn() throws Exception {
-        expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION_WITH_VERSION, 
-        SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION)
+    );
+
 
     PowerMock.replayAll();
 
@@ -104,9 +105,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test(expected = ConnectException.class)
   public void testTimestampInvalidColumn() throws Exception {
-        expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION_WITH_VERSION, 
-        SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -122,7 +124,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testManualIncrementing() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION, 
-        SINGLE_TABLE_PARTITION));
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -146,7 +149,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testAutoincrement() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION,
-        SINGLE_TABLE_PARTITION));
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -173,7 +177,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testTimestamp() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION,
-        SINGLE_TABLE_PARTITION));
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -201,7 +206,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testMultiColumnTimestamp() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION,
-        SINGLE_TABLE_PARTITION));
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
     // Manage these manually so we can verify the emitted values
@@ -226,7 +232,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testTimestampWithDelay() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION,
-        SINGLE_TABLE_PARTITION));
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -263,7 +270,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testTimestampAndIncrementing() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
         SINGLE_TABLE_PARTITION_WITH_VERSION,
-        SINGLE_TABLE_PARTITION));
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -288,9 +296,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testMultiColumnTimestampAndIncrementing() throws Exception {
-        expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION_WITH_VERSION, 
-        SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
@@ -315,8 +324,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testManualIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-                     Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+    expectInitialize(
+        Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
 
     PowerMock.replayAll();
 
@@ -337,8 +348,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testAutoincrementRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-                     Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+    expectInitialize(Arrays.asList(
+        SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
 
     PowerMock.replayAll();
 
@@ -362,8 +375,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-                     Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+    expectInitialize(Arrays.asList(
+        SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
 
     PowerMock.replayAll();
 
@@ -387,8 +402,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampAndIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
-                     Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+    expectInitialize(Arrays.asList(
+        SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
+    );
 
     PowerMock.replayAll();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -88,7 +88,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test(expected = ConnectException.class)
   public void testIncrementingInvalidColumn() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+        expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION, 
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -102,7 +104,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test(expected = ConnectException.class)
   public void testTimestampInvalidColumn() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+        expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION, 
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -116,7 +120,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testManualIncrementing() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION, 
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -138,7 +144,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testAutoincrement() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION,
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -163,7 +171,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestamp() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION,
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -189,7 +199,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testMultiColumnTimestamp() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION,
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
     // Manage these manually so we can verify the emitted values
@@ -212,7 +224,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampWithDelay() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION,
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -247,7 +261,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampAndIncrementing() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION,
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -272,7 +288,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testMultiColumnTimestampAndIncrementing() throws Exception {
-    expectInitializeNoOffsets(Arrays.asList(SINGLE_TABLE_PARTITION));
+        expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION, 
+        SINGLE_TABLE_PARTITION_WITH_VERSION));
 
     PowerMock.replayAll();
 
@@ -297,7 +315,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testManualIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
@@ -319,7 +337,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testAutoincrementRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
@@ -344,7 +362,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
@@ -369,7 +387,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampAndIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -338,12 +338,13 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testManualIncrementingRestoreOffset() throws Exception {
+  public void testManualIncrementingRestoreOffsetsWithMultipleProtocol() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    //we want to always use the offset with the latest protocol found
     testManualIncrementingRestoreOffset(offsets);
   }
 
@@ -386,12 +387,13 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testAutoincrementRestoreOffset() throws Exception {
+  public void testAutoincrementRestoreOffsetsWithMultipleProtocol() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    //we want to always use the offset with the latest protocol found
     testAutoincrementRestoreOffset(offsets);
   }
 
@@ -437,7 +439,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testTimestampRestore() throws Exception {
+  public void testTimestampRestoreOffsetsWithMultipleProtocol() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(
         new Timestamp(8L),
         null
@@ -446,6 +448,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    //we want to always use the offset with the latest protocol found
     testTimestampRestoreOffset(offsets);
   }
 
@@ -492,12 +495,13 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testTimestampAndIncrementingRestoreOffset() throws Exception {
+  public void testTimestampAndIncrementingRestoreOffsetsWithMultipleProtocol() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(new Timestamp(10L), 2L);
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
+    //we want to always use the offset with the latest protocol found
     testTimestampAndIncrementingRestoreOffset(offsets);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -89,8 +89,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test(expected = ConnectException.class)
   public void testIncrementingInvalidColumn() throws Exception {
         expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION, 
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION, 
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -105,8 +105,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test(expected = ConnectException.class)
   public void testTimestampInvalidColumn() throws Exception {
         expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION, 
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION, 
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -121,8 +121,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testManualIncrementing() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION, 
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION, 
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -145,8 +145,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testAutoincrement() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION,
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -172,8 +172,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestamp() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION,
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -200,8 +200,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testMultiColumnTimestamp() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION,
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
     // Manage these manually so we can verify the emitted values
@@ -225,8 +225,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampWithDelay() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION,
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -262,8 +262,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampAndIncrementing() throws Exception {
     expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION,
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION,
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -289,8 +289,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testMultiColumnTimestampAndIncrementing() throws Exception {
         expectInitializeNoOffsets(Arrays.asList(
-        SINGLE_TABLE_PARTITION, 
-        SINGLE_TABLE_PARTITION_WITH_VERSION));
+        SINGLE_TABLE_PARTITION_WITH_VERSION, 
+        SINGLE_TABLE_PARTITION));
 
     PowerMock.replayAll();
 
@@ -315,7 +315,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testManualIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
@@ -337,7 +337,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testAutoincrementRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
@@ -362,7 +362,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();
@@ -387,7 +387,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestampAndIncrementingRestoreOffset() throws Exception {
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION, SINGLE_TABLE_PARTITION_WITH_VERSION),
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION_WITH_VERSION, SINGLE_TABLE_PARTITION),
                      Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
 
     PowerMock.replayAll();


### PR DESCRIPTION
With the dialect changes introduced in 5.0.x, the JDBCSourceTask always gets the table names as fully qualified table names. In the offset management, the connector was using the unqualified table name while writing the offsets and fully qualified table name for reading the offsets. Because of this when a connector restarts, it never finds the stored offsets and hence always starts from the beginning. This issue occurs only for TABLE mode.

The solution is to include a backward compatible offset management. We do the following

- Introduce a new offset protocol version. This will help evolve any changes to offsets in future.
- Offset writes will always follow new protocol version which is to include the FQN of the table
- During read, we include both the new protocol version offset key and the old one for all tables
- While selecting the offset, we always try the new protocol version key first followed by the old

This PR doesn't handle any changes to topic names. The topic names will continue to be unqualified table name to be backward compatible. If there are multiple tables, matching the intent is to error out and will be implemented in a separate PR. 