### PR TITLE
Fix PostgreSqlDatabaseDialect to generate proper UPSERT queries when …

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -243,11 +243,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
            .delimitedBy(",")
            .transformedBy(ExpressionBuilder.columnNames())
            .of(keyColumns);
-    builder.append(") DO UPDATE SET ");
-    builder.appendList()
-           .delimitedBy(",")
-           .transformedBy(transform)
-           .of(nonKeyColumns);
+    if (nonKeyColumns.isEmpty()) {
+      builder.append(") DO NOTHING");
+    } else {
+      builder.append(") DO UPDATE SET ");
+      builder.appendList()
+              .delimitedBy(",")
+              .transformedBy(transform)
+              .of(nonKeyColumns);
+    }
     return builder.toString();
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -239,6 +239,16 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         )
     );
 
+    assertEquals(
+            "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
+                    "VALUES (?,?,?,?) ON CONFLICT (\"id\",\"name\",\"salary\",\"address\") DO NOTHING",
+            dialect.buildUpsertQueryStatement(
+                    customer,
+                    columns(customer, "id", "name", "salary", "address"),
+                    columns(customer)
+            )
+    );
+
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
 
@@ -251,6 +261,16 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             columns(customer, "id"),
             columns(customer, "name", "salary", "address")
         )
+    );
+
+    assertEquals(
+            "INSERT INTO Customer (id,name,salary,address) " +
+                    "VALUES (?,?,?,?) ON CONFLICT (id,name,salary,address) DO NOTHING",
+            dialect.buildUpsertQueryStatement(
+                    customer,
+                    columns(customer, "id", "name", "salary", "address"),
+                    columns(customer)
+            )
     );
   }
 


### PR DESCRIPTION
…no non-key columns are present

This commit fixes #401.

- Currently the PostgreSqlDatabaseDialect generates UPSERT queries of
  the form `ON CONFLICT (<keyColums>) DO UPDATE SET (<nonKeyColumns>)`
  unconditionally. This causes malformed queries to be generated when
  `nonKeyColumns` is empty. ie. all columns are part of the primary key.
- To fix this scenario, we generate `DO NOTHING` in the case when
  `nonKeyColumns` is empty. To test for this, two additional asserts are
  added to `PostgreSqlDatabaseDialectTest#upsert()`.