### PR TITLE
CC-2910: Changed source task to close connections when finished

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -71,6 +71,7 @@ public class TableMonitorThread extends Thread {
 
   @Override
   public void run() {
+    log.info("Starting thread to monitor tables.");
     while (shutdownLatch.getCount() > 0) {
       try {
         if (updateTables()) {
@@ -82,6 +83,7 @@ public class TableMonitorThread extends Thread {
       }
 
       try {
+        log.debug("Waiting {} ms to check for changed.", pollMs);
         boolean shuttingDown = shutdownLatch.await(pollMs, TimeUnit.MILLISECONDS);
         if (shuttingDown) {
           return;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -158,7 +158,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     criteria.whereClause(builder);
 
     String queryString = builder.toString();
-    log.debug("{} prepared SQL query: {}", this, queryString);
+    log.info("{} prepared SQL query: {}", this, queryString);
     stmt = dialect.createPreparedStatement(db, queryString);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -35,6 +35,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
   private final int maxConnectionAttempts;
   private final long connectionRetryBackoff;
 
+  private int count = 0;
   private Connection connection;
 
   public CachedConnectionProvider(
@@ -83,7 +84,8 @@ public class CachedConnectionProvider implements ConnectionProvider {
     int attempts = 0;
     while (attempts < maxConnectionAttempts) {
       try {
-        log.debug("Attempting to connect to {}", provider);
+        ++count;
+        log.debug("Attempting to connect #{} to {}", count, provider);
         connection = provider.getConnection();
         onConnect(connection);
         return;
@@ -109,6 +111,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
   public synchronized void close() {
     if (connection != null) {
       try {
+        log.info("Closing connection #{} to {}", count, provider);
         connection.close();
       } catch (SQLException sqle) {
         log.warn("Ignoring error closing connection", sqle);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -22,11 +22,13 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -85,9 +87,13 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   protected List<ColumnId> columnsAtoD;
   protected List<SinkRecordField> sinkRecordFields;
   protected T dialect;
+  protected int defaultLoginTimeout;
 
   @Before
   public void setup() throws Exception {
+    defaultLoginTimeout = DriverManager.getLoginTimeout();
+    DriverManager.setLoginTimeout(1);
+
     dialect = createDialect();
 
     // Set up some data ...
@@ -119,6 +125,11 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     SinkRecordField f7 = new SinkRecordField(optionalTsWithDefault, "c7", false);
     SinkRecordField f8 = new SinkRecordField(optionalDecimal, "c8", false);
     sinkRecordFields = Arrays.asList(f1, f2, f3, f4, f5, f6, f7, f8);
+  }
+
+  @After
+  public void teardown() throws Exception {
+    DriverManager.setLoginTimeout(defaultLoginTimeout);
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -74,7 +74,6 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
 
-    mockCachedConnectionProvider.close();
     PowerMock.expectLastCall();
 
     PowerMock.replayAll();


### PR DESCRIPTION
The JDBC source task was attempting to close the CachedConnectionProvider and its connections when the task was stopped, which happens asynchronously while the `poll()` method may be still working in the task’s primary thread. If the connection provider is closed but is needed again, it will reopen connections as needed but these will never be closed.

With this change, the connection provider is closed at the end of `poll()` after the task has been stopped (or after an exception has been thrown) and after the connections are no longer being used.