### PR TITLE
Fix values(CURRENT_TIMESTAMP) not working on DB2 because invalid sql-…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialect.java
@@ -62,7 +62,7 @@ public class Db2DatabaseDialect extends GenericDatabaseDialect {
 
   @Override
   protected String currentTimestampDatabaseQuery() {
-    return "values(CURRENT_TIMESTAMP)";
+    return "SELECT CURRENT_TIMESTAMP FROM SYSIBM.SYSDUMMY1;";
   }
 
   @Override


### PR DESCRIPTION
…statement. Replace with select-statement of CURRENT_TIMESTAMP

See more information on https://github.com/confluentinc/kafka-connect-jdbc/issues/211
