### PR TITLE
DOCS-618 - Refactor Connect docs

### DIFF
--- a/docs/includes/prerequisites.rst
+++ b/docs/includes/prerequisites.rst
@@ -2,7 +2,7 @@
 
 **Prerequisites:**
 
-- :ref:`Confluent Platform <installation>` is installed and services are running by using the Confluent CLI. This quick start assumes that you are using the Confluent CLI, but standalone installations are also supported. By default ZooKeeper, Kafka, Schema Registry, Kafka Connect REST API, and Kafka Connect are started with the ``confluent start`` command. For more information, see :ref:`installation_archive`.
+- :ref:`Confluent Platform <installation>` is installed and services are running by using the Confluent CLI. This quick start assumes that you are using the Confluent CLI, but standalone installations are also supported. By default ZooKeeper, Kafka, Schema Registry, Kafka Connect REST API, and Kafka Connect are started with the ``confluent start`` command. For more information, see :ref:`installing_cp`.
 - `SQLite <https://sqlite.org/download.html>`_ is installed. You can also use another database. If you are using another database, be sure to adjust the ``connection.url`` setting. |CP| includes JDBC drivers for SQLite and PostgreSQL, but if you're using a different database you must also verify that the JDBC driver is available on the Kafka Connect process's ``CLASSPATH``.
 - Kafka and Schema Registry are running locally on the default ports.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,17 @@
 .. _connect_jdbc:
 
-Confluent JDBC Connector
-========================
+|kconnect-long| JDBC Connector
+==============================
+
+You can use the JDBC source connector to import data from any relational database with a JDBC driver into Kafka
+topics. You can use the JDBC sink connector to export data from Kafka topics to any relational database with a JDBC driver.
+The JDBC connector supports a wide variety of databases without requiring custom code for each one.
 
 Contents:
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
 
-   source_connector
-   source_config_options
-   sink_connector
-   sink_config_options
+   source-connector/index
+   sink-connector/index
    changelog

--- a/docs/sink-connector/index.rst
+++ b/docs/sink-connector/index.rst
@@ -1,5 +1,5 @@
-JDBC Sink Connector
-===================
+|kconnect-long| JDBC Sink Connector
+===================================
 
 The JDBC sink connector allows you to export data from Kafka topics to any relational database with a JDBC driver.
 By using JDBC, this connector can support a wide variety of databases without requiring a dedicated connector for each one.
@@ -7,16 +7,25 @@ The connector polls data from Kafka to write to the database based on the topics
 It is possible to achieve idempotent writes with upserts.
 Auto-creation of tables, and limited auto-evolution is also supported.
 
+.. contents:: Contents
+        :local:
+        :depth: 1
+
+Install JDBC Sink Connector
+---------------------------
+
+.. include:: ../../../../includes/connector-native-install.rst
+
 Quick Start
 -----------
 
-.. include:: includes/prerequisites.rst
+To see the basic functionality of the connector, we'll be copying Avro data from a single topic to a local SQLite database.
+
+.. include:: ../includes/prerequisites.rst
         :start-line: 2
         :end-line: 8
 
-To see the basic functionality of the connector, we'll be copying Avro data from a single topic to a local SQLite database.
-
-.. include:: includes/prerequisites.rst
+.. include:: ../includes/prerequisites.rst
     :start-line: 11
     :end-line: 45
 
@@ -109,16 +118,18 @@ Produce a Record in SQLite
 Features
 --------
 
+------------
 Data mapping
-^^^^^^^^^^^^
+------------
 
 The sink connector requires knowledge of schemas, so you should use a suitable converter e.g. the Avro converter that comes with the schema registry, or the JSON converter with schemas enabled.
 Kafka record keys if present can be primitive types or a Connect struct, and the record value must be a Connect struct.
 Fields being selected from Connect structs must be of primitive types.
 If the data in the topic is not of a compatible format, implementing a custom ``Converter`` may be necessary.
 
+------------
 Key handling
-^^^^^^^^^^^^
+------------
 
 The default is for primary keys to not be extracted with ``pk.mode`` set to `none`,
 which is not suitable for advanced usage such as upsert semantics and when the connector is responsible for auto-creating the destination table.
@@ -126,8 +137,9 @@ There are different modes that enable to use fields from the Kafka record key, t
 
 Refer to :ref:`primary key configuration options <sink-pk-config-options>` for further detail.
 
