### PR TITLE
MINOR Add log statements to debug different flush paths

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -112,6 +112,7 @@ public class BufferedRecords {
       // Continue with current batch state
       records.add(record);
       if (records.size() >= config.batchSize) {
+        log.debug("Flushing buffered records after exceeding configured batch size.");
         flushed = flush();
       } else {
         flushed = Collections.emptyList();
@@ -119,6 +120,8 @@ public class BufferedRecords {
     } else {
       // Each batch needs to have the same SchemaPair, so get the buffered records out, reset
       // state and re-attempt the add
+      log.debug("Flushing buffered records after due to unequal schema pairs: "
+          + "Current Schemas: {}, Next Schemas: {}", currentSchemaPair, schemaPair);
       flushed = flush();
       currentSchemaPair = null;
       flushed.addAll(add(record));
@@ -131,6 +134,7 @@ public class BufferedRecords {
       log.debug("Records is empty");
       return new ArrayList<>();
     }
+    log.debug("Flushing {} Buffered Records", records.size());
     for (SinkRecord record : records) {
       preparedStatementBinder.bindRecord(record);
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -121,7 +121,7 @@ public class BufferedRecords {
       // Each batch needs to have the same SchemaPair, so get the buffered records out, reset
       // state and re-attempt the add
       log.debug("Flushing buffered records after due to unequal schema pairs: "
-          + "Current Schemas: {}, Next Schemas: {}", currentSchemaPair, schemaPair);
+          + "current schemas: {}, next schemas: {}", currentSchemaPair, schemaPair);
       flushed = flush();
       currentSchemaPair = null;
       flushed.addAll(add(record));

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -112,7 +112,8 @@ public class BufferedRecords {
       // Continue with current batch state
       records.add(record);
       if (records.size() >= config.batchSize) {
-        log.debug("Flushing buffered records after exceeding configured batch size.");
+        log.debug("Flushing buffered records after exceeding configured batch size {}.",
+            config.batchSize);
         flushed = flush();
       } else {
         flushed = Collections.emptyList();

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -134,7 +134,7 @@ public class BufferedRecords {
       log.debug("Records is empty");
       return new ArrayList<>();
     }
-    log.debug("Flushing {} Buffered Records", records.size());
+    log.debug("Flushing {} buffered records", records.size());
     for (SinkRecord record : records) {
       preparedStatementBinder.bindRecord(record);
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -66,7 +66,9 @@ public class JdbcDbWriter {
       }
       buffer.add(record);
     }
-    for (BufferedRecords buffer : bufferByTable.values()) {
+    for (TableId tableId : bufferByTable.keySet()) {
+      BufferedRecords buffer = bufferByTable.get(tableId);
+      log.debug("Flushing records in JDBC Writer for table ID: {}", tableId);
       buffer.flush();
       buffer.close();
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -66,8 +66,9 @@ public class JdbcDbWriter {
       }
       buffer.add(record);
     }
-    for (TableId tableId : bufferByTable.keySet()) {
-      BufferedRecords buffer = bufferByTable.get(tableId);
+    for (Map.Entry<TableId, BufferedRecords> entry : bufferByTable.entrySet()) {
+      TableId tableId = entry.getKey();
+      BufferedRecords buffer = entry.getValue();
       log.debug("Flushing records in JDBC Writer for table ID: {}", tableId);
       buffer.flush();
       buffer.close();

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SchemaPair.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SchemaPair.java
@@ -46,4 +46,8 @@ public class SchemaPair {
   public int hashCode() {
     return Objects.hash(keySchema, valueSchema);
   }
+
+  public String toString() {
+    return String.format("<SchemaPair: %s, %s>", keySchema.toString(), valueSchema.toString());
+  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SchemaPair.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SchemaPair.java
@@ -48,6 +48,6 @@ public class SchemaPair {
   }
 
   public String toString() {
-    return String.format("<SchemaPair: %s, %s>", keySchema.toString(), valueSchema.toString());
+    return String.format("<SchemaPair: %s, %s>", keySchema, valueSchema);
   }
 }


### PR DESCRIPTION
This will illuminate why we flush, either because of mismatched
schemas, batch size limits, or processed entire message batch.