### PR TITLE
Added db.timezone setting 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <derby.version>10.11.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>9.4-1206-jdbc41</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <licenses.name>Apache License 2.0</licenses.name>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <derby.version>10.11.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
         <postgresql.version>9.4-1206-jdbc41</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <licenses.name>Apache License 2.0</licenses.name>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -16,6 +16,8 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.data.Date;
@@ -132,6 +134,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();
   private final Queue<Connection> connections = new ConcurrentLinkedQueue<>();
   private volatile JdbcDriverInfo jdbcDriverInfo;
+  private final TimeZone timeZone;
 
   /**
    * Create a new dialect instance with the given connector configuration.
@@ -169,6 +172,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       mapNumerics = ((JdbcSourceConnectorConfig)config).numericMapping();
     } else {
       mapNumerics = NumericMapping.NONE;
+    }
+
+    if (config instanceof JdbcSourceConnectorConfig) {
+      timeZone = ((JdbcSourceConnectorConfig) config).timeZone();
+    } else if (config instanceof JdbcSinkConfig) {
+      timeZone = ((JdbcSinkConfig) config).timeZone;
+    } else {
+      timeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
     }
   }
 
@@ -813,7 +824,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       ColumnId incrementingColumn,
       List<ColumnId> timestampColumns
   ) {
-    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns);
+    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns, timeZone);
   }
 
   /**
@@ -1198,19 +1209,19 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         return rs -> rs.getBytes(col);
       }
 
-      // Date is day + moth + year
+      // Date is day + month + year
       case Types.DATE: {
-        return rs -> rs.getDate(col, DateTimeUtils.UTC_CALENDAR.get());
+        return rs -> rs.getDate(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Time is a time of day -- hour, minute, seconds, nanoseconds
       case Types.TIME: {
-        return rs -> rs.getTime(col, DateTimeUtils.UTC_CALENDAR.get());
+        return rs -> rs.getTime(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Timestamp is a date + time
       case Types.TIMESTAMP: {
-        return rs -> rs.getTimestamp(col, DateTimeUtils.UTC_CALENDAR.get());
+        return rs -> rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Datalink is basically a URL -> string
@@ -1479,7 +1490,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           statement.setDate(
               index,
               new java.sql.Date(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         case Decimal.LOGICAL_NAME:
@@ -1489,14 +1500,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           statement.setTime(
               index,
               new java.sql.Time(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME:
           statement.setTimestamp(
               index,
               new java.sql.Timestamp(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         default:
@@ -1638,13 +1649,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           builder.append(value);
           return;
         case Date.LOGICAL_NAME:
-          builder.appendStringQuoted(DateTimeUtils.formatUtcDate((java.util.Date) value));
+          builder.appendStringQuoted(DateTimeUtils.formatDate((java.util.Date) value, timeZone));
           return;
         case Time.LOGICAL_NAME:
-          builder.appendStringQuoted(DateTimeUtils.formatUtcTime((java.util.Date) value));
+          builder.appendStringQuoted(DateTimeUtils.formatTime((java.util.Date) value, timeZone));
           return;
         case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME:
-          builder.appendStringQuoted(DateTimeUtils.formatUtcTimestamp((java.util.Date) value));
+          builder
+              .appendStringQuoted(DateTimeUtils.formatTimestamp((java.util.Date) value, timeZone));
           return;
         default:
           // fall through to regular types

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1655,8 +1655,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           builder.appendStringQuoted(DateTimeUtils.formatTime((java.util.Date) value, timeZone));
           return;
         case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME:
-          builder
-              .appendStringQuoted(DateTimeUtils.formatTimestamp((java.util.Date) value, timeZone));
+          builder.appendStringQuoted(
+              DateTimeUtils.formatTimestamp((java.util.Date) value, timeZone)
+          );
           return;
         default:
           // fall through to regular types

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -193,8 +193,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public static final String DB_TIMEZONE_CONFIG = "db.timezone";
   public static final String DB_TIMEZONE_DEFAULT = "UTC";
   private static final String DB_TIMEZONE_CONFIG_DOC =
-      "Name of the timezone that should be used in the connector when "
-      + "specifying time-based criteria. Defaults to UTC.";
+      "Name of the JDBC timezone that should be used in the connector when "
+      + "inserting time-based values. Defaults to UTC.";
   private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB Time Zone";
 
   public static final ConfigDef CONFIG_DEF = new ConfigDef()

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -16,6 +16,9 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -239,6 +242,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + " from the last time we fetched until current time minus the delay.";
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
+
+  public static final String DB_TIMEZONE_CONFIG = "db.timezone";
+  public static final String DB_TIMEZONE_DEFAULT = "UTC";
+  private static final String DB_TIMEZONE_CONFIG_DOC =
+      "Alternative TimeZone of the database, to be used by JDBC driver instead of UTC (default)"
+          + "when instantiating PreparedStatements.";
+  private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
+
 
   public static final String DATABASE_GROUP = "Database";
   public static final String MODE_GROUP = "Mode";
@@ -537,7 +548,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         CONNECTOR_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);
+        TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY
+    ).define(
+        DB_TIMEZONE_CONFIG,
+        Type.STRING,
+        DB_TIMEZONE_DEFAULT,
+        Importance.HIGH,
+        DB_TIMEZONE_CONFIG_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        DB_TIMEZONE_CONFIG_DISPLAY);
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();
@@ -758,6 +779,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public NumericMapping numericMapping() {
     return NumericMapping.get(this);
+  }
+
+  public TimeZone timeZone() {
+    String dbTimeZone = getString(JdbcSourceTaskConfig.DB_TIMEZONE_CONFIG);
+    return dbTimeZone == null ? TimeZone.getTimeZone(ZoneOffset.UTC) :
+        TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -246,8 +246,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String DB_TIMEZONE_CONFIG = "db.timezone";
   public static final String DB_TIMEZONE_DEFAULT = "UTC";
   private static final String DB_TIMEZONE_CONFIG_DOC =
-      "Alternative TimeZone of the database, to be used by JDBC driver instead of UTC (default)"
-          + "when instantiating PreparedStatements.";
+      "Name of the JDBC timezone that should be used in the connector when "
+      + "querying with time-based criteria. Defaults to UTC.";
   private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
 
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -16,9 +16,28 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.dialect.DatabaseDialects;
+import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
+import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.TimeZoneValidator;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -29,25 +48,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
-import io.confluent.connect.jdbc.dialect.DatabaseDialects;
-import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
-import io.confluent.connect.jdbc.util.TableId;
 
 public class JdbcSourceConnectorConfig extends AbstractConfig {
 
@@ -553,7 +553,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         DB_TIMEZONE_CONFIG,
         Type.STRING,
         DB_TIMEZONE_DEFAULT,
-        Importance.HIGH,
+        TimeZoneValidator.INSTANCE,
+        Importance.MEDIUM,
         DB_TIMEZONE_CONFIG_DOC,
         CONNECTOR_GROUP,
         ++orderInGroup,
@@ -783,8 +784,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public TimeZone timeZone() {
     String dbTimeZone = getString(JdbcSourceTaskConfig.DB_TIMEZONE_CONFIG);
-    return dbTimeZone == null ? TimeZone.getTimeZone(ZoneOffset.UTC) :
-        TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
+    return TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.TimeZone;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -144,6 +145,7 @@ public class JdbcSourceTask extends SourceTask {
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+    TimeZone timeZone = config.timeZone();
 
     for (String tableOrQuery : tablesOrQuery) {
       final List<Map<String, String>> tablePartitionsToCheck;
@@ -201,7 +203,8 @@ public class JdbcSourceTask extends SourceTask {
                 null,
                 incrementingColumn,
                 offset,
-                timestampDelayInterval
+                timestampDelayInterval,
+                timeZone
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -214,7 +217,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampColumns,
                 null,
                 offset,
-                timestampDelayInterval
+                timestampDelayInterval,
+                timeZone
             )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -227,7 +231,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampColumns,
                 incrementingColumn,
                 offset,
-                timestampDelayInterval
+                timestampDelayInterval,
+                timeZone
             )
         );
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -69,15 +70,18 @@ public class TimestampIncrementingCriteria {
   protected final Logger log = LoggerFactory.getLogger(getClass());
   protected final List<ColumnId> timestampColumns;
   protected final ColumnId incrementingColumn;
+  protected final TimeZone timeZone;
 
 
   public TimestampIncrementingCriteria(
       ColumnId incrementingColumn,
-      List<ColumnId> timestampColumns
+      List<ColumnId> timestampColumns,
+      TimeZone timeZone
   ) {
     this.timestampColumns =
         timestampColumns != null ? timestampColumns : Collections.<ColumnId>emptyList();
     this.incrementingColumn = incrementingColumn;
+    this.timeZone = timeZone;
   }
 
   protected boolean hasTimestampColumns() {
@@ -131,14 +135,14 @@ public class TimestampIncrementingCriteria {
     Timestamp beginTime = values.beginTimetampValue();
     Timestamp endTime = values.endTimetampValue();
     Long incOffset = values.lastIncrementedValue();
-    stmt.setTimestamp(1, endTime, DateTimeUtils.UTC_CALENDAR.get());
-    stmt.setTimestamp(2, beginTime, DateTimeUtils.UTC_CALENDAR.get());
+    stmt.setTimestamp(1, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    stmt.setTimestamp(2, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setLong(3, incOffset);
-    stmt.setTimestamp(4, beginTime, DateTimeUtils.UTC_CALENDAR.get());
+    stmt.setTimestamp(4, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     log.debug(
         "Executing prepared statement with start time value = {} end time = {} and incrementing"
-        + " value = {}", DateTimeUtils.formatUtcTimestamp(beginTime),
-        DateTimeUtils.formatUtcTimestamp(endTime), incOffset
+        + " value = {}", DateTimeUtils.formatTimestamp(beginTime, timeZone),
+        DateTimeUtils.formatTimestamp(endTime, timeZone), incOffset
     );
   }
 
@@ -157,10 +161,11 @@ public class TimestampIncrementingCriteria {
   ) throws SQLException {
     Timestamp beginTime = values.beginTimetampValue();
     Timestamp endTime = values.endTimetampValue();
-    stmt.setTimestamp(1, beginTime, DateTimeUtils.UTC_CALENDAR.get());
-    stmt.setTimestamp(2, endTime, DateTimeUtils.UTC_CALENDAR.get());
+    stmt.setTimestamp(1, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    stmt.setTimestamp(2, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     log.debug("Executing prepared statement with timestamp value = {} end time = {}",
-              DateTimeUtils.formatUtcTimestamp(beginTime), DateTimeUtils.formatUtcTimestamp(endTime)
+        DateTimeUtils.formatTimestamp(beginTime, timeZone),
+        DateTimeUtils.formatTimestamp(endTime, timeZone)
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -20,56 +20,52 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 
 public class DateTimeUtils {
 
-  public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+  private static final ThreadLocal<Map<TimeZone, Calendar>> TIMEZONE_CALENDARS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  public static final ThreadLocal<Calendar> UTC_CALENDAR = new ThreadLocal<Calendar>() {
-    @Override
-    protected Calendar initialValue() {
-      return new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-    }
-  };
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_DATE_FORMATS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  private static final ThreadLocal<SimpleDateFormat> UTC_DATE_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIME_FORMATS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  private static final ThreadLocal<SimpleDateFormat> UTC_TIME_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIMESTAMP_FORMATS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  private static final ThreadLocal<SimpleDateFormat> UTC_TIMESTAMP_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
-
-  public static String formatUtcDate(Date date) {
-    return UTC_DATE_FORMAT.get().format(date);
+  public static Calendar getTimeZoneCalendar(final TimeZone timeZone) {
+    return TIMEZONE_CALENDARS.get().computeIfAbsent(timeZone, GregorianCalendar::new);
   }
 
-  public static String formatUtcTime(Date date) {
-    return UTC_TIME_FORMAT.get().format(date);
+  public static String formatDate(Date date, TimeZone timeZone) {
+    return TIMEZONE_DATE_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
   }
 
-  public static String formatUtcTimestamp(Date date) {
-    return UTC_TIMESTAMP_FORMAT.get().format(date);
+  public static String formatTime(Date date, TimeZone timeZone) {
+    return TIMEZONE_TIME_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
   }
 
+  public static String formatTimestamp(Date date, TimeZone timeZone) {
+    return TIMEZONE_TIMESTAMP_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
+  }
+
+  private DateTimeUtils() {
+  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package io.confluent.connect.jdbc.util;
 
 import java.time.DateTimeException;

--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -1,0 +1,22 @@
+package io.confluent.connect.jdbc.util;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class TimeZoneValidator implements ConfigDef.Validator {
+
+  public static final TimeZoneValidator INSTANCE = new TimeZoneValidator();
+
+  @Override
+  public void ensureValid(String name, Object value) {
+    if (value != null) {
+      try {
+        ZoneId.of(value.toString());
+      } catch (DateTimeException e) {
+        throw new ConfigException(name, value, "Invalid time zone identifier");
+      }
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -314,16 +314,27 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
-    verifyBindField(++index, Decimal.schema(0),
-            new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN))
-            .setBigDecimal(index, new BigDecimal(2));
+    verifyBindField(
+        ++index,
+        Decimal.schema(0),
+        new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)
+    ).setBigDecimal(index, new BigDecimal(2));
     Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index,
-        new java.sql.Date(0), utcCalendar);
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000))
-        .setTime(index, new java.sql.Time(1000), utcCalendar);
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100))
-        .setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
+    verifyBindField(
+      ++index,
+      Date.SCHEMA,
+      new java.util.Date(0)
+    ).setDate(index, new java.sql.Date(0), utcCalendar);
+    verifyBindField(
+      ++index,
+      Time.SCHEMA,
+      new java.util.Date(1000)
+    ).setTime(index, new java.sql.Time(1000), utcCalendar);
+    verifyBindField(
+      ++index,
+      Timestamp.SCHEMA,
+      new java.util.Date(100)
+    ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.time.ZoneOffset;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -313,11 +314,16 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
-    verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date
-        (0), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100), DateTimeUtils.UTC_CALENDAR.get());
+    verifyBindField(++index, Decimal.schema(0),
+            new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN))
+            .setBigDecimal(index, new BigDecimal(2));
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
+    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index,
+        new java.sql.Date(0), utcCalendar);
+    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000))
+        .setTime(index, new java.sql.Time(1000), utcCalendar);
+    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100))
+        .setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -14,9 +14,20 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.util.Calendar;
+import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.TableId;
+
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -24,17 +35,6 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
-
-import io.confluent.connect.jdbc.util.DateTimeUtils;
-import io.confluent.connect.jdbc.util.TableId;
-
-import static org.junit.Assert.assertEquals;
 
 public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDialect> {
 
@@ -241,11 +241,20 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
     verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
     Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0))
-        .setDate(index, new java.sql.Date(0), utcCalendar);
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000))
-        .setTime(index, new java.sql.Time(1000), utcCalendar);
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100))
-        .setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
+    verifyBindField(
+      ++index,
+      Date.SCHEMA,
+      new java.util.Date(0)
+    ).setDate(index, new java.sql.Date(0), utcCalendar);
+    verifyBindField(
+      ++index,
+      Time.SCHEMA,
+      new java.util.Date(1000)
+    ).setTime(index, new java.sql.Time(1000), utcCalendar);
+    verifyBindField(
+      ++index,
+      Timestamp.SCHEMA,
+      new java.util.Date(100)
+    ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -14,6 +14,9 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -237,9 +240,12 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
     verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date
-        (0), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100), DateTimeUtils.UTC_CALENDAR.get());
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
+    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0))
+        .setDate(index, new java.sql.Date(0), utcCalendar);
+    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000))
+        .setTime(index, new java.sql.Time(1000), utcCalendar);
+    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100))
+        .setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -126,8 +126,10 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
                 assertEquals(struct.getInt64("long").longValue(), rs.getLong("long"));
                 assertEquals(struct.getFloat32("float"), rs.getFloat("float"), 0.01);
                 assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
-                java.sql.Timestamp dbTimestamp = rs.getTimestamp("modified",
-                    DateTimeUtils.getTimeZoneCalendar(timeZone));
+                java.sql.Timestamp dbTimestamp = rs.getTimestamp(
+                    "modified",
+                    DateTimeUtils.getTimeZoneCalendar(timeZone)
+                );
                 assertEquals(((java.util.Date) struct.get("modified")).getTime(), dbTimestamp.getTime());
               }
             }
@@ -193,8 +195,10 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
                 rs.getShort("float");
                 assertTrue(rs.wasNull());
                 assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
-                java.sql.Timestamp dbTimestamp = rs.getTimestamp("modified",
-                    DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC)));
+                java.sql.Timestamp dbTimestamp = rs.getTimestamp(
+                    "modified",
+                    DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC))
+                );
                 assertEquals(((java.util.Date) struct.get("modified")).getTime(), dbTimestamp.getTime());
               }
             }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -16,7 +16,22 @@
 
 package io.confluent.connect.jdbc.sink;
 
-import io.confluent.connect.jdbc.util.DateTimeUtils;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -30,14 +45,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.time.ZoneOffset;
-import java.util.*;
-
-import static org.easymock.EasyMock.expectLastCall;
-import static org.junit.Assert.*;
+import io.confluent.connect.jdbc.util.DateTimeUtils;
 
 public class JdbcSinkTaskTest extends EasyMockSupport {
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -16,6 +16,9 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -137,9 +140,16 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setDouble(index++, valueStruct.getFloat64("double"));
     verify(statement, times(1)).setBytes(index++, valueStruct.getBytes("bytes"));
     verify(statement, times(1)).setBigDecimal(index++, (BigDecimal) valueStruct.get("decimal"));
-    verify(statement, times(1)).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
-    verify(statement, times(1)).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
-    verify(statement, times(1)).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
+    verify(statement, times(1))
+        .setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()),
+            utcCalendar);
+    verify(statement, times(1))
+        .setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()),
+            utcCalendar);
+    verify(statement, times(1)).setTimestamp(index++,
+        new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()),
+        utcCalendar);
     // last field is optional and is null-valued in struct
     verify(statement, times(1)).setObject(index++, null);
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -141,15 +141,18 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setBytes(index++, valueStruct.getBytes("bytes"));
     verify(statement, times(1)).setBigDecimal(index++, (BigDecimal) valueStruct.get("decimal"));
     Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
-    verify(statement, times(1))
-        .setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()),
-            utcCalendar);
-    verify(statement, times(1))
-        .setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()),
-            utcCalendar);
-    verify(statement, times(1)).setTimestamp(index++,
-        new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()),
-        utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()), utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()), utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()), utcCalendar);
     // last field is optional and is null-valued in struct
     verify(statement, times(1)).setObject(index++, null);
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -196,8 +196,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     db.createTable(SINGLE_TABLE_NAME,
                    "modified", "TIMESTAMP NOT NULL",
                    "id", "INT");
-    db.insert(SINGLE_TABLE_NAME, "modified",
-            DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 1);
 
     startTask("modified", null, null);
     verifyTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
@@ -307,8 +308,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     db.createTable(SINGLE_TABLE_NAME,
                    "modified", "TIMESTAMP NOT NULL",
                    "id", "INT NOT NULL");
-    db.insert(SINGLE_TABLE_NAME, "modified",
-            DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 1);
 
     startTask("modified", "id", null);
     verifyIncrementingAndTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
@@ -383,8 +385,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
                    "modified", "TIMESTAMP",
                    "created", "TIMESTAMP NOT NULL",
                    "id", "INT NOT NULL");
-    db.insert(SINGLE_TABLE_NAME, "created",
-            DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+        "created", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 1);
 
     startTask("modified, created", "id", null);
     verifyIncrementingAndMultiTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
@@ -392,8 +395,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     db.insert(SINGLE_TABLE_NAME, "created",
             DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 3);
     db.insert(SINGLE_TABLE_NAME,
-            "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
-            "created", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 1);
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
+        "created", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 1);
 
     verifyPoll(2, "id", Arrays.asList(3, 1), false, true, true, TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
@@ -545,12 +549,15 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
                    "modified", "TIMESTAMP NOT NULL",
                    "id", "INT");
     // id=2 will be ignored since it has the same timestamp as the initial offset.
-    db.insert(SINGLE_TABLE_NAME, "modified",
-            DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 2);
-    db.insert(SINGLE_TABLE_NAME, "modified",
-            DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE), "id", 3);
-    db.insert(SINGLE_TABLE_NAME, "modified",
-            DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE), "id", 4);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 2);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
+        "id", 3);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE),
+        "id", 4);
 
     startTask("modified", null, null);
 
@@ -712,7 +719,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     startTask(timestampColumn, incrementingColumn, query, 0L, "UTC");
   }
 
-  private void startTask(String timestampColumn, String incrementingColumn, String query, Long delay, String timeZone) {
+  private void startTask(String timestampColumn, String incrementingColumn,
+                         String query, Long delay, String timeZone) {
     String mode = null;
     if (timestampColumn != null && incrementingColumn != null) {
       mode = JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING;

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -14,6 +14,8 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -47,13 +49,14 @@ public class TimestampIncrementingCriteriaTest {
   private TimestampIncrementingCriteria criteriaIncTs;
   private Schema schema;
   private Struct record;
+  private TimeZone utcTimeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
 
   @Before
   public void beforeEach() {
-    criteria = new TimestampIncrementingCriteria(null, null);
-    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null);
-    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS);
-    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS);
+    criteria = new TimestampIncrementingCriteria(null, null, utcTimeZone);
+    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null, utcTimeZone);
+    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS, utcTimeZone);
+    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS, utcTimeZone);
   }
 
   protected void assertExtractedOffset(long expected, Schema schema, Struct record) {

--- a/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
 package io.confluent.connect.jdbc.util;
 
 import java.util.stream.Stream;

--- a/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
@@ -1,0 +1,39 @@
+package io.confluent.connect.jdbc.util;
+
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Test;
+
+public class TimeZoneValidatorTest {
+
+  @Test
+  public void testAccuracy() {
+    String[] validTimeZones = new String[]{
+        "Europe/Vienna",
+        "Asia/Tokyo",
+        "America/Los_Angeles",
+        "UTC",
+        "GMT+01:00",
+        "UTC"
+    };
+
+    Stream.of(validTimeZones)
+        .forEach(timeZone -> TimeZoneValidator.INSTANCE.ensureValid("db.timezone", timeZone));
+  }
+
+  @Test
+  public void testTimeZoneNotSpecified() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", null);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidTimeZone() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", "invalid");
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testEmptyTimeZone() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", "");
+  }
+}


### PR DESCRIPTION
Added db.timezone setting in order to be able to customize the timezone (to a different value than the default value UTC) used at the jdbc level.

When customizing this setting, the  date/time/timestamp values read from the source database will be instantiated with the customized time zone.

The timestamp  1474661402123L  corresponds to `2016-09-23 20:10:02.123` in UTC zone.
When the database timezone is not UTC, but Europe/Vienna, the value  read from the database should be `2016-09-23 22:10:02.123`.

This pull requests addresses exactly the problem mentioned in the example above, by allowing the user of kafka-jdbc connector to customize the timezone in which the date/time/timestamp values are read from the database.
This is being done by adding a new `timezone` field to io.confluent.connect.jdbc.dialect.GenericDatabaseDialect class which is to be used when reading/writing date/time/timestamp values.