### PR TITLE
MINOR: CC-3812: Update unit test to use updated DateTimeUtils function

### DIFF
--- a/licenses.html
+++ b/licenses.html
@@ -33,7 +33,7 @@ th {
 </THEAD>
 <TBODY>
 <TR>
-<TD><A HREF="http://confluent.io">kafka-connect-jdbc-5.2.0-SNAPSHOT</A></TD><TD>jar</TD><TD>5.2.0-SNAPSHOT</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</A><br></TD></TR>
+<TD><A HREF="http://confluent.io">kafka-connect-jdbc-5.3.0-SNAPSHOT</A></TD><TD>jar</TD><TD>5.3.0-SNAPSHOT</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</A><br></TD></TR>
 <TR>
 <TD>postgresql-9.4-1206-jdbc41</TD><TD>jar</TD><TD>9.4.0.build-1206</TD><TD><A HREF="http://www.postgresql.org/about/licence/">link from artifact (META-INF/MANIFEST.MF)</A><br></TD></TR>
 <TR>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -286,7 +286,7 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
 
   @Test
   public void useCurrentTimestampValue() throws SQLException {
-    Calendar cal = DateTimeUtils.UTC_CALENDAR.get();
+    Calendar cal = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone("UTC"));
 
     //Regular expression to check if the timestamp is of the format %Y-%m-%d %H:%M:%S.%f
     Pattern p = Pattern.compile("(\\p{Nd}++)\\Q-\\E(\\p{Nd}++)\\Q-\\E(\\p{Nd}++)\\Q \\E(\\p{Nd}++)"

--- a/src/test/java/io/confluent/connect/jdbc/source/MockTime.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/MockTime.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc.source;
 import org.apache.kafka.common.utils.Time;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * A clock that you can manually advance by calling sleep
@@ -58,4 +59,8 @@ public class MockTime implements Time {
         this.nanos += TimeUnit.NANOSECONDS.convert(ms, TimeUnit.MILLISECONDS);
     }
 
+    @Override
+    public void waitObject(Object obj, Supplier<Boolean> condition, long timeoutMs) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
DateTimeUtils in branch 5.2.x has function ```getTimeZoneCalendar``` instead of ```UTC_CALENDAR.get()```

Modifying unit test ```useCurrentTimestampValue()``` in ```SqliteDatabaseDialect.java``` to use the updated function