### PR TITLE
Add support for uuid columns

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -1142,41 +1141,21 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         builder.field(fieldName, tsSchemaBuilder.build());
         break;
       }
-      case Types.OTHER: {
-        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
-          builder.field(
-                  fieldName,
-                  columnDefn.isOptional()
-                          ?
-                          Schema.OPTIONAL_STRING_SCHEMA :
-                          Schema.STRING_SCHEMA
-          );
-          return fieldName;
-        } else {
-          logJdbcTypeNotSupported(columnDefn, sqlType);
-          return null;
-        }
-      }
+
       case Types.ARRAY:
       case Types.JAVA_OBJECT:
+      case Types.OTHER:
       case Types.DISTINCT:
       case Types.STRUCT:
       case Types.REF:
       case Types.ROWID:
       default: {
-        logJdbcTypeNotSupported(columnDefn, sqlType);
+        log.warn("JDBC type {} ({}) not currently supported", sqlType, columnDefn.typeName());
         return null;
       }
     }
     return fieldName;
   }
-
-  private void logJdbcTypeNotSupported(ColumnDefinition columnDefn, int sqlType) {
-    if (log.isWarnEnabled()) {
-      log.warn("JDBC type {} ({}) not currently supported", sqlType, columnDefn.typeName());
-    }
-  }
-
 
   @Override
   public void applyDdlStatements(
@@ -1418,16 +1397,10 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         };
       }
 
-      case Types.OTHER: {
-        if (UUID.class.getName().equals(defn.classNameForType())) {
-          return rs -> rs.getString(col);
-        }
-        break;
-      }
-
       case Types.NULL:
       case Types.ARRAY:
       case Types.JAVA_OBJECT:
+      case Types.OTHER:
       case Types.DISTINCT:
       case Types.STRUCT:
       case Types.REF:

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -31,6 +31,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
+import java.util.UUID;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -130,6 +131,18 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           );
           return fieldName;
         }
+
+        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
+          builder.field(
+                  fieldName,
+                  columnDefn.isOptional()
+                          ?
+                          Schema.OPTIONAL_STRING_SCHEMA :
+                          Schema.STRING_SCHEMA
+          );
+          return fieldName;
+        }
+
         break;
       }
       default:
@@ -165,6 +178,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       }
       case Types.OTHER: {
         if (isJsonType(columnDefn)) {
+          return rs -> rs.getString(col);
+        }
+
+        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
           return rs -> rs.getString(col);
         }
         break;

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
@@ -17,32 +17,24 @@ package io.confluent.connect.jdbc.dialect;
 
 import java.math.BigDecimal;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Types;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
-import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.TableId;
 
-import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Time;
-import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,7 +53,6 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
   public static final short SHORT = Short.MAX_VALUE;
   public static final byte BYTE = Byte.MAX_VALUE;
   public static final double DOUBLE = Double.MAX_VALUE;
-  public static final String UUID_VALUE = "8A52DFE1-CFB9-4C55-B74F-E3D56BBED827";
 
   @Parameterized.Parameter(0)
   public Schema.Type expectedType;
@@ -83,9 +74,6 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
 
   @Parameterized.Parameter(6)
   public int scale;
-
-  @Parameterized.Parameter(7)
-  public String classNameForType;
 
   @Mock
   ResultSet resultSet = mock(ResultSet.class);
@@ -113,7 +101,6 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
     when(columnDefn.id()).thenReturn(COLUMN_ID);
     when(columnDefn.isSignedNumber()).thenReturn(signed);
     when(columnDefn.typeName()).thenReturn("parameterizedType");
-    when(columnDefn.classNameForType()).thenReturn(classNameForType);
 
     dialect = createDialect();
     schemaBuilder = SchemaBuilder.struct();

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
@@ -18,15 +18,8 @@ package io.confluent.connect.jdbc.dialect;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.sql.Types;
+import java.util.*;
 
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -68,6 +61,7 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
   public static final short SHORT = Short.MAX_VALUE;
   public static final byte BYTE = Byte.MAX_VALUE;
   public static final double DOUBLE = Double.MAX_VALUE;
