### PR TITLE
CC-3525: Reduced log message for creating query

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -859,7 +859,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     int scale = columnDefn.scale();
     switch (sqlType) {
       case Types.NULL: {
-        log.warn("JDBC type 'NULL' not currently supported for column '{}'", fieldName);
+        log.debug("JDBC type 'NULL' not currently supported for column '{}'", fieldName);
         return null;
       }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -158,7 +158,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     criteria.whereClause(builder);
 
     String queryString = builder.toString();
-    log.info("{} prepared SQL query: {}", this, queryString);
+    log.debug("{} prepared SQL query: {}", this, queryString);
     stmt = dialect.createPreparedStatement(db, queryString);
   }
 


### PR DESCRIPTION
The INFO-level log message about creating query was introduced recently, but INFO level results in the message being logged too frequently (about every 5 seconds). It has been reduced to DEBUG-level.