### PR TITLE
CC-3638: Added logic to optionally quote tables and/or columns

### DIFF
--- a/config/sink-quickstart-sqlite.properties
+++ b/config/sink-quickstart-sqlite.properties
@@ -28,3 +28,13 @@ topics=orders
 # We want to connect to a SQLite database stored in the file test.db and auto-create tables.
 connection.url=jdbc:sqlite:test.db
 auto.create=true
+
+# Define when table names should be quoted in DDL and DML statements.
+# The default is 'always' to maintain backward compatibility with prior versions.
+# Set this to 'never' to avoid quoting fully-qualified or simple table names.
+#quote.table.names=always
+
+# Define when column names should be quoted in DDL and DML statements.
+# The default is 'always' to maintain backward compatibility with prior versions.
+# Set this to 'never' to avoid quoting fully-qualified or simple column names.
+#quote.column.names=always

--- a/config/source-quickstart-sqlite.properties
+++ b/config/source-quickstart-sqlite.properties
@@ -28,3 +28,13 @@ connection.url=jdbc:sqlite:test.db
 mode=incrementing
 incrementing.column.name=id
 topic.prefix=test-sqlite-jdbc-
+
+# Define when table names should be quoted in DDL and DML statements.
+# The default is 'always' to maintain backward compatibility with prior versions.
+# Set this to 'never' to avoid quoting fully-qualified or simple table names.
+#quote.table.names=always
+
+# Define when column names should be quoted in DDL and DML statements.
+# The default is 'always' to maintain backward compatibility with prior versions.
+# Set this to 'never' to avoid quoting fully-qualified or simple column names.
+#quote.column.names=always

