### PR TITLE
MINOR: Tweak Kafka Connect Maven Plugin details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <confluent.version>${project.version}</confluent.version>
         <derby.version>10.11.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
+        <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
         <postgresql.version>9.4-1206-jdbc41</postgresql.version>
         <licenses.name>Apache License 2.0</licenses.name>
@@ -144,7 +145,7 @@
         <plugins>
             <plugin>
                 <groupId>io.confluent</groupId>
-                <version>0.10.0</version>
+                <version>${kafka.connect.maven.plugin.version}</version>
                 <artifactId>kafka-connect-maven-plugin</artifactId>
                 <executions>
                     <execution>
@@ -153,7 +154,7 @@
                         </goals>
                         <configuration>
                             <title>Kafka Connect JDBC</title>
-                            <documentationUrl>https://docs.confluent.io/current/connect/connect-jdbc/docs/index.html</documentationUrl>
+                            <documentationUrl>https://docs.confluent.io/${project.version}/connect/connect-jdbc/docs/index.html</documentationUrl>
                             <description>
                                 The JDBC source connector allows you to import data from any relational database with a JDBC driver into Kafka topics. By using JDBC, this connector can support a wide variety of databases without requiring custom code for each one.
 


### PR DESCRIPTION
This will align the configuration for the Kafka Connect Maven Plugin with the configuration proposed in https://github.com/confluentinc/kafka-connect-jdbc/pull/499; otherwise, future 4.0.x, 4.1.x, and 5.0.x releases wouldn't contain the changes included in there as well.