### PR TITLE
CC-2455: Corrected timestamp query for DB2

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java
@@ -191,6 +191,8 @@ public class JdbcUtils {
       query = "select CURRENT_TIMESTAMP from dual";
     else if ("Apache Derby".equals(dbProduct))
       query = "values(CURRENT_TIMESTAMP)";
+    else if (dbProduct != null && dbProduct.startsWith("DB2"))
+      query = "select CURRENT_TIMESTAMP from sysibm.sysdummy1";
     else
       query = "select CURRENT_TIMESTAMP;";
 


### PR DESCRIPTION
The new query works on all versions of DB2.

See also #479 (already merged) for a fix on 5.0.x and later.