+-----------------
 Idempotent writes
-^^^^^^^^^^^^^^^^^
+-----------------
 
 The default ``insert.mode`` is `insert`. If it is configured as `upsert`, the connector will use upsert semantics rather than plain `INSERT` statements.
 Upsert semantics refer to atomically adding a new row or updating the existing row if there is a primary key constraint violation, which provides idempotence.
@@ -150,14 +162,15 @@ SQL Server      `MERGE ..`
 Other           *not supported*
 ===========     ================================================
 
+-------------------------------
 Auto-creation and Auto-evoluton
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------
 
 .. tip:: Make sure the JDBC user has the appropriate permissions for DDL.
 
 If ``auto.create`` is enabled, the connector can `CREATE` the destination table if it is found to be missing.
 The creation takes place online with records being consumed from the topic, since the connector uses the record schema as a basis for the table definition.
-Primary keys are specified based on the key configuration settings.
+Primary keys are specified based on the key :ref:`configuration settings <sink-config-options>`.
 
 If ``auto.evolve`` is enabled, the connector can perform limited auto-evolution by issuing `ALTER` on the destination table when it encounters a record for which a column is found to be missing.
 Since data-type changes and removal of columns can be dangerous, the connector does not attempt to perform such evolutions on the table.
@@ -201,4 +214,11 @@ Auto-creation or auto-evolution is not supported for databases not mentioned her
 
 .. important::
     For backwards-compatible table schema evolution, new fields in record schemas must be optional or have a default value.
-    If you need to delete a field, the table schema should be manually altered to either drop the corresponding column, assign it a default value, or make it nullable.
+    If you need to delete a field, the table schema should be manually altered to either drop the corresponding column, assign
+    it a default value, or make it nullable.
+
+
+.. toctree::
+        :maxdepth: 1
+
+        sink_config_options

--- a/docs/sink-connector/sink_config_options.rst
+++ b/docs/sink-connector/sink_config_options.rst
@@ -3,7 +3,10 @@
 JDBC Sink Configuration Options
 -------------------------------
 
-.. include:: includes/db_connection_security.rst
+.. contents:: Contents
+    :local:
+
+.. include:: ../includes/db_connection_security.rst
 
 Connection
 ^^^^^^^^^^
@@ -66,6 +69,8 @@ Writes
   * Default: 3000
   * Valid Values: [0,...]
   * Importance: medium
+
+.. _sink-pk-config-options:
 
 Data Mapping
 ^^^^^^^^^^^^

--- a/docs/source-connector/index.rst
+++ b/docs/source-connector/index.rst
@@ -1,5 +1,5 @@
-JDBC Source Connector
-=====================
+|kconnect-long| JDBC Source Connector
+=====================================
 
 The JDBC source connector allows you to import data from any relational database with a
 JDBC driver into Kafka topics. By using JDBC, this connector can support a wide variety of
@@ -11,10 +11,18 @@ The database is monitored for new or deleted tables and adapts automatically. Wh
 from a table, the connector can load only new or modified rows by specifying which columns should
 be used to detect new or modified data.
 
-.. include:: ../../../includes/connect-streams-pipeline-link.rst
+.. contents::
+    :local:
+    :depth: 1
+
+.. include:: ../../../../includes/connect-streams-pipeline-link.rst
    :start-line: 2
    :end-line: 6
 
+Install JDBC Source Connector
+-----------------------------
+
+.. include:: ../../../../includes/connector-native-install.rst
 
 Quick Start
 -----------
@@ -23,11 +31,11 @@ To see the basic functionality of the connector, you'll copy a single table from
 database. In this quick start, you can assume each entry in the table is assigned a unique ID
 and is not modified after creation.
 
-.. include:: includes/prerequisites.rst
+.. include:: ../includes/prerequisites.rst
     :start-line: 2
     :end-line: 8
 
-.. include:: includes/prerequisites.rst
+.. include:: ../includes/prerequisites.rst
     :start-line: 11
     :end-line: 45
 
@@ -144,8 +152,9 @@ location on the next iteration (or in case of a crash). The source connector use
 functionality to only get updated rows from a table (or from the output of a custom query) on each
 iteration. Several modes are supported, each of which differs in how modified rows are detected.
 
+-----------------------
 Incremental Query Modes
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 Each incremental query mode tracks a set of columns for each row, which it uses to keep track of
 which rows have been processed and which rows are new or have been updated. The ``mode`` setting
