### PR TITLE
Fix tests to pass on windows as well

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
@@ -91,10 +91,15 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected =
-        "CREATE TABLE \"myTable\" (\n" + "\"c1\" INTEGER NOT NULL,\n" + "\"c2\" BIGINT NOT NULL,\n"
-        + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator()
+        + "\"c1\" INTEGER NOT NULL," + System.lineSeparator()
+        + "\"c2\" BIGINT NOT NULL," + System.lineSeparator()
+        + "\"c3\" VARCHAR(32672) NOT NULL," + System.lineSeparator()
+        + "\"c4\" VARCHAR(32672) NULL," + System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "\"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "\"c8\" DECIMAL(31,4) NULL," + System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -106,15 +111,15 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
     dialect = createDialect();
 
     String expected =
-        "CREATE TABLE myTable (\n"
-        + "c1 INTEGER NOT NULL,\n"
-        + "c2 BIGINT NOT NULL,\n"
-        + "c3 VARCHAR(32672) NOT NULL,\n"
-        + "c4 VARCHAR(32672) NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\n"
-        + "c6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 DECIMAL(31,4) NULL,\n"
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 INTEGER NOT NULL," + System.lineSeparator()
+        + "c2 BIGINT NOT NULL," + System.lineSeparator()
+        + "c3 VARCHAR(32672) NOT NULL," + System.lineSeparator()
+        + "c4 VARCHAR(32672) NULL," + System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 DECIMAL(31,4) NULL," + System.lineSeparator()
         + "PRIMARY KEY(c1))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -123,14 +128,14 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
   @Test
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" \n"
-                    + "ADD \"c1\" INTEGER NOT NULL,\n"
-                    + "ADD \"c2\" BIGINT NOT NULL,\n"
-                    + "ADD \"c3\" VARCHAR(32672) NOT NULL,\n"
-                    + "ADD \"c4\" VARCHAR(32672) NULL,\n"
-                    + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
-                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+    String[] sql = {"ALTER TABLE \"myTable\" " + System.lineSeparator()
+                    + "ADD \"c1\" INTEGER NOT NULL," + System.lineSeparator()
+                    + "ADD \"c2\" BIGINT NOT NULL," + System.lineSeparator()
+                    + "ADD \"c3\" VARCHAR(32672) NOT NULL," + System.lineSeparator()
+                    + "ADD \"c4\" VARCHAR(32672) NULL," + System.lineSeparator()
+                    + "ADD \"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
                     + "ADD \"c8\" DECIMAL(31,4) NULL"};
     assertStatements(sql, statements);
   }