+  public static final String UUID_VALUE = "8A52DFE1-CFB9-4C55-B74F-E3D56BBED827";
 
   @Parameterized.Parameter(0)
   public Schema.Type expectedType;
@@ -90,6 +84,9 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
   @Parameterized.Parameter(6)
   public int scale;
 
+  @Parameterized.Parameter(7)
+  public String classNameForType;
+
   @Mock
   ResultSet resultSet = mock(ResultSet.class);
 
@@ -108,7 +105,7 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
 
   @SuppressWarnings("deprecation")
   @Test
-  public void testValueConversionOnNumeric() throws Exception {
+  public void testValueConversion() throws Exception {
     when(columnDefn.precision()).thenReturn(precision);
     when(columnDefn.scale()).thenReturn(scale);
     when(columnDefn.type()).thenReturn(columnType);
@@ -116,6 +113,7 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
     when(columnDefn.id()).thenReturn(COLUMN_ID);
     when(columnDefn.isSignedNumber()).thenReturn(signed);
     when(columnDefn.typeName()).thenReturn("parameterizedType");
+    when(columnDefn.classNameForType()).thenReturn(classNameForType);
 
     dialect = createDialect();
     schemaBuilder = SchemaBuilder.struct();
@@ -137,6 +135,10 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
     when(resultSet.getShort(1)).thenReturn(SHORT);
     when(resultSet.getByte(1)).thenReturn(BYTE);
     when(resultSet.getDouble(1)).thenReturn(DOUBLE);
+
+    if (expectedValue instanceof String) {
+      when(resultSet.getString(1)).thenReturn((String)expectedValue);
+    }
 
     // Check the converter operates correctly
     ColumnMapping mapping = new ColumnMapping(columnDefn, 1, field);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTypeTest.java
@@ -17,7 +17,6 @@ package io.confluent.connect.jdbc.dialect;
 
 import java.sql.Types;
 import java.util.Arrays;
-import java.util.UUID;
 
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 
@@ -34,70 +33,65 @@ public class GenericDatabaseDialectTypeTest extends BaseDialectTypeTest<GenericD
         new Object[][] {
             // MAX_VALUE means this value doesn't matter
             // Parameter range 1-4
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127 },
 
             // integers - non optional
             // Parameter range 5-8
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 0, null },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 0, null},
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, 0, null},
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, 0, null},
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 0 },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 0 },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, 0 },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, 0 },
 
             // integers - optional
             // Parameter range 9-12
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 0, null },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 0, null },
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, 0, null },
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, 0, null },
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 0 },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 0 },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, 0 },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, 0 },
 
             // scale != 0 - non optional
             // Parameter range 13-16
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, -1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, -1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, -1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, -1 },
 
             // scale != 0 - optional
             // Parameter range 17-20
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, -1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, -1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, -1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, -1 },
 
             // integers - non optional
             // Parameter range 21-25
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, -1, null },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, -1, null },
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 3, 0, null },
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 1, 0, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, -1, null },
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, -1 },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, -1 },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 3, 0 },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 1, 0 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, -1 },
 
             // integers - optional
             // Parameter range 26-30
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, -1, null },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, -1, null },
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 3, 0, null },
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 1, 0, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, -1, null },
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, -1 },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, -1 },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 3, 0 },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 1, 0 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, -1 },
 
             // floating point - fitting - non optional
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, 127, null },
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, 1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, 1, null },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, 127 },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, 1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, 1 },
 
             // floating point - fitting - optional
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, 127, null },
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, 1, null },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, 1, null },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, 127 },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, 1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, 1 },
 