@@ -188,10 +197,11 @@ indexes on those columns to efficiently perform the queries.
 For incremental query modes that use timestamps, the source connector uses a configuration
 ``timestamp.delay.interval.ms`` to control the waiting period after a row with certain timestamp appears
 before you include it in the result. The additional wait allows transactions with earlier timestamps
-to complete and the related changes to be included in the result.
+to complete and the related changes to be included in the result. For more information, see :ref:`jdbc-source-configs`.
 
+--------------------
 Mapping Column Types
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 The source connector has a few options for controlling how column types are mapped into
 Connect field types. By default, the connector maps SQL/JDBC types to the most accurate
@@ -216,6 +226,7 @@ Precision    Scale      Connect "best fit" primitive type
 5 to 9       -84 to 0   INT32
 10 to 18     -84 to 0   INT64
 1 to 18      positive   FLOAT64
+============ ========== =================================
 
 The ``precision_only`` option attempts to map ``NUMERIC`` columns to
 Connect ``INT8``, ``INT16``, ``INT32``, and ``INT64`` based only upon the column's precision,
@@ -228,13 +239,14 @@ Precision    Scale      Connect "best fit" primitive type
 3 to 4       0          INT16
 5 to 9       0          INT32
 10 to 18     0          INT64
+============ ========== =================================
 
 Any other combination of precision and scale for ``NUMERIC`` columns will always map to
 Connect's ``Decimal`` type.
 
 .. note:: The ``numeric.precision.mapping`` property is older and is now deprecated. When
-enabled it is exactly equivalent to ``numeric.mapping=precision_only``, and when not enabled it
-is exactly equivalent to ``numeric.mapping=none``.
+          enabled it is exactly equivalent to ``numeric.mapping=precision_only``, and when not enabled it
+          is exactly equivalent to ``numeric.mapping=none``.
 
 Configuration
 -------------
@@ -242,10 +254,11 @@ Configuration
 The source connector gives you quite a bit of flexibility in the databases you can import data from
 and how that data is imported. This section first describes how to access databases whose drivers
 are not included with Confluent Platform, then gives a few example configuration files that cover
-common scenarios, then provides an exhaustive description of the available configuration options.
+common scenarios, then provides an :ref:`exhaustive description of the available configuration options <jdbc-source-configs>`.
 
+------------
 JDBC Drivers
-~~~~~~~~~~~~
+------------
 
 The source connector implements the data copying functionality on the generic JDBC APIs, but relies
 on JDBC drivers to handle the database-specific implementation of those APIs. Confluent Platform
@@ -268,10 +281,11 @@ would add the JDBC driver for the Firebird database, located in ``/usr/local/fir
 you to use JDBC connection URLs like
 ``jdbc:firebirdsql:localhost/3050:/var/lib/firebird/example.db``.
 
+--------
 Examples
-~~~~~~~~
+--------
 
-The full set of configuration options are listed in the next section, but here are a few
+The full set of configuration options are listed in :ref:`jdbc-source-configs`, but here are a few
 template configurations that cover some common usage scenarios.
 
 Use a whitelist to limit changes to a subset of tables in a MySQL database, using ``id`` and
@@ -349,3 +363,8 @@ backward, forward and full to ensure that the Hive schema is able to query the w
 topic. As some compatible schema change will be treated as incompatible schema change, those
 changes will not work as the resulting Hive schema will not be able to query the whole data for a
 topic.
+
+.. toctree::
+        :maxdepth: 1
+
+        source_config_options

--- a/docs/source-connector/source_config_options.rst
+++ b/docs/source-connector/source_config_options.rst
@@ -1,7 +1,9 @@
+.. _jdbc-source-configs:
+
 JDBC Source Configuration Options
 ---------------------------------
 
-.. include:: includes/db_connection_security.rst
+.. include:: ../includes/db_connection_security.rst
 
 Database
 ^^^^^^^^


### PR DESCRIPTION
- simplifies doc design by moving the child sink_connector.rst and source_connector.rst  pages contents to their own subfolders.
- moved config_options. rst files to the respective subfolders
- added include which points to shared connector install include for reuse across all connectors.
- adds text string replace for common terms (e.g. Kafka Connect)
- changes titles to match naming shown at https://www.confluent.io/hub/#
- redirect added here https://github.com/confluentinc/docs/pull/1146/