@@ -141,14 +146,14 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
     dialect = createDialect();
 
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE myTable \n"
-                    + "ADD c1 INTEGER NOT NULL,\n"
-                    + "ADD c2 BIGINT NOT NULL,\n"
-                    + "ADD c3 VARCHAR(32672) NOT NULL,\n"
-                    + "ADD c4 VARCHAR(32672) NULL,\n"
-                    + "ADD c5 DATE DEFAULT '2001-03-15',\n"
-                    + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+    String[] sql = {"ALTER TABLE myTable " + System.lineSeparator()
+                    + "ADD c1 INTEGER NOT NULL," + System.lineSeparator()
+                    + "ADD c2 BIGINT NOT NULL," + System.lineSeparator()
+                    + "ADD c3 VARCHAR(32672) NOT NULL," + System.lineSeparator()
+                    + "ADD c4 VARCHAR(32672) NULL," + System.lineSeparator()
+                    + "ADD c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+                    + "ADD c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
                     + "ADD c8 DECIMAL(31,4) NULL"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
@@ -92,10 +92,15 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected =
-        "CREATE TABLE \"myTable\" (\n" + "\"c1\" INTEGER NOT NULL,\n" + "\"c2\" BIGINT NOT NULL,\n"
-        + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator()
+        + "\"c1\" INTEGER NOT NULL," + System.lineSeparator()
+        + "\"c2\" BIGINT NOT NULL," + System.lineSeparator()
+        + "\"c3\" VARCHAR(32672) NOT NULL," + System.lineSeparator()
+        + "\"c4\" VARCHAR(32672) NULL," + System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "\"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "\"c8\" DECIMAL(31,4) NULL," + System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -107,10 +112,15 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
     dialect = createDialect();
 
     String expected =
-        "CREATE TABLE myTable (\nc1 INTEGER NOT NULL,\nc2 BIGINT NOT NULL,\n"
-        + "c3 VARCHAR(32672) NOT NULL,\nc4 VARCHAR(32672) NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\nc6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\nc8 DECIMAL(31,4) NULL,\n"
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 INTEGER NOT NULL," + System.lineSeparator()
+        + "c2 BIGINT NOT NULL," + System.lineSeparator()
+        + "c3 VARCHAR(32672) NOT NULL," + System.lineSeparator()
+        + "c4 VARCHAR(32672) NULL," + System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 DECIMAL(31,4) NULL," + System.lineSeparator()
         + "PRIMARY KEY(c1))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -119,12 +129,14 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
   @Test
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" \n" + "ADD \"c1\" INTEGER NOT NULL,\n"
-                    + "ADD \"c2\" BIGINT NOT NULL,\n" + "ADD \"c3\" VARCHAR(32672) NOT NULL,\n"
-                    + "ADD \"c4\" VARCHAR(32672) NULL,\n"
-                    + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
-                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+    String[] sql = {"ALTER TABLE \"myTable\" " + System.lineSeparator()
+                    + "ADD \"c1\" INTEGER NOT NULL," + System.lineSeparator()
+                    + "ADD \"c2\" BIGINT NOT NULL," + System.lineSeparator()
+                    + "ADD \"c3\" VARCHAR(32672) NOT NULL," + System.lineSeparator()
+                    + "ADD \"c4\" VARCHAR(32672) NULL," + System.lineSeparator()
+                    + "ADD \"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
                     + "ADD \"c8\" DECIMAL(31,4) NULL"};
     assertStatements(sql, statements);
   }
