### PR TITLE
CC-3578: Logging query for source connector at INFO level only the first time it's used

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -53,14 +53,14 @@ public class BulkTableQuerier extends TableQuerier {
       case TABLE:
         String queryStr = dialect.expressionBuilder().append("SELECT * FROM ")
                                  .append(tableId).toString();
+        recordQuery(queryStr);
         log.debug("{} prepared SQL query: {}", this, queryStr);
         stmt = dialect.createPreparedStatement(db, queryStr);
-        recordQuery(queryStr);
         break;
       case QUERY:
+        recordQuery(query);
         log.debug("{} prepared SQL query: {}", this, query);
         stmt = dialect.createPreparedStatement(db, query);
-        recordQuery(query);
         break;
       default:
         throw new ConnectException("Unknown mode: " + mode);

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -55,10 +55,12 @@ public class BulkTableQuerier extends TableQuerier {
                                  .append(tableId).toString();
         log.debug("{} prepared SQL query: {}", this, queryStr);
         stmt = dialect.createPreparedStatement(db, queryStr);
+        recordQuery(queryStr);
         break;
       case QUERY:
         log.debug("{} prepared SQL query: {}", this, query);
         stmt = dialect.createPreparedStatement(db, query);
+        recordQuery(query);
         break;
       default:
         throw new ConnectException("Unknown mode: " + mode);

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -17,6 +17,8 @@
 package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -37,6 +39,8 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     QUERY // User-specified query
   }
 
+  private final Logger log = LoggerFactory.getLogger(getClass()); // use concrete subclass
+
   protected final DatabaseDialect dialect;
   protected final QueryMode mode;
   protected final String query;
@@ -49,6 +53,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected PreparedStatement stmt;
   protected ResultSet resultSet;
   protected SchemaMapping schemaMapping;
+  private String loggedQueryString;
 
   public TableQuerier(
       DatabaseDialect dialect,
@@ -128,6 +133,14 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       }
     }
     resultSet = null;
+  }
+
+  protected void recordQuery(String query) {
+    if (query != null && !query.equals(loggedQueryString)) {
+      // For usability, log the statement at INFO level only when it changes
+      log.info("Begin using SQL query: {}", query);
+      loggedQueryString = query;
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -160,6 +160,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     String queryString = builder.toString();
     log.debug("{} prepared SQL query: {}", this, queryString);
     stmt = dialect.createPreparedStatement(db, queryString);
+    recordQuery(queryString);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -158,9 +158,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     criteria.whereClause(builder);
 
     String queryString = builder.toString();
+    recordQuery(queryString);
     log.debug("{} prepared SQL query: {}", this, queryString);
     stmt = dialect.createPreparedStatement(db, queryString);
-    recordQuery(queryString);
   }
 
   @Override


### PR DESCRIPTION
This will log at INFO level the parameterized query statements the first time their used (or if they change), so that users don't have to change to DEBUG level to know what these query statements are. The existing DEBUG statements will continue to be logged *every* time the queries are generated and executed.

Fixes #559 