### PR TITLE
CC-2436: Test for method call to occur at least once

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -110,7 +110,7 @@ public class JdbcSourceConnectorTest {
     EasyMock.expect(conn.getMetaData()).andStubThrow(new SQLException());
     // Close will be invoked both for the SQLExeption and when the connector is stopped
     mockCachedConnectionProvider.closeQuietly();
-    PowerMock.expectLastCall().times(2);
+    PowerMock.expectLastCall().atLeastOnce();
 
     PowerMock.replayAll();
 


### PR DESCRIPTION
The first call to closeQuietly is guaranteed by the stop method. But the
second one will only happen if control reaches the updateTables() method
in TableMonitorThread. This can be skipped in cases where
TableMonitorThread's run() method detects a shutdown scenario to simply
exit and not poll the source table.

Signed-off-by: Arjun Satish <arjun@confluent.io>