@@ -135,14 +147,14 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
     dialect = createDialect();
 
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE myTable \n"
-                    + "ADD c1 INTEGER NOT NULL,\n"
-                    + "ADD c2 BIGINT NOT NULL,\n"
-                    + "ADD c3 VARCHAR(32672) NOT NULL,\n"
-                    + "ADD c4 VARCHAR(32672) NULL,\n"
-                    + "ADD c5 DATE DEFAULT '2001-03-15',\n"
-                    + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+    String[] sql = {"ALTER TABLE myTable " + System.lineSeparator() 
+                    + "ADD c1 INTEGER NOT NULL," + System.lineSeparator() 
+                    + "ADD c2 BIGINT NOT NULL," + System.lineSeparator() 
+                    + "ADD c3 VARCHAR(32672) NOT NULL," + System.lineSeparator() 
+                    + "ADD c4 VARCHAR(32672) NULL," + System.lineSeparator() 
+                    + "ADD c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator() 
+                    + "ADD c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator() 
+                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() 
                     + "ADD c8 DECIMAL(31,4) NULL"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -93,10 +93,15 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected =
-        "CREATE TABLE `myTable` (\n" + "`c1` INT NOT NULL,\n" + "`c2` BIGINT NOT NULL,\n" +
-        "`c3` VARCHAR(256) NOT NULL,\n" + "`c4` VARCHAR(256) NULL,\n" +
-        "`c5` DATE DEFAULT '2001-03-15',\n" + "`c6` TIME(3) DEFAULT '00:00:00.000',\n" +
-        "`c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" + "`c8` DECIMAL(65,4) NULL,\n" +
+        "CREATE TABLE `myTable` (" + System.lineSeparator() +
+        "`c1` INT NOT NULL," + System.lineSeparator() +
+        "`c2` BIGINT NOT NULL," + System.lineSeparator() +
+        "`c3` VARCHAR(256) NOT NULL," + System.lineSeparator() +
+        "`c4` VARCHAR(256) NULL," + System.lineSeparator() +
+        "`c5` DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
+        "`c6` TIME(3) DEFAULT '00:00:00.000'," + System.lineSeparator() +
+        "`c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
+        "`c8` DECIMAL(65,4) NULL," + System.lineSeparator() +
         "PRIMARY KEY(`c1`))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -106,10 +111,14 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
     String[] sql = {
-        "ALTER TABLE `myTable` \n" + "ADD `c1` INT NOT NULL,\n" + "ADD `c2` BIGINT NOT NULL,\n" +
-        "ADD `c3` VARCHAR(256) NOT NULL,\n" + "ADD `c4` VARCHAR(256) NULL,\n" +
-        "ADD `c5` DATE DEFAULT '2001-03-15',\n" + "ADD `c6` TIME(3) DEFAULT '00:00:00.000',\n" +
-        "ADD `c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" +
+        "ALTER TABLE `myTable` " + System.lineSeparator() +
+        "ADD `c1` INT NOT NULL," + System.lineSeparator() +
+        "ADD `c2` BIGINT NOT NULL," + System.lineSeparator() +
+        "ADD `c3` VARCHAR(256) NOT NULL," + System.lineSeparator() +
+        "ADD `c4` VARCHAR(256) NULL," + System.lineSeparator() +
+        "ADD `c5` DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
+        "ADD `c6` TIME(3) DEFAULT '00:00:00.000'," + System.lineSeparator() +
+        "ADD `c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
         "ADD `c8` DECIMAL(65,4) NULL"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -90,12 +90,16 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
   @Test
   public void shouldBuildCreateQueryStatement() {
-    String expected = "CREATE TABLE \"myTable\" (\n" + "\"c1\" NUMBER(10,0) NOT NULL,\n" +
-                      "\"c2\" NUMBER(19,0) NOT NULL,\n" + "\"c3\" CLOB NOT NULL,\n" +
-                      "\"c4\" CLOB NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
-                      "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
-                      "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-                      "\"c8\" NUMBER(*,4) NULL,\n" + "PRIMARY KEY(\"c1\"))";
+    String expected = "CREATE TABLE \"myTable\" (" + System.lineSeparator() +
+            "\"c1\" NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+            "\"c2\" NUMBER(19,0) NOT NULL," + System.lineSeparator() +
+            "\"c3\" CLOB NOT NULL," + System.lineSeparator() +
+            "\"c4\" CLOB NULL," + System.lineSeparator() +
+            "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
+            "\"c6\" DATE DEFAULT '00:00:00.000'," + System.lineSeparator() +
+            "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
+            "\"c8\" NUMBER(*,4) NULL," + System.lineSeparator() +
+            "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }
@@ -104,14 +108,14 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   public void shouldBuildAlterTableStatement() {
     assertStatements(
         new String[]{
-            "ALTER TABLE \"myTable\" ADD(\n" +
-            "\"c1\" NUMBER(10,0) NOT NULL,\n" +
-            "\"c2\" NUMBER(19,0) NOT NULL,\n" +
-            "\"c3\" CLOB NOT NULL,\n" +
-            "\"c4\" CLOB NULL,\n" +
-            "\"c5\" DATE DEFAULT '2001-03-15',\n" +
-            "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
-            "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
+            "ALTER TABLE \"myTable\" ADD(" + System.lineSeparator() +
+            "\"c1\" NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+            "\"c2\" NUMBER(19,0) NOT NULL," + System.lineSeparator() +
+            "\"c3\" CLOB NOT NULL," + System.lineSeparator() +
+            "\"c4\" CLOB NULL," + System.lineSeparator() +
+            "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
+            "\"c6\" DATE DEFAULT '00:00:00.000'," + System.lineSeparator() +
+            "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
             "\"c8\" NUMBER(*,4) NULL)"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
@@ -122,14 +126,14 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
     assertStatements(
         new String[]{
-            "ALTER TABLE myTable ADD(\n" +
-            "c1 NUMBER(10,0) NOT NULL,\n" +
-            "c2 NUMBER(19,0) NOT NULL,\n" +
-            "c3 CLOB NOT NULL,\n" +
-            "c4 CLOB NULL,\n" +
-            "c5 DATE DEFAULT '2001-03-15',\n" +
-            "c6 DATE DEFAULT '00:00:00.000',\n" +
-            "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
+            "ALTER TABLE myTable ADD(" + System.lineSeparator() +
+            "c1 NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+            "c2 NUMBER(19,0) NOT NULL," + System.lineSeparator() +
+            "c3 CLOB NOT NULL," + System.lineSeparator() +
+            "c4 CLOB NULL," + System.lineSeparator() +
+            "c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
+            "c6 DATE DEFAULT '00:00:00.000'," + System.lineSeparator() +
+            "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
             "c8 NUMBER(*,4) NULL)"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -92,15 +92,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE \"myTable\" (\n"
-        + "\"c1\" INT NOT NULL,\n"
-        + "\"c2\" BIGINT NOT NULL,\n"
-        + "\"c3\" TEXT NOT NULL,\n"
-        + "\"c4\" TEXT NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
-        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" DECIMAL NULL,\n"
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator()
+        + "\"c1\" INT NOT NULL," + System.lineSeparator()
+        + "\"c2\" BIGINT NOT NULL," + System.lineSeparator()
+        + "\"c3\" TEXT NOT NULL," + System.lineSeparator()
+        + "\"c4\" TEXT NULL," + System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "\"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "\"c8\" DECIMAL NULL," + System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -109,15 +109,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     dialect = createDialect();
 
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 INT NOT NULL,\n"
-        + "c2 BIGINT NOT NULL,\n"
-        + "c3 TEXT NOT NULL,\n"
-        + "c4 TEXT NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\n"
-        + "c6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 DECIMAL NULL,\n"
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 INT NOT NULL," + System.lineSeparator()
+        + "c2 BIGINT NOT NULL," + System.lineSeparator()
+        + "c3 TEXT NOT NULL," + System.lineSeparator()
+        + "c4 TEXT NULL," + System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 DECIMAL NULL," + System.lineSeparator()
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -127,14 +127,14 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldBuildAlterTableStatement() {
     assertEquals(
         Arrays.asList(
-            "ALTER TABLE \"myTable\" \n"
-            + "ADD \"c1\" INT NOT NULL,\n"
-            + "ADD \"c2\" BIGINT NOT NULL,\n"
-            + "ADD \"c3\" TEXT NOT NULL,\n"
-            + "ADD \"c4\" TEXT NULL,\n"
-            + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
-            + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
-            + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+            "ALTER TABLE \"myTable\" " + System.lineSeparator()
+            + "ADD \"c1\" INT NOT NULL," + System.lineSeparator()
+            + "ADD \"c2\" BIGINT NOT NULL," + System.lineSeparator()
+            + "ADD \"c3\" TEXT NOT NULL," + System.lineSeparator()
+            + "ADD \"c4\" TEXT NULL," + System.lineSeparator()
+            + "ADD \"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+            + "ADD \"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+            + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
             + "ADD \"c8\" DECIMAL NULL"
         ),
         dialect.buildAlterTable(tableId, sinkRecordFields)
@@ -145,14 +145,14 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     assertEquals(
         Arrays.asList(
-            "ALTER TABLE myTable \n"
-            + "ADD c1 INT NOT NULL,\n"
-            + "ADD c2 BIGINT NOT NULL,\n"
-            + "ADD c3 TEXT NOT NULL,\n"
-            + "ADD c4 TEXT NULL,\n"
-            + "ADD c5 DATE DEFAULT '2001-03-15',\n"
-            + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
-            + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+            "ALTER TABLE myTable " + System.lineSeparator()
+            + "ADD c1 INT NOT NULL," + System.lineSeparator()
+            + "ADD c2 BIGINT NOT NULL," + System.lineSeparator()
+            + "ADD c3 TEXT NOT NULL," + System.lineSeparator()
+            + "ADD c4 TEXT NULL," + System.lineSeparator()
+            + "ADD c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+            + "ADD c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+            + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
             + "ADD c8 DECIMAL NULL"
         ),
         dialect.buildAlterTable(tableId, sinkRecordFields)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -92,15 +92,15 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE [myTable] (\n"
-        + "[c1] int NOT NULL,\n"
-        + "[c2] bigint NOT NULL,\n"
-        + "[c3] varchar(max) NOT NULL,\n"
-        + "[c4] varchar(max) NULL,\n"
-        + "[c5] date DEFAULT '2001-03-15',\n"
-        + "[c6] time DEFAULT '00:00:00.000',\n"
-        + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "[c8] decimal(38,4) NULL,\n" +
+        "CREATE TABLE [myTable] (" + System.lineSeparator()
+        + "[c1] int NOT NULL," + System.lineSeparator()
+        + "[c2] bigint NOT NULL," + System.lineSeparator()
+        + "[c3] varchar(max) NOT NULL," + System.lineSeparator()
+        + "[c4] varchar(max) NULL," + System.lineSeparator()
+        + "[c5] date DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "[c6] time DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "[c8] decimal(38,4) NULL," + System.lineSeparator()  +
         "PRIMARY KEY([c1]))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -108,15 +108,15 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 int NOT NULL,\n"
-        + "c2 bigint NOT NULL,\n"
-        + "c3 varchar(max) NOT NULL,\n"
-        + "c4 varchar(max) NULL,\n"
-        + "c5 date DEFAULT '2001-03-15',\n"
-        + "c6 time DEFAULT '00:00:00.000',\n"
-        + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 decimal(38,4) NULL,\n" +
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 int NOT NULL," + System.lineSeparator()
+        + "c2 bigint NOT NULL," + System.lineSeparator()
+        + "c3 varchar(max) NOT NULL," + System.lineSeparator()
+        + "c4 varchar(max) NULL," + System.lineSeparator()
+        + "c5 date DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 time DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 decimal(38,4) NULL," + System.lineSeparator()  +
         "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -126,14 +126,14 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
   public void shouldBuildAlterTableStatement() {
     assertStatements(
         new String[]{
-            "ALTER TABLE [myTable] ADD\n"
-            + "[c1] int NOT NULL,\n"
-            + "[c2] bigint NOT NULL,\n"
-            + "[c3] varchar(max) NOT NULL,\n"
-            + "[c4] varchar(max) NULL,\n"
-            + "[c5] date DEFAULT '2001-03-15',\n"
-            + "[c6] time DEFAULT '00:00:00.000',\n"
-            + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+            "ALTER TABLE [myTable] ADD" + System.lineSeparator()
+            + "[c1] int NOT NULL," + System.lineSeparator()
+            + "[c2] bigint NOT NULL," + System.lineSeparator()
+            + "[c3] varchar(max) NOT NULL," + System.lineSeparator()
+            + "[c4] varchar(max) NULL," + System.lineSeparator()
+            + "[c5] date DEFAULT '2001-03-15'," + System.lineSeparator()
+            + "[c6] time DEFAULT '00:00:00.000'," + System.lineSeparator()
+            + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
             + "[c8] decimal(38,4) NULL"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
@@ -143,14 +143,14 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     dialect = createDialect();
     assertStatements(
         new String[]{
-            "ALTER TABLE myTable ADD\n"
-            + "c1 int NOT NULL,\n"
-            + "c2 bigint NOT NULL,\n"
-            + "c3 varchar(max) NOT NULL,\n"
-            + "c4 varchar(max) NULL,\n"
-            + "c5 date DEFAULT '2001-03-15',\n"
-            + "c6 time DEFAULT '00:00:00.000',\n"
-            + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+            "ALTER TABLE myTable ADD" + System.lineSeparator()
+            + "c1 int NOT NULL," + System.lineSeparator()
+            + "c2 bigint NOT NULL," + System.lineSeparator()
+            + "c3 varchar(max) NOT NULL," + System.lineSeparator()
+            + "c4 varchar(max) NULL," + System.lineSeparator()
+            + "c5 date DEFAULT '2001-03-15'," + System.lineSeparator()
+            + "c6 time DEFAULT '00:00:00.000'," + System.lineSeparator()
+            + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
             + "c8 decimal(38,4) NULL"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -111,15 +111,15 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE `myTable` (\n"
-        + "`c1` INTEGER NOT NULL,\n"
-        + "`c2` INTEGER NOT NULL,\n"
-        + "`c3` TEXT NOT NULL,\n"
-        + "`c4` TEXT NULL,\n"
-        + "`c5` NUMERIC DEFAULT '2001-03-15',\n"
-        + "`c6` NUMERIC DEFAULT '00:00:00.000',\n"
-        + "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "`c8` NUMERIC NULL,\n"
+        "CREATE TABLE `myTable` (" + System.lineSeparator()
+        + "`c1` INTEGER NOT NULL," + System.lineSeparator()
+        + "`c2` INTEGER NOT NULL," + System.lineSeparator()
+        + "`c3` TEXT NOT NULL," + System.lineSeparator()
+        + "`c4` TEXT NULL," + System.lineSeparator()
+        + "`c5` NUMERIC DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "`c6` NUMERIC DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "`c8` NUMERIC NULL," + System.lineSeparator()
         + "PRIMARY KEY(`c1`))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -127,15 +127,15 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 INTEGER NOT NULL,\n"
-        + "c2 INTEGER NOT NULL,\n"
-        + "c3 TEXT NOT NULL,\n"
-        + "c4 TEXT NULL,\n"
-        + "c5 NUMERIC DEFAULT '2001-03-15',\n"
-        + "c6 NUMERIC DEFAULT '00:00:00.000',\n"
-        + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 NUMERIC NULL,\n"
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 INTEGER NOT NULL," + System.lineSeparator()
+        + "c2 INTEGER NOT NULL," + System.lineSeparator()
+        + "c3 TEXT NOT NULL," + System.lineSeparator()
+        + "c4 TEXT NULL," + System.lineSeparator()
+        + "c5 NUMERIC DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 NUMERIC DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 NUMERIC NULL," + System.lineSeparator()
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -102,15 +102,15 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
   @Test
   public void shouldBuildCreateTableStatement() {
     assertEquals(
-        "CREATE TABLE \"myTable\" (\n"
-        + "\"c1\" int NOT NULL,\n"
-        + "\"c2\" bigint NOT NULL,\n"
-        +"\"c3\" text NOT NULL,\n"
-        + "\"c4\" text NULL,\n"
-        + "\"c5\" date DEFAULT '2001-03-15',\n"
-        + "\"c6\" time DEFAULT '00:00:00.000',\n"
-        + "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" decimal(38,4) NULL,\n" +
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator()
+        + "\"c1\" int NOT NULL," + System.lineSeparator()
+        + "\"c2\" bigint NOT NULL," + System.lineSeparator()
+        +"\"c3\" text NOT NULL," + System.lineSeparator()
+        + "\"c4\" text NULL," + System.lineSeparator()
+        + "\"c5\" date DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "\"c6\" time DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "\"c8\" decimal(38,4) NULL," + System.lineSeparator()  +
         "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -118,15 +118,15 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 int NOT NULL,\n"
-        + "c2 bigint NOT NULL,\n"
-        + "c3 text NOT NULL,\n"
-        + "c4 text NULL,\n"
-        + "c5 date DEFAULT '2001-03-15',\n"
-        + "c6 time DEFAULT '00:00:00.000',\n"
-        + "c7 datetime DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 decimal(38,4) NULL,\n" +
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 int NOT NULL," + System.lineSeparator()
+        + "c2 bigint NOT NULL," + System.lineSeparator()
+        + "c3 text NOT NULL," + System.lineSeparator()
+        + "c4 text NULL," + System.lineSeparator()
+        + "c5 date DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 time DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 datetime DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 decimal(38,4) NULL," + System.lineSeparator()  +
         "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -171,10 +171,15 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
     String[] sql = {
-        "ALTER TABLE \"myTable\" ADD\n" + "\"c1\" int NOT NULL,\n" + "\"c2\" bigint NOT NULL,\n" +
-        "\"c3\" text NOT NULL,\n" + "\"c4\" text NULL,\n" +
-        "\"c5\" date DEFAULT '2001-03-15',\n" + "\"c6\" time DEFAULT '00:00:00.000',\n" +
-        "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" decimal(38,4) NULL"};
+        "ALTER TABLE \"myTable\" ADD" + System.lineSeparator() +
+        "\"c1\" int NOT NULL," + System.lineSeparator() +
+        "\"c2\" bigint NOT NULL," + System.lineSeparator() +
+        "\"c3\" text NOT NULL," + System.lineSeparator() +
+        "\"c4\" text NULL," + System.lineSeparator() +
+        "\"c5\" date DEFAULT '2001-03-15'," + System.lineSeparator() +
+        "\"c6\" time DEFAULT '00:00:00.000'," + System.lineSeparator() +
+        "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
+        "\"c8\" decimal(38,4) NULL"};
     assertStatements(sql, statements);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
@@ -91,15 +91,15 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE \"myTable\" (\n"
-        + "\"c1\" INT NOT NULL,\n"
-        + "\"c2\" INT NOT NULL,\n"
-        + "\"c3\" VARCHAR(1024) NOT NULL,\n"
-        + "\"c4\" VARCHAR(1024) NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
-        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" DECIMAL(18,4) NULL,\n"
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator()
+        + "\"c1\" INT NOT NULL," + System.lineSeparator()
+        + "\"c2\" INT NOT NULL," + System.lineSeparator()
+        + "\"c3\" VARCHAR(1024) NOT NULL," + System.lineSeparator()
+        + "\"c4\" VARCHAR(1024) NULL," + System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "\"c6\" TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "\"c8\" DECIMAL(18,4) NULL," + System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -107,15 +107,15 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 INT NOT NULL,\n"
-        + "c2 INT NOT NULL,\n"
-        + "c3 VARCHAR(1024) NOT NULL,\n"
-        + "c4 VARCHAR(1024) NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\n"
-        + "c6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 DECIMAL(18,4) NULL,\n"
+        "CREATE TABLE myTable (" + System.lineSeparator()
+        + "c1 INT NOT NULL," + System.lineSeparator()
+        + "c2 INT NOT NULL," + System.lineSeparator()
+        + "c3 VARCHAR(1024) NOT NULL," + System.lineSeparator()
+        + "c4 VARCHAR(1024) NULL," + System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15'," + System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000'," + System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator()
+        + "c8 DECIMAL(18,4) NULL," + System.lineSeparator()
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -104,6 +104,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     task.put(Collections.singleton(
         new SinkRecord(topic, 1, null, null, SCHEMA, struct, 42)
     ));
+    task.stop();
 
     assertEquals(
         1,
@@ -176,6 +177,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         .put("modified", new Date(1474661402123L));
 
     task.put(Collections.singleton(new SinkRecord(topic, 1, null, null, SCHEMA, struct, 43)));
+    task.stop();
 
     assertEquals(
         1,

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -42,9 +42,6 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   @Mock
   private CachedConnectionProvider mockCachedConnectionProvider;
 
-  @Mock
-  private Connection conn;
-
   @Test(expected = ConnectException.class)
   public void testMissingParentConfig() {
     Map<String, String> props = singleTableConfig();
@@ -104,10 +101,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     task.poll();
     assertEquals(startTime + 2 * JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT,
                  time.milliseconds());
-
-    task.stop();
   }
-
 
   @Test
   public void testSingleUpdateMultiplePoll() throws Exception {
@@ -135,7 +129,6 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     task.poll();
     assertEquals(startTime + JdbcSourceConnectorConfig.POLL_INTERVAL_MS_DEFAULT,
                  time.milliseconds());
-
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -80,6 +80,9 @@ public class JdbcSourceTaskTestBase {
 
   @After
   public void tearDown() throws Exception {
+    task.stop();
+    // call poll in order to close task resources
+    task.poll();
     db.close();
     db.dropDatabase();
   }


### PR DESCRIPTION
Some tests did not close task resources which caused an exception to be
thrown when deleting the test db directory.
Update tests to expect sql statements with system new line character.