### PR TITLE
MINOR: bump up version of sqlite-jdbc library to the latest version available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <derby.version>10.11.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <sqlite-jdbc.version>3.8.11.2</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>9.4-1206-jdbc41</postgresql.version>
         <licenses.name>Apache License 2.0</licenses.name>
         <licenses.version>${project.version}</licenses.version>


### PR DESCRIPTION
Bump up version of the sqlite-jdbc library used for testing as embedded database in order to benefit of making use of jdbc4 classes.