### PR TITLE
MINOR: CC-3812: Update unit test to use updated DateTimeUtils function

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -286,7 +286,7 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
 
   @Test
   public void useCurrentTimestampValue() throws SQLException {
-    Calendar cal = DateTimeUtils.UTC_CALENDAR.get();
+    Calendar cal = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone("UTC"));
 
     //Regular expression to check if the timestamp is of the format %Y-%m-%d %H:%M:%S.%f
     Pattern p = Pattern.compile("(\\p{Nd}++)\\Q-\\E(\\p{Nd}++)\\Q-\\E(\\p{Nd}++)\\Q \\E(\\p{Nd}++)"


### PR DESCRIPTION
DateTimeUtils in branch 5.2.x has function ```getTimeZoneCalendar()``` instead of ```UTC_CALENDAR.get()```

Modifying unit test ```useCurrentTimestampValue()``` in ```SqliteDatabaseDialect.java``` to use the updated function