-            // UUID - non optional
-            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
-
-            // UUID - optional
-            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
             }
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTypeTest.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.dialect;
 
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.UUID;
 
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 
@@ -33,64 +34,70 @@ public class GenericDatabaseDialectTypeTest extends BaseDialectTypeTest<GenericD
         new Object[][] {
             // MAX_VALUE means this value doesn't matter
             // Parameter range 1-4
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, 0, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.NUMERIC, Integer.MAX_VALUE, -127, null },
 
             // integers - non optional
             // Parameter range 5-8
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 0 },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 0,},
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, 0,},
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, 0,},
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 0, null },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 0, null},
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, 0, null},
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, 0, null},
 
             // integers - optional
             // Parameter range 9-12
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 0 },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 0 },
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, 0 },
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, 0 },
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 0, null },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 0, null },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, 0, null },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, 0, null },
 
             // scale != 0 - non optional
             // Parameter range 13-16
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, -1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, -1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 18, 1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 8, 1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 3, -1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NOT_NULLABLE, Types.NUMERIC, 1, -1, null },
 
             // scale != 0 - optional
             // Parameter range 17-20
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, -1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, -1 },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 18, 1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 8, 1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 3, -1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.PRECISION_ONLY, NULLABLE, Types.NUMERIC, 1, -1, null },
 
             // integers - non optional
             // Parameter range 21-25
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, -1 },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, -1 },
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 3, 0 },
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 1, 0 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, -1 },
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, -1, null },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, -1, null },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 3, 0, null },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 1, 0, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, -1, null },
 
             // integers - optional
             // Parameter range 26-30
-            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, -1 },
-            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, -1 },
-            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 3, 0 },
-            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 1, 0 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, -1 },
+            {Schema.Type.INT64, LONG, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, -1, null },
+            {Schema.Type.INT32, INT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, -1, null },
+            {Schema.Type.INT16, SHORT, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 3, 0, null },
+            {Schema.Type.INT8, BYTE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 1, 0, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, -1, null },
 
             // floating point - fitting - non optional
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, 127 },
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, 1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, 1 },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 18, 127, null },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 8, 1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NOT_NULLABLE, Types.NUMERIC, 19, 1, null },
 
             // floating point - fitting - optional
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, 127 },
-            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, 1 },
-            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, 1 },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 18, 127, null },
+            {Schema.Type.FLOAT64, DOUBLE, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 8, 1, null },
+            {Schema.Type.BYTES, BIG_DECIMAL, JdbcSourceConnectorConfig.NumericMapping.BEST_FIT, NULLABLE, Types.NUMERIC, 19, 1, null },
+
+            // UUID - non optional
+            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
+
+            // UUID - optional
+            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
             }
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTypeTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class PostgreSqlDatabaseDialectTypeTest extends BaseDialectTypeTest<PostgreSqlDatabaseDialect> {
+
+  public static final String UUID_VALUE = "8A52DFE1-CFB9-4C55-B74F-E3D56BBED827";
+
+  @Parameterized.Parameter(7)
+  public String classNameForType;
+
+  @Parameterized.Parameters
+  public static Iterable<Object[]> mapping() {
+    return Arrays.asList(
+        new Object[][] {
+            // UUID - non optional
+            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NOT_NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
+
+            // UUID - optional
+            {Schema.Type.STRING, UUID_VALUE, JdbcSourceConnectorConfig.NumericMapping.NONE, NULLABLE, Types.OTHER, 0, 0, UUID.class.getName() },
+        }
+    );
+  }
+
+  @Override
+  protected PostgreSqlDatabaseDialect createDialect() {
+    return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:some:db"));
+  }
+
+  @Override
+  public void testValueConversion() throws Exception {
+    when(columnDefn.classNameForType()).thenReturn(classNameForType);
+
+    super.testValueConversion();
+  }
+}


### PR DESCRIPTION
This PR adds support for uuid columns in the `GenericDatabaseDialect`. It works by checking the classNameForType property of the ColumnDefinition. If the JDBC driver supports UUIDs, like the PostgreSQL driver does, and classNameForType of a column matches `java.util.UUID` then the `JdbcSourceConnector` reads the column value simply as a String, because Kafka Connect does not support a logical type for UUIDs at the moment: https://issues.apache.org/jira/browse/KAFKA-4353

Related issue: https://github.com/confluentinc/kafka-connect-jdbc/issues/81