--- a/src/main/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialect.java
@@ -120,9 +120,9 @@ public class Db2DatabaseDialect extends GenericDatabaseDialect {
     final Transform<ColumnId> transform = (builder, col) -> {
       builder.append(table)
              .append(".")
-             .appendIdentifierQuoted(col.name())
+             .appendColumnName(col.name())
              .append("=DAT.")
-             .appendIdentifierQuoted(col.name());
+             .appendColumnName(col.name());
     };
 
     ExpressionBuilder builder = expressionBuilder();

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialect.java
@@ -120,9 +120,9 @@ public class DerbyDatabaseDialect extends GenericDatabaseDialect {
     final Transform<ColumnId> transform = (builder, col) -> {
       builder.append(table)
              .append(".")
-             .appendIdentifierQuoted(col.name())
+             .appendColumnName(col.name())
              .append("=DAT.")
-             .appendIdentifierQuoted(col.name());
+             .appendColumnName(col.name());
     };
 
     ExpressionBuilder builder = expressionBuilder();

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -84,6 +84,7 @@ import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
 import io.confluent.connect.jdbc.util.IdentifierRules;
 import io.confluent.connect.jdbc.util.JdbcDriverInfo;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
 
@@ -128,6 +129,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected final String schemaPattern;
   protected final Set<String> tableTypes;
   protected final String jdbcUrl;
+  private final QuoteMethod quoteTableNames;
+  private final QuoteMethod quoteColumnNames;
   private final IdentifierRules defaultIdentifierRules;
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();
   private final Queue<Connection> connections = new ConcurrentLinkedQueue<>();
@@ -160,10 +163,22 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       catalogPattern = JdbcSourceTaskConfig.CATALOG_PATTERN_DEFAULT;
       schemaPattern = JdbcSourceTaskConfig.SCHEMA_PATTERN_DEFAULT;
       tableTypes = new HashSet<>(Arrays.asList(JdbcSourceTaskConfig.TABLE_TYPE_DEFAULT));
+      quoteTableNames = QuoteMethod.get(
+          config.getString(JdbcSinkConfig.QUOTE_TABLE_NAMES_CONFIG)
+      );
+      quoteColumnNames = QuoteMethod.get(
+          config.getString(JdbcSinkConfig.QUOTE_COLUMN_NAMES_CONFIG)
+      );
     } else {
       catalogPattern = config.getString(JdbcSourceTaskConfig.CATALOG_PATTERN_CONFIG);
       schemaPattern = config.getString(JdbcSourceTaskConfig.SCHEMA_PATTERN_CONFIG);
       tableTypes = new HashSet<>(config.getList(JdbcSourceTaskConfig.TABLE_TYPE_CONFIG));
+      quoteTableNames = QuoteMethod.get(
+          config.getString(JdbcSourceConnectorConfig.QUOTE_TABLE_NAMES_CONFIG)
+      );
+      quoteColumnNames = QuoteMethod.get(
+          config.getString(JdbcSourceConnectorConfig.QUOTE_COLUMN_NAMES_CONFIG)
+      );
     }
     if (config instanceof JdbcSourceConnectorConfig) {
       mapNumerics = ((JdbcSourceConnectorConfig)config).numericMapping();
@@ -440,7 +455,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
   @Override
   public ExpressionBuilder expressionBuilder() {
-    return identifierRules().expressionBuilder();
+    return identifierRules().expressionBuilder()
+                            .setQuoteTables(quoteTableNames)
+                            .setQuoteColumns(quoteColumnNames);
   }
 
   /**
@@ -1524,7 +1541,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       builder.append("PRIMARY KEY(");
       builder.appendList()
              .delimitedBy(",")
-             .transformedBy(ExpressionBuilder.quote())
+             .transformedBy(ExpressionBuilder.quoteColumns())
              .of(pkFieldNames);
       builder.append(")");
     }
@@ -1601,7 +1618,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       ExpressionBuilder builder,
       SinkRecordField f
   ) {
-    builder.appendIdentifierQuoted(f.name());
+    builder.appendColumnName(f.name());
     builder.append(" ");
     String sqlType = getSqlType(f);
     builder.append(sqlType);

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -131,9 +131,9 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
   ) {
     //MySql doesn't support SQL 2003:merge so here how the upsert is handled
     final Transform<ColumnId> transform = (builder, col) -> {
-      builder.appendIdentifierQuoted(col.name());
+      builder.appendColumnName(col.name());
       builder.append("=values(");
-      builder.appendIdentifierQuoted(col.name());
+      builder.appendColumnName(col.name());
       builder.append(")");
     };
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -169,9 +169,9 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     final Transform<ColumnId> transform = (builder, col) -> {
       builder.append(table)
              .append(".")
-             .appendIdentifierQuoted(col.name())
+             .appendColumnName(col.name())
              .append("=incoming.")
-             .appendIdentifierQuoted(col.name());
+             .appendColumnName(col.name());
     };
 
     ExpressionBuilder builder = expressionBuilder();

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -224,9 +224,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       Collection<ColumnId> nonKeyColumns
   ) {
     final Transform<ColumnId> transform = (builder, col) -> {
-      builder.appendIdentifierQuoted(col.name())
+      builder.appendColumnName(col.name())
              .append("=EXCLUDED.")
-             .appendIdentifierQuoted(col.name());
+             .appendColumnName(col.name());
     };
 
     ExpressionBuilder builder = expressionBuilder();

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -185,15 +185,15 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
 
   private void transformAs(ExpressionBuilder builder, ColumnId col) {
     builder.append("target.")
-           .appendIdentifierQuoted(col.name())
+           .appendColumnName(col.name())
            .append("=incoming.")
-           .appendIdentifierQuoted(col.name());
+           .appendColumnName(col.name());
   }
 
   private void transformUpdate(ExpressionBuilder builder, ColumnId col) {
-    builder.appendIdentifierQuoted(col.name())
+    builder.appendColumnName(col.name())
            .append("=incoming.")
-           .appendIdentifierQuoted(col.name());
+           .appendColumnName(col.name());
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -283,14 +283,14 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
 
   private void transformAs(ExpressionBuilder builder, ColumnId col) {
     builder.append("target.")
-           .appendIdentifierQuoted(col.name())
+           .appendColumnName(col.name())
            .append("=incoming.")
-           .appendIdentifierQuoted(col.name());
+           .appendColumnName(col.name());
   }
 
   private void transformUpdate(ExpressionBuilder builder, ColumnId col) {
-    builder.appendIdentifierQuoted(col.name())
+    builder.appendColumnName(col.name())
            .append("=incoming.")
-           .appendIdentifierQuoted(col.name());
+           .appendColumnName(col.name());
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -26,6 +26,8 @@ import java.util.Set;
 
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
+import io.confluent.connect.jdbc.util.EnumRecommender;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.StringUtils;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -174,7 +176,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_GROUP = "Connection";
   private static final String WRITES_GROUP = "Writes";
   private static final String DATAMAPPING_GROUP = "Data Mapping";
-  private static final String DDL_GROUP = "DDL Support";
+  private static final String DDL_GROUP = "SQL/DDL Support";
   private static final String RETRIES_GROUP = "Retries";
 
   public static final String DIALECT_NAME_CONFIG = "dialect.name";
@@ -186,6 +188,25 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "JDBC connection URL. Use this if you want to override that behavior and use a "
       + "specific dialect. All properly-packaged dialects in the JDBC connector plugin "
       + "can be used.";
+
+  public static final String QUOTE_TABLE_NAMES_CONFIG =
+      JdbcSourceConnectorConfig.QUOTE_TABLE_NAMES_CONFIG;
+  public static final String QUOTE_TABLE_NAMES_DEFAULT = QuoteMethod.ALWAYS.name().toString();
+  public static final String QUOTE_TABLE_NAMES_DOC =
+      "When to quote table names in DML and SQL statements. For backward compatibility, "
+      + "the default is 'always'.";
+  private static final String QUOTE_TABLE_NAMES_DISPLAY = "Quote Tables";
+
+  public static final String QUOTE_COLUMN_NAMES_CONFIG =
+      JdbcSourceConnectorConfig.QUOTE_COLUMN_NAMES_CONFIG;
+  public static final String QUOTE_COLUMN_NAMES_DEFAULT = QuoteMethod.ALWAYS.name().toString();
+  public static final String QUOTE_COLUMN_NAMES_DOC =
+      "When to quote column names in DML and SQL statements. For backward compatibility, "
+      + "the default is 'always'.";
+  private static final String QUOTE_COLUMN_NAMES_DISPLAY = "Quote Columns";
+
+  private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
+      EnumRecommender.in(QuoteMethod.values());
 
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
         // Connection
@@ -324,6 +345,28 @@ public class JdbcSinkConfig extends AbstractConfig {
             2,
             ConfigDef.Width.SHORT,
             AUTO_EVOLVE_DISPLAY
+        ).define(
+            QUOTE_TABLE_NAMES_CONFIG,
+            ConfigDef.Type.STRING,
+            QUOTE_TABLE_NAMES_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            QUOTE_TABLE_NAMES_DOC,
+            DDL_GROUP,
+            3,
+            ConfigDef.Width.MEDIUM,
+            QUOTE_TABLE_NAMES_DISPLAY,
+            QUOTE_METHOD_RECOMMENDER
+        ).define(
+            QUOTE_COLUMN_NAMES_CONFIG,
+            ConfigDef.Type.STRING,
+            QUOTE_COLUMN_NAMES_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            QUOTE_COLUMN_NAMES_DOC,
+            DDL_GROUP,
+            4,
+            ConfigDef.Width.MEDIUM,
+            QUOTE_COLUMN_NAMES_DISPLAY,
+            QUOTE_METHOD_RECOMMENDER
         )
         // Retries
         .define(

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -29,21 +29,20 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
+import io.confluent.connect.jdbc.util.EnumRecommender;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 public class JdbcSourceConnectorConfig extends AbstractConfig {
@@ -239,6 +238,23 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + " from the last time we fetched until current time minus the delay.";
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
+
+  public static final String QUOTE_TABLE_NAMES_CONFIG = "quote.table.names";
+  public static final String QUOTE_TABLE_NAMES_DEFAULT = QuoteMethod.ALWAYS.name().toString();
+  public static final String QUOTE_TABLE_NAMES_DOC =
+      "When to quote table names in DML query statements. For backward compatibility, "
+      + "the default is 'always'.";
+  private static final String QUOTE_TABLE_NAMES_DISPLAY = "Quote Tables";
+
+  public static final String QUOTE_COLUMN_NAMES_CONFIG = "quote.column.names";
+  public static final String QUOTE_COLUMN_NAMES_DEFAULT = QuoteMethod.ALWAYS.name().toString();
+  public static final String QUOTE_COLUMN_NAMES_DOC =
+      "When to quote column names in DML query statements. For backward compatibility, "
+      + "the default is 'always'.";
+  private static final String QUOTE_COLUMN_NAMES_DISPLAY = "Quote Columns";
+
+  private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
+      EnumRecommender.in(QuoteMethod.values());
 
   public static final String DATABASE_GROUP = "Database";
   public static final String MODE_GROUP = "Mode";
@@ -474,7 +490,29 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         MODE_GROUP,
         ++orderInGroup,
         Width.SHORT,
-        QUERY_DISPLAY);
+        QUERY_DISPLAY
+    ).define(
+        QUOTE_TABLE_NAMES_CONFIG,
+        Type.STRING,
+        QUOTE_TABLE_NAMES_DEFAULT,
+        Importance.MEDIUM,
+        QUOTE_TABLE_NAMES_DOC,
+        MODE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        QUOTE_TABLE_NAMES_DISPLAY,
+        QUOTE_METHOD_RECOMMENDER
+    ).define(
+        QUOTE_COLUMN_NAMES_CONFIG,
+        Type.STRING,
+        QUOTE_COLUMN_NAMES_DEFAULT,
+        Importance.MEDIUM,
+        QUOTE_COLUMN_NAMES_DOC,
+        MODE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        QUOTE_COLUMN_NAMES_DISPLAY,
+        QUOTE_METHOD_RECOMMENDER);
   }
 
   private static final void addConnectorOptions(ConfigDef config) {
@@ -702,53 +740,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         return NumericMapping.PRECISION_ONLY;
       }
       return NumericMapping.NONE;
-    }
-  }
-
-  //Porting from JdbcSinkConfig and extending to implement Recommender interface too.
-  //TODO: Should factor out to common class.
-  private static class EnumRecommender implements ConfigDef.Validator, ConfigDef.Recommender {
-    private final List<String> canonicalValues;
-    private final Set<String> validValues;
-
-    private EnumRecommender(List<String> canonicalValues, Set<String> validValues) {
-      this.canonicalValues = canonicalValues;
-      this.validValues = validValues;
-    }
-
-    @SafeVarargs
-    public static <E> EnumRecommender in(E... enumerators) {
-      final List<String> canonicalValues = new ArrayList<>(enumerators.length);
-      final Set<String> validValues = new HashSet<>(enumerators.length * 2);
-      for (E e : enumerators) {
-        canonicalValues.add(e.toString().toLowerCase());
-        validValues.add(e.toString().toUpperCase(Locale.ROOT));
-        validValues.add(e.toString().toLowerCase(Locale.ROOT));
-      }
-      return new EnumRecommender(canonicalValues, validValues);
-    }
-
-    @Override
-    public void ensureValid(String key, Object value) {
-      // calling toString on itself because IDE complains if the Object is passed.
-      if (value != null && !validValues.contains(value.toString())) {
-        throw new ConfigException(key, value, "Invalid enumerator");
-      }
-    }
-
-    @Override
-    public String toString() {
-      return canonicalValues.toString();
-    }
-
-    @Override
-    public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
-      return new ArrayList<Object>(canonicalValues);
-    }
-
-    @Override
-    public boolean visible(String name, Map<String, Object> connectorConfigs) {
-      return true;
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/OffsetProtocols.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/OffsetProtocols.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.jdbc.source;
 
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import java.util.Collections;
@@ -35,7 +36,7 @@ public class OffsetProtocols {
    * @return the partition map for V1 protocol
    */
   public static Map<String, String> sourcePartitionForProtocolV1(TableId tableId) {
-    String fqn = ExpressionBuilder.create().append(tableId, false).toString();
+    String fqn = ExpressionBuilder.create().append(tableId, QuoteMethod.NEVER).toString();
     Map<String, String> partitionForV1 = new HashMap<>();
     partitionForV1.put(JdbcSourceConnectorConstants.TABLE_NAME_KEY, fqn);
     partitionForV1.put(

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc.source;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.util.ConnectionProvider;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -154,8 +155,8 @@ public class TableMonitorThread extends Thread {
     final List<TableId> filteredTables = new ArrayList<>(tables.size());
     if (whitelist != null) {
       for (TableId table : tables) {
-        String fqn1 = dialect.expressionBuilder().append(table, false).toString();
-        String fqn2 = dialect.expressionBuilder().append(table, true).toString();
+        String fqn1 = dialect.expressionBuilder().append(table, QuoteMethod.NEVER).toString();
+        String fqn2 = dialect.expressionBuilder().append(table, QuoteMethod.ALWAYS).toString();
         if (whitelist.contains(fqn1) || whitelist.contains(fqn2)
             || whitelist.contains(table.tableName())) {
           filteredTables.add(table);
@@ -163,8 +164,8 @@ public class TableMonitorThread extends Thread {
       }
     } else if (blacklist != null) {
       for (TableId table : tables) {
-        String fqn1 = dialect.expressionBuilder().append(table, false).toString();
-        String fqn2 = dialect.expressionBuilder().append(table, true).toString();
+        String fqn1 = dialect.expressionBuilder().append(table, QuoteMethod.NEVER).toString();
+        String fqn2 = dialect.expressionBuilder().append(table, QuoteMethod.ALWAYS).toString();
         if (!(blacklist.contains(fqn1) || blacklist.contains(fqn2)
               || blacklist.contains(table.tableName()))) {
           filteredTables.add(table);

--- a/src/main/java/io/confluent/connect/jdbc/util/ColumnId.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/ColumnId.java
@@ -67,11 +67,19 @@ public class ColumnId implements Expressable {
 
   @Override
   public void appendTo(ExpressionBuilder builder, boolean useQuotes) {
+    appendTo(builder, QuoteMethod.ALWAYS);
+  }
+
+  @Override
+  public void appendTo(
+      ExpressionBuilder builder,
+      QuoteMethod useQuotes
+  ) {
     if (tableId != null) {
       builder.append(tableId);
       builder.appendIdentifierDelimiter();
     }
-    builder.appendIdentifier(this.name, useQuotes);
+    builder.appendColumnName(this.name, useQuotes);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/util/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/EnumRecommender.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class EnumRecommender implements ConfigDef.Validator, ConfigDef.Recommender {
+  private final List<String> canonicalValues;
+  private final Set<String> validValues;
+
+  private EnumRecommender(List<String> canonicalValues, Set<String> validValues) {
+    this.canonicalValues = canonicalValues;
+    this.validValues = validValues;
+  }
+
+  @SafeVarargs
+  public static <E> EnumRecommender in(E... enumerators) {
+    final List<String> canonicalValues = new ArrayList<>(enumerators.length);
+    final Set<String> validValues = new HashSet<>(enumerators.length * 2);
+    for (E e : enumerators) {
+      canonicalValues.add(e.toString().toLowerCase());
+      validValues.add(e.toString().toUpperCase(Locale.ROOT));
+      validValues.add(e.toString().toLowerCase(Locale.ROOT));
+    }
+    return new EnumRecommender(canonicalValues, validValues);
+  }
+
+  @Override
+  public void ensureValid(String key, Object value) {
+    // calling toString on itself because IDE complains if the Object is passed.
+    if (value != null && !validValues.contains(value.toString())) {
+      throw new ConfigException(key, value, "Invalid enumerator");
+    }
+  }
+
+  @Override
+  public String toString() {
+    return canonicalValues.toString();
+  }
+
+  @Override
+  public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
+    return new ArrayList<Object>(canonicalValues);
+  }
+
+  @Override
+  public boolean visible(String name, Map<String, Object> connectorConfigs) {
+    return true;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/QuoteMethod.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/QuoteMethod.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.util;
+
+public enum QuoteMethod {
+  ALWAYS("always"),
+  NEVER("never");
+
+  public static QuoteMethod get(String name) {
+    for (QuoteMethod method : values()) {
+      if (method.toString().equalsIgnoreCase(name)) {
+        return method;
+      }
+    }
+    throw new IllegalArgumentException("No matching QuoteMethod found for '" + name + "'");
+  }
+
+  private final String name;
+
+  QuoteMethod(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/TableId.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableId.java
@@ -52,6 +52,14 @@ public class TableId implements Comparable<TableId>, Expressable {
 
   @Override
   public void appendTo(ExpressionBuilder builder, boolean useQuotes) {
+    appendTo(builder, QuoteMethod.ALWAYS);
+  }
+
+  @Override
+  public void appendTo(
+      ExpressionBuilder builder,
+      QuoteMethod useQuotes
+  ) {
     if (catalogName != null) {
       builder.appendIdentifier(catalogName, useQuotes);
       builder.appendIdentifierDelimiter();
@@ -60,7 +68,7 @@ public class TableId implements Comparable<TableId>, Expressable {
       builder.appendIdentifier(schemaName, useQuotes);
       builder.appendIdentifierDelimiter();
     }
-    builder.appendIdentifier(tableName, useQuotes);
+    builder.appendTableName(tableName, useQuotes);
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -49,6 +49,7 @@ import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -76,6 +77,8 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     MARCH_15_2001_MIDNIGHT.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
+  protected QuoteMethod quoteTableNames;
+  protected QuoteMethod quoteColumnNames;
   protected TableId tableId;
   protected ColumnId columnPK1;
   protected ColumnId columnPK2;
@@ -93,8 +96,6 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   public void setup() throws Exception {
     defaultLoginTimeout = DriverManager.getLoginTimeout();
     DriverManager.setLoginTimeout(1);
-
-    dialect = createDialect();
 
     // Set up some data ...
     Schema optionalDateWithDefault = Date.builder().defaultValue(MARCH_15_2001_MIDNIGHT.getTime())
@@ -125,6 +126,8 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     SinkRecordField f7 = new SinkRecordField(optionalTsWithDefault, "c7", false);
     SinkRecordField f8 = new SinkRecordField(optionalDecimal, "c8", false);
     sinkRecordFields = Arrays.asList(f1, f2, f3, f4, f5, f6, f7, f8);
+
+    dialect = createDialect();
   }
 
   @After
@@ -155,6 +158,18 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
     connProps.putAll(propertiesFromPairs(propertyPairs));
     connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, url);
+    if (quoteTableNames != null) {
+      connProps.put(
+          JdbcSourceConnectorConfig.QUOTE_TABLE_NAMES_CONFIG,
+          quoteTableNames.toString()
+      );
+    }
+    if (quoteColumnNames != null) {
+      connProps.put(
+          JdbcSourceConnectorConfig.QUOTE_COLUMN_NAMES_CONFIG,
+          quoteColumnNames.toString()
+      );
+    }
     return new JdbcSourceConnectorConfig(connProps);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
@@ -101,6 +102,37 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
   }
 
   @Test
+  public void shouldBuildCreateQueryStatementWithNoTableQuoting() {
+    quoteTableNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    String expected =
+        "CREATE TABLE myTable (\n" + "\"c1\" INTEGER NOT NULL,\n" + "\"c2\" BIGINT NOT NULL,\n"
+        + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
+        + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
+        + "PRIMARY KEY(\"c1\"))";
+    String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
+    assertEquals(expected, sql);
+  }
+
+  @Test
+  public void shouldBuildCreateQueryStatementWithNoTableQuotingAndNoColumnQuoting() {
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    String expected =
+        "CREATE TABLE myTable (\nc1 INTEGER NOT NULL,\nc2 BIGINT NOT NULL,\n"
+        + "c3 VARCHAR(32672) NOT NULL,\nc4 VARCHAR(32672) NULL,\n"
+        + "c5 DATE DEFAULT '2001-03-15',\nc6 TIME DEFAULT '00:00:00.000',\n"
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\nc8 DECIMAL(31,4) NULL,\n"
+        + "PRIMARY KEY(c1))";
+    String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
+    assertEquals(expected, sql);
+  }
+
+  @Test
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
     String[] sql = {"ALTER TABLE \"myTable\" \n" + "ADD \"c1\" INTEGER NOT NULL,\n"
@@ -110,6 +142,44 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
                     + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
                     + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
                     + "ADD \"c8\" DECIMAL(31,4) NULL"};
+    assertStatements(sql, statements);
+  }
+
+  @Test
+  public void shouldBuildAlterTableStatementWithoutColumnQuotes() {
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
+    String[] sql = {"ALTER TABLE \"myTable\" \n"
+                    + "ADD c1 INTEGER NOT NULL,\n"
+                    + "ADD c2 BIGINT NOT NULL,\n"
+                    + "ADD c3 VARCHAR(32672) NOT NULL,\n"
+                    + "ADD c4 VARCHAR(32672) NULL,\n"
+                    + "ADD c5 DATE DEFAULT '2001-03-15',\n"
+                    + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
+                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+                    + "ADD c8 DECIMAL(31,4) NULL"};
+    assertStatements(sql, statements);
+  }
+
+  @Test
+  public void shouldBuildAlterTableStatementWithoutColumnOrTableQuotes() {
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
+    String[] sql = {"ALTER TABLE myTable \n"
+                    + "ADD c1 INTEGER NOT NULL,\n"
+                    + "ADD c2 BIGINT NOT NULL,\n"
+                    + "ADD c3 VARCHAR(32672) NOT NULL,\n"
+                    + "ADD c4 VARCHAR(32672) NULL,\n"
+                    + "ADD c5 DATE DEFAULT '2001-03-15',\n"
+                    + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
+                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+                    + "ADD c8 DECIMAL(31,4) NULL"};
     assertStatements(sql, statements);
   }
 
@@ -216,6 +286,36 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
     String expected = "merge into \"actor\" using (values(?)) as DAT(\"actor_id\") on \"actor\""
                       + ".\"actor_id\"=DAT.\"actor_id\" when not matched then insert(\"actor\""
                       + ".\"actor_id\") values(DAT.\"actor_id\")";
+    String sql = dialect.buildUpsertQueryStatement(
+        actor, columns(actor, "actor_id"), columns(actor));
+    assertEquals(expected, sql);
+  }
+
+  @Test
+  public void upsertOnlyKeyColsWithoutTableOrColumnQuoting() {
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    TableId actor = tableId("actor");
+    String expected = "merge into actor using (values(?)) as DAT(actor_id) on actor"
+                      + ".actor_id=DAT.actor_id when not matched then insert(actor"
+                      + ".actor_id) values(DAT.actor_id)";
+    String sql = dialect.buildUpsertQueryStatement(
+        actor, columns(actor, "actor_id"), columns(actor));
+    assertEquals(expected, sql);
+  }
+
+  @Test
+  public void upsertOnlyKeyColsWithoutColumnQuoting() {
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    TableId actor = tableId("actor");
+    String expected = "merge into \"actor\" using (values(?)) as DAT(actor_id) on \"actor\""
+                      + ".actor_id=DAT.actor_id when not matched then insert(\"actor\""
+                      + ".actor_id) values(DAT.actor_id)";
     String sql = dialect.buildUpsertQueryStatement(
         actor, columns(actor, "actor_id"), columns(actor));
     assertEquals(expected, sql);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -47,6 +47,7 @@ import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.ConnectionProvider;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.StringUtils;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
@@ -353,6 +354,12 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   private void verifyWriteColumnSpec(String expected, SinkRecordField field) {
     GenericDatabaseDialect dialect = dummyDialect();
     ExpressionBuilder builder = dialect.expressionBuilder();
+    if (quoteTableNames != null) {
+      builder.setQuoteTables(quoteTableNames);
+    }
+    if (quoteColumnNames != null) {
+      builder.setQuoteColumns(quoteColumnNames);
+    }
     dialect.writeColumnSpec(builder, field);
     assertEquals(expected, builder.toString());
   }
@@ -373,11 +380,13 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
         SchemaBuilder.int32().defaultValue(42).build(), "foo", true));
     verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", false));
     verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", true));
-    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", false));
-    verifyWriteColumnSpec("\"foo\" DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", true));
-    verifyWriteColumnSpec("\"foo\" DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", false));
-    verifyWriteColumnSpec("\"foo\" DUMMY NOT NULL", new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "foo", true));
-    verifyWriteColumnSpec("\"foo\" DUMMY NULL", new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "foo", false));
+
+    quoteColumnNames = QuoteMethod.NEVER;
+    verifyWriteColumnSpec("foo DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", false));
+    verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", true));
+    verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", false));
+    verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "foo", true));
+    verifyWriteColumnSpec("foo DUMMY NULL", new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "foo", false));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
@@ -103,14 +104,58 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
   @Test
   public void shouldBuildAlterTableStatement() {
-    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" ADD(\n" + "\"c1\" NUMBER(10,0) NOT NULL,\n" +
-                    "\"c2\" NUMBER(19,0) NOT NULL,\n" + "\"c3\" CLOB NOT NULL,\n" +
-                    "\"c4\" CLOB NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
-                    "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
-                    "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-                    "\"c8\" NUMBER(*,4) NULL)"};
-    assertStatements(sql, statements);
+    assertStatements(
+        new String[]{
+            "ALTER TABLE \"myTable\" ADD(\n" +
+            "\"c1\" NUMBER(10,0) NOT NULL,\n" +
+            "\"c2\" NUMBER(19,0) NOT NULL,\n" +
+            "\"c3\" CLOB NOT NULL,\n" +
+            "\"c4\" CLOB NULL,\n" +
+            "\"c5\" DATE DEFAULT '2001-03-15',\n" +
+            "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
+            "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
+            "\"c8\" NUMBER(*,4) NULL)"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertStatements(
+        new String[]{
+            "ALTER TABLE \"myTable\" ADD(\n" +
+            "c1 NUMBER(10,0) NOT NULL,\n" +
+            "c2 NUMBER(19,0) NOT NULL,\n" +
+            "c3 CLOB NOT NULL,\n" +
+            "c4 CLOB NULL,\n" +
+            "c5 DATE DEFAULT '2001-03-15',\n" +
+            "c6 DATE DEFAULT '00:00:00.000',\n" +
+            "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
+            "c8 NUMBER(*,4) NULL)"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertStatements(
+        new String[]{
+            "ALTER TABLE myTable ADD(\n" +
+            "c1 NUMBER(10,0) NOT NULL,\n" +
+            "c2 NUMBER(19,0) NOT NULL,\n" +
+            "c3 CLOB NOT NULL,\n" +
+            "c4 CLOB NULL,\n" +
+            "c5 DATE DEFAULT '2001-03-15',\n" +
+            "c6 DATE DEFAULT '00:00:00.000',\n" +
+            "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
+            "c8 NUMBER(*,4) NULL)"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
   }
 
   @Test
@@ -150,6 +195,26 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
         System.lineSeparator() + "\"pk2\" NUMBER(10,0) NOT NULL," + System.lineSeparator() +
         "\"col1\" NUMBER(10,0) NOT NULL," + System.lineSeparator() +
         "PRIMARY KEY(\"pk1\",\"pk2\"))");
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "pk1 NUMBER(10,0) NOT NULL," +
+        System.lineSeparator() + "pk2 NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+        "col1 NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+        "PRIMARY KEY(pk1,pk2))");
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 NUMBER(10,0) NOT NULL," +
+        System.lineSeparator() + "pk2 NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+        "col1 NUMBER(10,0) NOT NULL," + System.lineSeparator() +
+        "PRIMARY KEY(pk1,pk2))");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -22,8 +22,10 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
@@ -90,37 +92,149 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void shouldBuildCreateQueryStatement() {
-    String expected =
-        "CREATE TABLE \"myTable\" (\n" + "\"c1\" INT NOT NULL,\n" + "\"c2\" BIGINT NOT NULL,\n" +
-        "\"c3\" TEXT NOT NULL,\n" + "\"c4\" TEXT NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
-        "\"c6\" TIME DEFAULT '00:00:00.000',\n" +
-        "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL NULL,\n" +
-        "PRIMARY KEY(\"c1\"))";
-    String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
-    assertEquals(expected, sql);
+    assertEquals(
+        "CREATE TABLE \"myTable\" (\n"
+        + "\"c1\" INT NOT NULL,\n"
+        + "\"c2\" BIGINT NOT NULL,\n"
+        + "\"c3\" TEXT NOT NULL,\n"
+        + "\"c4\" TEXT NULL,\n"
+        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
+        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "\"c8\" DECIMAL NULL,\n"
+        + "PRIMARY KEY(\"c1\"))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "CREATE TABLE \"myTable\" (\n"
+        + "c1 INT NOT NULL,\n"
+        + "c2 BIGINT NOT NULL,\n"
+        + "c3 TEXT NOT NULL,\n"
+        + "c4 TEXT NULL,\n"
+        + "c5 DATE DEFAULT '2001-03-15',\n"
+        + "c6 TIME DEFAULT '00:00:00.000',\n"
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 DECIMAL NULL,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "CREATE TABLE myTable (\n"
+        + "c1 INT NOT NULL,\n"
+        + "c2 BIGINT NOT NULL,\n"
+        + "c3 TEXT NOT NULL,\n"
+        + "c4 TEXT NULL,\n"
+        + "c5 DATE DEFAULT '2001-03-15',\n"
+        + "c6 TIME DEFAULT '00:00:00.000',\n"
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 DECIMAL NULL,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
   }
 
   @Test
   public void shouldBuildAlterTableStatement() {
-    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" \n" + "ADD \"c1\" INT NOT NULL,\n" +
-                    "ADD \"c2\" BIGINT NOT NULL,\n" + "ADD \"c3\" TEXT NOT NULL,\n" +
-                    "ADD \"c4\" TEXT NULL,\n" + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n" +
-                    "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n" +
-                    "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-                    "ADD \"c8\" DECIMAL NULL"};
-    assertStatements(sql, statements);
+    assertEquals(
+        Arrays.asList(
+            "ALTER TABLE \"myTable\" \n"
+            + "ADD \"c1\" INT NOT NULL,\n"
+            + "ADD \"c2\" BIGINT NOT NULL,\n"
+            + "ADD \"c3\" TEXT NOT NULL,\n"
+            + "ADD \"c4\" TEXT NULL,\n"
+            + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
+            + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
+            + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+            + "ADD \"c8\" DECIMAL NULL"
+        ),
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        Arrays.asList(
+            "ALTER TABLE \"myTable\" \n"
+            + "ADD c1 INT NOT NULL,\n"
+            + "ADD c2 BIGINT NOT NULL,\n"
+            + "ADD c3 TEXT NOT NULL,\n"
+            + "ADD c4 TEXT NULL,\n"
+            + "ADD c5 DATE DEFAULT '2001-03-15',\n"
+            + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
+            + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+            + "ADD c8 DECIMAL NULL"
+        ),
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        Arrays.asList(
+            "ALTER TABLE myTable \n"
+            + "ADD c1 INT NOT NULL,\n"
+            + "ADD c2 BIGINT NOT NULL,\n"
+            + "ADD c3 TEXT NOT NULL,\n"
+            + "ADD c4 TEXT NULL,\n"
+            + "ADD c5 DATE DEFAULT '2001-03-15',\n"
+            + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
+            + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+            + "ADD c8 DECIMAL NULL"
+        ),
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
   }
 
   @Test
   public void shouldBuildUpsertStatement() {
-    String expected = "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
-                      "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
-                      "\"id2\") DO UPDATE SET \"columnA\"=EXCLUDED" +
-                      ".\"columnA\",\"columnB\"=EXCLUDED.\"columnB\",\"columnC\"=EXCLUDED" +
-                      ".\"columnC\",\"columnD\"=EXCLUDED.\"columnD\"";
-    String sql = dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD);
-    assertEquals(expected, sql);
+    assertEquals(
+        "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+        "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
+        "\"id2\") DO UPDATE SET \"columnA\"=EXCLUDED" +
+        ".\"columnA\",\"columnB\"=EXCLUDED.\"columnB\",\"columnC\"=EXCLUDED" +
+        ".\"columnC\",\"columnD\"=EXCLUDED.\"columnD\"",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO \"myTable\" (id1,id2,columnA,columnB," +
+        "columnC,columnD) VALUES (?,?,?,?,?,?) ON CONFLICT (id1," +
+        "id2) DO UPDATE SET columnA=EXCLUDED" +
+        ".columnA,columnB=EXCLUDED.columnB,columnC=EXCLUDED" +
+        ".columnC,columnD=EXCLUDED.columnD",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO myTable (id1,id2,columnA,columnB," +
+        "columnC,columnD) VALUES (?,?,?,?,?,?) ON CONFLICT (id1," +
+        "id2) DO UPDATE SET columnA=EXCLUDED" +
+        ".columnA,columnB=EXCLUDED.columnB,columnC=EXCLUDED" +
+        ".columnC,columnD=EXCLUDED.columnD",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
   }
 
   @Test
@@ -142,6 +256,24 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INT NOT NULL," +
         System.lineSeparator() + "\"pk2\" INT NOT NULL," + System.lineSeparator() +
         "\"col1\" INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(\"pk1\",\"pk2\"))");
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "pk1 INT NOT NULL," +
+        System.lineSeparator() + "pk2 INT NOT NULL," + System.lineSeparator() +
+        "col1 INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 INT NOT NULL," +
+        System.lineSeparator() + "pk2 INT NOT NULL," + System.lineSeparator() +
+        "col1 INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
   }
 
   @Test
@@ -159,11 +291,46 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Test
   public void upsert() {
     TableId customer = tableId("Customer");
-    assertEquals("INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
-                 "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\"," +
-                 "\"salary\"=EXCLUDED.\"salary\",\"address\"=EXCLUDED.\"address\"", dialect
-                     .buildUpsertQueryStatement(customer, columns(customer, "id"),
-                                                columns(customer, "name", "salary", "address")));
+    assertEquals(
+        "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
+         "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\"," +
+         "\"salary\"=EXCLUDED.\"salary\",\"address\"=EXCLUDED.\"address\"",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO \"Customer\" (id,name,salary,address) " +
+        "VALUES (?,?,?,?) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name," +
+        "salary=EXCLUDED.salary,address=EXCLUDED.address",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO Customer (id,name,salary,address) " +
+        "VALUES (?,?,?,?) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name," +
+        "salary=EXCLUDED.salary,address=EXCLUDED.address",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
@@ -92,40 +93,155 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
 
   @Test
   public void shouldBuildCreateQueryStatement() {
-    String expected =
-        "CREATE TABLE [myTable] (\n" + "[c1] int NOT NULL,\n" + "[c2] bigint NOT NULL,\n" +
-        "[c3] varchar(max) NOT NULL,\n" + "[c4] varchar(max) NULL,\n" +
-        "[c5] date DEFAULT '2001-03-15',\n" + "[c6] time DEFAULT '00:00:00.000',\n" +
-        "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n" + "[c8] decimal(38,4) NULL,\n" +
-        "PRIMARY KEY([c1]))";
-    String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
-    assertEquals(expected, sql);
+    assertEquals(
+        "CREATE TABLE [myTable] (\n"
+        + "[c1] int NOT NULL,\n"
+        + "[c2] bigint NOT NULL,\n"
+        + "[c3] varchar(max) NOT NULL,\n"
+        + "[c4] varchar(max) NULL,\n"
+        + "[c5] date DEFAULT '2001-03-15',\n"
+        + "[c6] time DEFAULT '00:00:00.000',\n"
+        + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "[c8] decimal(38,4) NULL,\n" +
+        "PRIMARY KEY([c1]))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "CREATE TABLE [myTable] (\n"
+        + "c1 int NOT NULL,\n"
+        + "c2 bigint NOT NULL,\n"
+        + "c3 varchar(max) NOT NULL,\n"
+        + "c4 varchar(max) NULL,\n"
+        + "c5 date DEFAULT '2001-03-15',\n"
+        + "c6 time DEFAULT '00:00:00.000',\n"
+        + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 decimal(38,4) NULL,\n" +
+        "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "CREATE TABLE myTable (\n"
+        + "c1 int NOT NULL,\n"
+        + "c2 bigint NOT NULL,\n"
+        + "c3 varchar(max) NOT NULL,\n"
+        + "c4 varchar(max) NULL,\n"
+        + "c5 date DEFAULT '2001-03-15',\n"
+        + "c6 time DEFAULT '00:00:00.000',\n"
+        + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 decimal(38,4) NULL,\n" +
+        "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
   }
 
   @Test
   public void shouldBuildAlterTableStatement() {
-    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {
-        "ALTER TABLE [myTable] ADD\n" + "[c1] int NOT NULL,\n" + "[c2] bigint NOT NULL,\n" +
-        "[c3] varchar(max) NOT NULL,\n" + "[c4] varchar(max) NULL,\n" +
-        "[c5] date DEFAULT '2001-03-15',\n" + "[c6] time DEFAULT '00:00:00.000',\n" +
-        "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n" + "[c8] decimal(38,4) NULL"};
-    assertStatements(sql, statements);
+    assertStatements(
+        new String[]{
+            "ALTER TABLE [myTable] ADD\n"
+            + "[c1] int NOT NULL,\n"
+            + "[c2] bigint NOT NULL,\n"
+            + "[c3] varchar(max) NOT NULL,\n"
+            + "[c4] varchar(max) NULL,\n"
+            + "[c5] date DEFAULT '2001-03-15',\n"
+            + "[c6] time DEFAULT '00:00:00.000',\n"
+            + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+            + "[c8] decimal(38,4) NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE [myTable] ADD\n"
+            + "c1 int NOT NULL,\n"
+            + "c2 bigint NOT NULL,\n"
+            + "c3 varchar(max) NOT NULL,\n"
+            + "c4 varchar(max) NULL,\n"
+            + "c5 date DEFAULT '2001-03-15',\n"
+            + "c6 time DEFAULT '00:00:00.000',\n"
+            + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+            + "c8 decimal(38,4) NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE myTable ADD\n"
+            + "c1 int NOT NULL,\n"
+            + "c2 bigint NOT NULL,\n"
+            + "c3 varchar(max) NOT NULL,\n"
+            + "c4 varchar(max) NULL,\n"
+            + "c5 date DEFAULT '2001-03-15',\n"
+            + "c6 time DEFAULT '00:00:00.000',\n"
+            + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
+            + "c8 decimal(38,4) NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
   }
 
   @Test
   public void shouldBuildUpsertStatement() {
-    String expected = "merge into [myTable] with (HOLDLOCK) AS target using (select ? AS [id1], ?" +
-                      " AS [id2], ? AS [columnA], ? AS [columnB], ? AS [columnC], ? AS [columnD])" +
-                      " AS incoming on (target.[id1]=incoming.[id1] and target.[id2]=incoming" +
-                      ".[id2]) when matched then update set [columnA]=incoming.[columnA]," +
-                      "[columnB]=incoming.[columnB],[columnC]=incoming.[columnC]," +
-                      "[columnD]=incoming.[columnD] when not matched then insert ([columnA], " +
-                      "[columnB], [columnC], [columnD], [id1], [id2]) values (incoming.[columnA]," +
-                      "incoming.[columnB],incoming.[columnC],incoming.[columnD],incoming.[id1]," +
-                      "incoming.[id2]);";
-    String sql = dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD);
-    assertEquals(expected, sql);
+    assertEquals(
+        "merge into [myTable] with (HOLDLOCK) AS target using (select ? AS [id1], ?" +
+        " AS [id2], ? AS [columnA], ? AS [columnB], ? AS [columnC], ? AS [columnD])" +
+        " AS incoming on (target.[id1]=incoming.[id1] and target.[id2]=incoming" +
+        ".[id2]) when matched then update set [columnA]=incoming.[columnA]," +
+        "[columnB]=incoming.[columnB],[columnC]=incoming.[columnC]," +
+        "[columnD]=incoming.[columnD] when not matched then insert ([columnA], " +
+        "[columnB], [columnC], [columnD], [id1], [id2]) values (incoming.[columnA]," +
+        "incoming.[columnB],incoming.[columnC],incoming.[columnD],incoming.[id1]," +
+        "incoming.[id2]);",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "merge into [myTable] with (HOLDLOCK) AS target using (select ? AS id1, ?" +
+        " AS id2, ? AS columnA, ? AS columnB, ? AS columnC, ? AS columnD)" +
+        " AS incoming on (target.id1=incoming.id1 and target.id2=incoming" +
+        ".id2) when matched then update set columnA=incoming.columnA," +
+        "columnB=incoming.columnB,columnC=incoming.columnC," +
+        "columnD=incoming.columnD when not matched then insert (columnA, " +
+        "columnB, columnC, columnD, id1, id2) values (incoming.columnA," +
+        "incoming.columnB,incoming.columnC,incoming.columnD,incoming.id1," +
+        "incoming.id2);",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "merge into myTable with (HOLDLOCK) AS target using (select ? AS id1, ?" +
+        " AS id2, ? AS columnA, ? AS columnB, ? AS columnC, ? AS columnD)" +
+        " AS incoming on (target.id1=incoming.id1 and target.id2=incoming" +
+        ".id2) when matched then update set columnA=incoming.columnA," +
+        "columnB=incoming.columnB,columnC=incoming.columnC," +
+        "columnD=incoming.columnD when not matched then insert (columnA, " +
+        "columnB, columnC, columnD, id1, id2) values (incoming.columnA," +
+        "incoming.columnB,incoming.columnC,incoming.columnD,incoming.id1," +
+        "incoming.id2);",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
   }
 
   @Test
@@ -172,8 +288,46 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
         ".[address] when not matched then insert " +
         "([name], [salary], [address], [id]) values (incoming.[name],incoming" +
         ".[salary],incoming.[address],incoming.[id]);",
-        dialect.buildUpsertQueryStatement(customer, columns(customer, "id"),
-                                          columns(customer, "name", "salary", "address")));
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "merge into [Customer] with (HOLDLOCK) AS target using (select ? AS id, ? AS name, ? " +
+        "AS salary, ? AS address) AS incoming on (target.id=incoming.id) when matched then update set " +
+        "name=incoming.name,salary=incoming.salary,address=incoming" +
+        ".address when not matched then insert " +
+        "(name, salary, address, id) values (incoming.name,incoming" +
+        ".salary,incoming.address,incoming.id);",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "merge into Customer with (HOLDLOCK) AS target using (select ? AS id, ? AS name, ? " +
+        "AS salary, ? AS address) AS incoming on (target.id=incoming.id) when matched then update set " +
+        "name=incoming.name,salary=incoming.salary,address=incoming" +
+        ".address when not matched then insert " +
+        "(name, salary, address, id) values (incoming.name,incoming" +
+        ".salary,incoming.address,incoming.id);",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
   }
 
   @Test
@@ -187,8 +341,48 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
         "[pages]=incoming.[pages] when not " +
         "matched then insert ([ISBN], [year], [pages], [author], [title]) values (incoming" +
         ".[ISBN],incoming.[year]," + "incoming.[pages],incoming.[author],incoming.[title]);",
-        dialect.buildUpsertQueryStatement(book, columns(book, "author", "title"),
-                                          columns(book, "ISBN", "year", "pages")));
+        dialect.buildUpsertQueryStatement(
+            book,
+            columns(book, "author", "title"),
+            columns(book, "ISBN", "year", "pages")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "merge into [Book] with (HOLDLOCK) AS target using (select ? AS author, ? AS title, ?" +
+        " AS ISBN, ? AS year, ? AS pages)" +
+        " AS incoming on (target.author=incoming.author and target.title=incoming.title)" +
+        " when matched then update set ISBN=incoming.ISBN,year=incoming.year," +
+        "pages=incoming.pages when not " +
+        "matched then insert (ISBN, year, pages, author, title) values (incoming" +
+        ".ISBN,incoming.year," + "incoming.pages,incoming.author,incoming.title);",
+        dialect.buildUpsertQueryStatement(
+            book,
+            columns(book, "author", "title"),
+            columns(book, "ISBN", "year", "pages")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "merge into Book with (HOLDLOCK) AS target using (select ? AS author, ? AS title, ?" +
+        " AS ISBN, ? AS year, ? AS pages)" +
+        " AS incoming on (target.author=incoming.author and target.title=incoming.title)" +
+        " when matched then update set ISBN=incoming.ISBN,year=incoming.year," +
+        "pages=incoming.pages when not " +
+        "matched then insert (ISBN, year, pages, author, title) values (incoming" +
+        ".ISBN,incoming.year," + "incoming.pages,incoming.author,incoming.title);",
+        dialect.buildUpsertQueryStatement(
+            book,
+            columns(book, "author", "title"),
+            columns(book, "ISBN", "year", "pages")
+        )
+    );
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -26,10 +26,12 @@ import org.junit.Test;
 
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.List;
 
 import io.confluent.connect.jdbc.sink.SqliteHelper;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
 
@@ -110,28 +112,104 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
 
   @Test
   public void shouldBuildCreateQueryStatement() {
-    String expected =
-        "CREATE TABLE `myTable` (\n" + "`c1` INTEGER NOT NULL,\n" + "`c2` INTEGER NOT NULL,\n" +
-        "`c3` TEXT NOT NULL,\n" + "`c4` TEXT NULL,\n" + "`c5` NUMERIC DEFAULT '2001-03-15',\n" +
-        "`c6` NUMERIC DEFAULT '00:00:00.000',\n" +
-        "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n" + "`c8` NUMERIC NULL,\n" +
-        "PRIMARY KEY(`c1`))";
-    String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
-    assertEquals(expected, sql);
+    assertEquals(
+        "CREATE TABLE `myTable` (\n"
+        + "`c1` INTEGER NOT NULL,\n"
+        + "`c2` INTEGER NOT NULL,\n"
+        + "`c3` TEXT NOT NULL,\n"
+        + "`c4` TEXT NULL,\n"
+        + "`c5` NUMERIC DEFAULT '2001-03-15',\n"
+        + "`c6` NUMERIC DEFAULT '00:00:00.000',\n"
+        + "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "`c8` NUMERIC NULL,\n"
+        + "PRIMARY KEY(`c1`))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "CREATE TABLE `myTable` (\n"
+        + "c1 INTEGER NOT NULL,\n"
+        + "c2 INTEGER NOT NULL,\n"
+        + "c3 TEXT NOT NULL,\n"
+        + "c4 TEXT NULL,\n"
+        + "c5 NUMERIC DEFAULT '2001-03-15',\n"
+        + "c6 NUMERIC DEFAULT '00:00:00.000',\n"
+        + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 NUMERIC NULL,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "CREATE TABLE myTable (\n"
+        + "c1 INTEGER NOT NULL,\n"
+        + "c2 INTEGER NOT NULL,\n"
+        + "c3 TEXT NOT NULL,\n"
+        + "c4 TEXT NULL,\n"
+        + "c5 NUMERIC DEFAULT '2001-03-15',\n"
+        + "c6 NUMERIC DEFAULT '00:00:00.000',\n"
+        + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 NUMERIC NULL,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
   }
 
   @Test
   public void shouldBuildAlterTableStatement() {
-    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE `myTable` ADD `c1` INTEGER NOT NULL",
-                    "ALTER TABLE `myTable` ADD `c2` INTEGER NOT NULL",
-                    "ALTER TABLE `myTable` ADD `c3` TEXT NOT NULL",
-                    "ALTER TABLE `myTable` ADD `c4` TEXT NULL",
-                    "ALTER TABLE `myTable` ADD `c5` NUMERIC DEFAULT '2001-03-15'",
-                    "ALTER TABLE `myTable` ADD `c6` NUMERIC DEFAULT '00:00:00.000'",
-                    "ALTER TABLE `myTable` ADD `c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000'",
-                    "ALTER TABLE `myTable` ADD `c8` NUMERIC NULL"};
-    assertStatements(sql, statements);
+    assertStatements(
+        new String[]{
+            "ALTER TABLE `myTable` ADD `c1` INTEGER NOT NULL",
+            "ALTER TABLE `myTable` ADD `c2` INTEGER NOT NULL",
+            "ALTER TABLE `myTable` ADD `c3` TEXT NOT NULL",
+            "ALTER TABLE `myTable` ADD `c4` TEXT NULL",
+            "ALTER TABLE `myTable` ADD `c5` NUMERIC DEFAULT '2001-03-15'",
+            "ALTER TABLE `myTable` ADD `c6` NUMERIC DEFAULT '00:00:00.000'",
+            "ALTER TABLE `myTable` ADD `c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000'",
+            "ALTER TABLE `myTable` ADD `c8` NUMERIC NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE `myTable` ADD c1 INTEGER NOT NULL",
+            "ALTER TABLE `myTable` ADD c2 INTEGER NOT NULL",
+            "ALTER TABLE `myTable` ADD c3 TEXT NOT NULL",
+            "ALTER TABLE `myTable` ADD c4 TEXT NULL",
+            "ALTER TABLE `myTable` ADD c5 NUMERIC DEFAULT '2001-03-15'",
+            "ALTER TABLE `myTable` ADD c6 NUMERIC DEFAULT '00:00:00.000'",
+            "ALTER TABLE `myTable` ADD c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000'",
+            "ALTER TABLE `myTable` ADD c8 NUMERIC NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE myTable ADD c1 INTEGER NOT NULL",
+            "ALTER TABLE myTable ADD c2 INTEGER NOT NULL",
+            "ALTER TABLE myTable ADD c3 TEXT NOT NULL",
+            "ALTER TABLE myTable ADD c4 TEXT NULL",
+            "ALTER TABLE myTable ADD c5 NUMERIC DEFAULT '2001-03-15'",
+            "ALTER TABLE myTable ADD c6 NUMERIC DEFAULT '00:00:00.000'",
+            "ALTER TABLE myTable ADD c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000'",
+            "ALTER TABLE myTable ADD c8 NUMERIC NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
   }
 
   @Test
@@ -161,6 +239,22 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
         "CREATE TABLE `myTable` (" + System.lineSeparator() + "`pk1` INTEGER NOT NULL," +
         System.lineSeparator() + "`pk2` INTEGER NOT NULL," + System.lineSeparator() +
         "`col1` INTEGER NOT NULL," + System.lineSeparator() + "PRIMARY KEY(`pk1`,`pk2`))");
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE `myTable` (" + System.lineSeparator() + "pk1 INTEGER NOT NULL," +
+        System.lineSeparator() + "pk2 INTEGER NOT NULL," + System.lineSeparator() +
+        "col1 INTEGER NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 INTEGER NOT NULL," +
+        System.lineSeparator() + "pk2 INTEGER NOT NULL," + System.lineSeparator() +
+        "col1 INTEGER NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
   }
 
   @Test
@@ -179,8 +273,36 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
     TableId book = new TableId(null, null, "Book");
     assertEquals(
         "INSERT OR REPLACE INTO `Book`(`author`,`title`,`ISBN`,`year`,`pages`) VALUES(?,?,?,?,?)",
-        dialect.buildUpsertQueryStatement(book, columns(book, "author", "title"),
-                                          columns(book, "ISBN", "year", "pages")));
+        dialect.buildUpsertQueryStatement(
+            book,
+            columns(book, "author", "title"),
+            columns(book, "ISBN", "year", "pages")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "INSERT OR REPLACE INTO `Book`(author,title,ISBN,year,pages) VALUES(?,?,?,?,?)",
+        dialect.buildUpsertQueryStatement(
+            book,
+            columns(book, "author", "title"),
+            columns(book, "ISBN", "year", "pages")
+        )
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "INSERT OR REPLACE INTO Book(author,title,ISBN,year,pages) VALUES(?,?,?,?,?)",
+        dialect.buildUpsertQueryStatement(
+            book,
+            columns(book, "author", "title"),
+            columns(book, "ISBN", "year", "pages")
+        )
+    );
   }
 
   @Test(expected = SQLException.class)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import io.confluent.connect.jdbc.util.QuoteMethod;
+
 import static org.junit.Assert.assertEquals;
 
 public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseDialect> {
@@ -90,28 +92,104 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
 
   @Test
   public void shouldBuildCreateQueryStatement() {
-    String expected =
-        "CREATE TABLE \"myTable\" (\n" + "\"c1\" INT NOT NULL,\n" + "\"c2\" INT NOT NULL,\n" +
-        "\"c3\" VARCHAR(1024) NOT NULL,\n" + "\"c4\" VARCHAR(1024) NULL,\n" +
-        "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n" +
-        "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(18,4) NULL,\n" +
-        "PRIMARY KEY(\"c1\"))";
-    String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
-    assertEquals(expected, sql);
+    assertEquals(
+        "CREATE TABLE \"myTable\" (\n"
+        + "\"c1\" INT NOT NULL,\n"
+        + "\"c2\" INT NOT NULL,\n"
+        + "\"c3\" VARCHAR(1024) NOT NULL,\n"
+        + "\"c4\" VARCHAR(1024) NULL,\n"
+        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
+        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "\"c8\" DECIMAL(18,4) NULL,\n"
+        + "PRIMARY KEY(\"c1\"))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "CREATE TABLE \"myTable\" (\n"
+        + "c1 INT NOT NULL,\n"
+        + "c2 INT NOT NULL,\n"
+        + "c3 VARCHAR(1024) NOT NULL,\n"
+        + "c4 VARCHAR(1024) NULL,\n"
+        + "c5 DATE DEFAULT '2001-03-15',\n"
+        + "c6 TIME DEFAULT '00:00:00.000',\n"
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 DECIMAL(18,4) NULL,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertEquals(
+        "CREATE TABLE myTable (\n"
+        + "c1 INT NOT NULL,\n"
+        + "c2 INT NOT NULL,\n"
+        + "c3 VARCHAR(1024) NOT NULL,\n"
+        + "c4 VARCHAR(1024) NULL,\n"
+        + "c5 DATE DEFAULT '2001-03-15',\n"
+        + "c6 TIME DEFAULT '00:00:00.000',\n"
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 DECIMAL(18,4) NULL,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
   }
 
   @Test
   public void shouldBuildAlterTableStatement() {
-    List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" ADD \"c1\" INT NOT NULL",
-                    "ALTER TABLE \"myTable\" ADD \"c2\" INT NOT NULL",
-                    "ALTER TABLE \"myTable\" ADD \"c3\" VARCHAR(1024) NOT NULL",
-                    "ALTER TABLE \"myTable\" ADD \"c4\" VARCHAR(1024) NULL",
-                    "ALTER TABLE \"myTable\" ADD \"c5\" DATE DEFAULT '2001-03-15'",
-                    "ALTER TABLE \"myTable\" ADD \"c6\" TIME DEFAULT '00:00:00.000'",
-                    "ALTER TABLE \"myTable\" ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 " +
-                    "00:00:00.000'", "ALTER TABLE \"myTable\" ADD \"c8\" DECIMAL(18,4) NULL"};
-    assertStatements(sql, statements);
+    assertStatements(
+        new String[]{
+            "ALTER TABLE \"myTable\" ADD \"c1\" INT NOT NULL",
+            "ALTER TABLE \"myTable\" ADD \"c2\" INT NOT NULL",
+            "ALTER TABLE \"myTable\" ADD \"c3\" VARCHAR(1024) NOT NULL",
+            "ALTER TABLE \"myTable\" ADD \"c4\" VARCHAR(1024) NULL",
+            "ALTER TABLE \"myTable\" ADD \"c5\" DATE DEFAULT '2001-03-15'",
+            "ALTER TABLE \"myTable\" ADD \"c6\" TIME DEFAULT '00:00:00.000'",
+            "ALTER TABLE \"myTable\" ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
+            "ALTER TABLE \"myTable\" ADD \"c8\" DECIMAL(18,4) NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE \"myTable\" ADD c1 INT NOT NULL",
+            "ALTER TABLE \"myTable\" ADD c2 INT NOT NULL",
+            "ALTER TABLE \"myTable\" ADD c3 VARCHAR(1024) NOT NULL",
+            "ALTER TABLE \"myTable\" ADD c4 VARCHAR(1024) NULL",
+            "ALTER TABLE \"myTable\" ADD c5 DATE DEFAULT '2001-03-15'",
+            "ALTER TABLE \"myTable\" ADD c6 TIME DEFAULT '00:00:00.000'",
+            "ALTER TABLE \"myTable\" ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
+            "ALTER TABLE \"myTable\" ADD c8 DECIMAL(18,4) NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE myTable ADD c1 INT NOT NULL",
+            "ALTER TABLE myTable ADD c2 INT NOT NULL",
+            "ALTER TABLE myTable ADD c3 VARCHAR(1024) NOT NULL",
+            "ALTER TABLE myTable ADD c4 VARCHAR(1024) NULL",
+            "ALTER TABLE myTable ADD c5 DATE DEFAULT '2001-03-15'",
+            "ALTER TABLE myTable ADD c6 TIME DEFAULT '00:00:00.000'",
+            "ALTER TABLE myTable ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
+            "ALTER TABLE myTable ADD c8 DECIMAL(18,4) NULL"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
   }
 
   @Test(expected = UnsupportedOperationException.class)
@@ -139,6 +217,22 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
         "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INT NOT NULL," +
         System.lineSeparator() + "\"pk2\" INT NOT NULL," + System.lineSeparator() +
         "\"col1\" INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(\"pk1\",\"pk2\"))");
+
+    quoteTableNames = QuoteMethod.ALWAYS;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "pk1 INT NOT NULL," +
+        System.lineSeparator() + "pk2 INT NOT NULL," + System.lineSeparator() +
+        "col1 INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
+
+    quoteTableNames = QuoteMethod.NEVER;
+    quoteColumnNames = QuoteMethod.NEVER;
+    dialect = createDialect();
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 INT NOT NULL," +
+        System.lineSeparator() + "pk2 INT NOT NULL," + System.lineSeparator() +
+        "col1 INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -29,6 +29,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
@@ -41,6 +44,10 @@ public class TimestampIncrementingCriteriaTest {
   private static final ColumnId TS2_COLUMN = new ColumnId(TABLE_ID, "ts2");
   private static final List<ColumnId> TS_COLUMNS = Arrays.asList(TS1_COLUMN, TS2_COLUMN);
 
+  private IdentifierRules rules;
+  private QuoteMethod tableQuotes;
+  private QuoteMethod columnQuotes;
+  private ExpressionBuilder builder;
   private TimestampIncrementingCriteria criteria;
   private TimestampIncrementingCriteria criteriaInc;
   private TimestampIncrementingCriteria criteriaTs;
@@ -54,6 +61,10 @@ public class TimestampIncrementingCriteriaTest {
     criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null);
     criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS);
     criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS);
+    tableQuotes = null;
+    columnQuotes = null;
+    rules = null;
+    builder = null;
   }
 
   protected void assertExtractedOffset(long expected, Schema schema, Struct record) {
@@ -121,5 +132,135 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema).put("id", 42);
     assertExtractedOffset(42L, schema, record);
 
+  }
+
+  @Test
+  public void createIncrementingWhereClause() {
+    builder = builder();
+    criteriaInc.incrementingWhereClause(builder);
+    assertEquals(
+        " WHERE \"myTable\".\"id\" > ? ORDER BY \"myTable\".\"id\" ASC",
+        builder.toString()
+    );
+
+    tableQuotes = QuoteMethod.ALWAYS;
+    columnQuotes = QuoteMethod.NEVER;
+    builder = builder();
+    criteriaInc.incrementingWhereClause(builder);
+    assertEquals(
+        " WHERE \"myTable\".id > ? ORDER BY \"myTable\".id ASC",
+        builder.toString()
+    );
+
+    tableQuotes = QuoteMethod.NEVER;
+    columnQuotes = QuoteMethod.NEVER;
+    builder = builder();
+    criteriaInc.incrementingWhereClause(builder);
+    assertEquals(
+        " WHERE myTable.id > ? ORDER BY myTable.id ASC",
+        builder.toString()
+    );
+  }
+
+  @Test
+  public void createTimestampWhereClause() {
+    builder = builder();
+    criteriaTs.timestampWhereClause(builder);
+    assertEquals(
+        " WHERE "
+        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") > ? "
+        + "AND "
+        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") < ? "
+        + "ORDER BY "
+        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") "
+        + "ASC",
+        builder.toString()
+    );
+
+    tableQuotes = QuoteMethod.ALWAYS;
+    columnQuotes = QuoteMethod.NEVER;
+    builder = builder();
+    criteriaTs.timestampWhereClause(builder);
+    assertEquals(
+        " WHERE "
+        + "COALESCE(\"myTable\".ts1,\"myTable\".ts2) > ? "
+        + "AND "
+        + "COALESCE(\"myTable\".ts1,\"myTable\".ts2) < ? "
+        + "ORDER BY "
+        + "COALESCE(\"myTable\".ts1,\"myTable\".ts2) "
+        + "ASC",
+        builder.toString()
+    );
+
+    tableQuotes = QuoteMethod.NEVER;
+    columnQuotes = QuoteMethod.NEVER;
+    builder = builder();
+    criteriaTs.timestampWhereClause(builder);
+    assertEquals(
+        " WHERE "
+        + "COALESCE(myTable.ts1,myTable.ts2) > ? "
+        + "AND "
+        + "COALESCE(myTable.ts1,myTable.ts2) < ? "
+        + "ORDER BY "
+        + "COALESCE(myTable.ts1,myTable.ts2) "
+        + "ASC",
+        builder.toString()
+    );
+  }
+
+  @Test
+  public void createTimestampIncrementingWhereClause() {
+    builder = builder();
+    criteriaIncTs.timestampIncrementingWhereClause(builder);
+    assertEquals(
+        " WHERE "
+        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") < ? "
+        + "AND ("
+        + "(COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") = ? AND \"myTable\".\"id\" > ?) "
+        + "OR "
+        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") > ?) "
+        + "ORDER BY COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\"),"
+        + "\"myTable\".\"id\" ASC",
+        builder.toString()
+    );
+
+    tableQuotes = QuoteMethod.ALWAYS;
+    columnQuotes = QuoteMethod.NEVER;
+    builder = builder();
+    criteriaIncTs.timestampIncrementingWhereClause(builder);
+    assertEquals(
+        " WHERE "
+        + "COALESCE(\"myTable\".ts1,\"myTable\".ts2) < ? "
+        + "AND ("
+        + "(COALESCE(\"myTable\".ts1,\"myTable\".ts2) = ? AND \"myTable\".id > ?) "
+        + "OR "
+        + "COALESCE(\"myTable\".ts1,\"myTable\".ts2) > ?) "
+        + "ORDER BY COALESCE(\"myTable\".ts1,\"myTable\".ts2),"
+        + "\"myTable\".id ASC",
+        builder.toString()
+    );
+
+    tableQuotes = QuoteMethod.NEVER;
+    columnQuotes = QuoteMethod.NEVER;
+    builder = builder();
+    criteriaIncTs.timestampIncrementingWhereClause(builder);
+    assertEquals(
+        " WHERE "
+        + "COALESCE(myTable.ts1,myTable.ts2) < ? "
+        + "AND ("
+        + "(COALESCE(myTable.ts1,myTable.ts2) = ? AND myTable.id > ?) "
+        + "OR "
+        + "COALESCE(myTable.ts1,myTable.ts2) > ?) "
+        + "ORDER BY COALESCE(myTable.ts1,myTable.ts2),"
+        + "myTable.id ASC",
+        builder.toString()
+    );
+  }
+
+  protected ExpressionBuilder builder() {
+    ExpressionBuilder result = new ExpressionBuilder(rules);
+    result.setQuoteTables(tableQuotes);
+    result.setQuoteColumns(columnQuotes);
+    return result;
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/ExpressionBuilderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/ExpressionBuilderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExpressionBuilderTest {
+
+  protected static final TableId TABLE_ID_T1 = new TableId("c", "s", "t1");
+  protected static final ColumnId COLUMN_ID_T1_A = new ColumnId(TABLE_ID_T1, "c1");
+
+  protected static final TableId TABLE_ID_T2 = new TableId(null, null, "t2");
+  protected static final ColumnId COLUMN_ID_T2_A = new ColumnId(TABLE_ID_T2, "c2");
+
+  private IdentifierRules rules;
+  private QuoteMethod tableQuotes;
+  private QuoteMethod columnQuotes;
+
+  @Before
+  public void setup() {
+    rules = null;
+    tableQuotes = QuoteMethod.ALWAYS;
+    columnQuotes = QuoteMethod.ALWAYS;
+  }
+
+  @Test
+  public void shouldQuoteTableNamesByDefault() {
+    assertExpression("\"c\".\"s\".\"t1\"", b-> b.append(TABLE_ID_T1));
+    assertExpression("\"t1\"", b-> b.appendTableName(TABLE_ID_T1.tableName()));
+
+    assertExpression("\"t2\"", b-> b.append(TABLE_ID_T2));
+    assertExpression("\"t2\"", b-> b.appendTableName(TABLE_ID_T2.tableName()));
+  }
+
+  @Test
+  public void shouldQuoteTableNamesOnlyWhenSet() {
+    tableQuotes = QuoteMethod.ALWAYS;
+    assertExpression("\"c\".\"s\".\"t1\"", b-> b.append(TABLE_ID_T1));
+    assertExpression("\"t1\"", b-> b.appendTableName(TABLE_ID_T1.tableName()));
+
+    assertExpression("\"t2\"", b-> b.append(TABLE_ID_T2));
+    assertExpression("\"t2\"", b-> b.appendTableName(TABLE_ID_T2.tableName()));
+
+    tableQuotes = QuoteMethod.NEVER;
+    assertExpression("c.s.t1", b-> b.append(TABLE_ID_T1));
+    assertExpression("t1", b-> b.appendTableName(TABLE_ID_T1.tableName()));
+
+    assertExpression("t2", b-> b.append(TABLE_ID_T2));
+    assertExpression("t2", b-> b.appendTableName(TABLE_ID_T2.tableName()));
+  }
+
+  @Test
+  public void shouldQuoteTableNamesAndColumnNamesByDefault() {
+    assertExpression("\"c\".\"s\".\"t1\".\"c1\"", b-> b.append(COLUMN_ID_T1_A));
+    assertExpression("\"t2\".\"c2\"", b-> b.append(COLUMN_ID_T2_A));
+  }
+
+  @Test
+  public void shouldQuoteTableNamesAndColumnNamesOnlyWhenSet() {
+    tableQuotes = QuoteMethod.ALWAYS;
+    columnQuotes = QuoteMethod.ALWAYS;
+    assertExpression("\"c\".\"s\".\"t1\".\"c1\"", b-> b.append(COLUMN_ID_T1_A));
+    assertExpression("\"t2\".\"c2\"", b-> b.append(COLUMN_ID_T2_A));
+
+    tableQuotes = QuoteMethod.NEVER;
+    columnQuotes = QuoteMethod.ALWAYS;
+    assertExpression("c.s.t1.\"c1\"", b-> b.append(COLUMN_ID_T1_A));
+    assertExpression("t2.\"c2\"", b-> b.append(COLUMN_ID_T2_A));
+
+    tableQuotes = QuoteMethod.ALWAYS;
+    columnQuotes = QuoteMethod.NEVER;
+    assertExpression("\"c\".\"s\".\"t1\".c1", b-> b.append(COLUMN_ID_T1_A));
+    assertExpression("\"t2\".c2", b-> b.append(COLUMN_ID_T2_A));
+
+    tableQuotes = QuoteMethod.NEVER;
+    columnQuotes = QuoteMethod.NEVER;
+    assertExpression("c.s.t1.c1", b-> b.append(COLUMN_ID_T1_A));
+    assertExpression("t2.c2", b-> b.append(COLUMN_ID_T2_A));
+  }
+
+  @Test
+  public void shouldQuoteColumnNamesWhenSet() {
+    columnQuotes = QuoteMethod.ALWAYS;
+    assertExpression("\"c1\"", b-> b.appendColumnName(COLUMN_ID_T1_A.name()));
+    assertExpression("\"c2\"", b-> b.appendColumnName(COLUMN_ID_T2_A.name()));
+
+    columnQuotes = QuoteMethod.NEVER;
+    assertExpression("c1", b-> b.appendColumnName(COLUMN_ID_T1_A.name()));
+    assertExpression("c2", b-> b.appendColumnName(COLUMN_ID_T2_A.name()));
+  }
+
+  protected void assertExpression(String expected, Consumer<ExpressionBuilder> builderFunction) {
+    ExpressionBuilder builder = builderWith(rules);
+    builderFunction.accept(builder);
+    String actual = builder.toString();
+    assertEquals(expected, actual);
+  }
+
+  protected ExpressionBuilder builderWith(IdentifierRules rules) {
+    ExpressionBuilder result = new ExpressionBuilder(rules);
+    result.setQuoteTables(tableQuotes);
+    result.setQuoteColumns(columnQuotes);
+    return result;
+  }
+
+}


### PR DESCRIPTION
Added the ability for JDBC source and sink connector configurations to explicitly set when table and column names would be quoted within DDL and DML statements, including the generated WHERE criteria. This is useful, for example, when column or table names don’t match exactly the records, and when incrementing and timestamp columns specified in the configuration include fully-qualified names, functions, or already-quoted values.

The `quote.table.names` and `quote.column.names` can be independently set to `always` or `never`. For example:
```
   quote.table.names=never
   quote.column.names=never
```

***This PR does maintains existing behavior for unmodified connector configurations.*** It is possible that some existing connectors may be relying upon the previous quoting behavior, especially if the table names or column names did require quoting. Therefore, the default for both `quote.table.names` and `quote.column.names` is `always` to match prior behavior; set these explicitly in any connector configuration to avoid quoting of columns and/or tables requires.

This is a long-standing problem identified through quite a few still-open issues. In fact, this PR will fix several:

Fixes #555 
Fixes #455 
Fixes #432
Fixes #369 
Fixes #274
Fixes #439

Another, #269 and the corresponding PR #270 proposed a similar approach but also included other changes (e.g., configs for alias incrementing and timestamp columns). #270 also _changed_ the existing behavior, which as outlined above was avoided with this PR. Consequently, #269 is not fixed in its entirety.