### PR TITLE
CC-3414: Changed PostgreSQL dialect to use BYTEA rather than BLOB

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -211,7 +211,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       case STRING:
         return "TEXT";
       case BYTES:
-        return "BLOB";
+        return "BYTEA";
       default:
         return super.getSqlType(field);
     }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -44,7 +44,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertPrimitiveMapping(Type.FLOAT32, "REAL");
     assertPrimitiveMapping(Type.FLOAT64, "DOUBLE PRECISION");
     assertPrimitiveMapping(Type.BOOLEAN, "BOOLEAN");
-    assertPrimitiveMapping(Type.BYTES, "BLOB");
+    assertPrimitiveMapping(Type.BYTES, "BYTEA");
     assertPrimitiveMapping(Type.STRING, "TEXT");
   }
 
@@ -66,7 +66,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     verifyDataTypeMapping("DOUBLE PRECISION", Schema.FLOAT64_SCHEMA);
     verifyDataTypeMapping("BOOLEAN", Schema.BOOLEAN_SCHEMA);
     verifyDataTypeMapping("TEXT", Schema.STRING_SCHEMA);
-    verifyDataTypeMapping("BLOB", Schema.BYTES_SCHEMA);
+    verifyDataTypeMapping("BYTEA", Schema.BYTES_SCHEMA);
     verifyDataTypeMapping("DECIMAL", Decimal.schema(0));
     verifyDataTypeMapping("DATE", Date.SCHEMA);
     verifyDataTypeMapping("TIME", Time.SCHEMA);


### PR DESCRIPTION
The sink connector uses this type when it creates the table in the database.

1. Backward compatibility - `BLOB` doesn't exist in PostgreSQL, so the previous code never worked. Also, because only the `PostgresqlDialect` is changed, this change does not affect other DBMSes (unless they use the PostgreSQL dialect).
2. The dialect also uses `statement.setBytes(index, bytes)` ([see code](https://github.com/confluentinc/kafka-connect-jdbc/blob/309d4454b410573d0de37ff3219e888cb6aae554/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java#L1462)) to set the column values, and the PostgreSQL JDBC driver will correctly binary set values for `BYTEA` columns. Basically, `BYTEA` is pretty much PostgreSQL's `BLOB` type.

Fixes #404, #324 

Supersedes #271 which is not currently mergeable.