### PR TITLE
Non optional columns should be NOT NULL

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1633,6 +1633,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           f.schemaType(),
           f.defaultValue()
       );
+      if (!isColumnOptional(f)) {
+        builder.append(" NOT NULL");
+      }
     } else if (isColumnOptional(f)) {
       builder.append(" NULL");
     } else {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -311,7 +311,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   protected void verifyAlterAddTwoCols(String... expected) {
     assertArrayEquals(expected, dialect.buildAlterTable(tableId, Arrays.asList(
         new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "newcol1", false),
-        new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "newcol2", false)
+        new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "newcol2", false)
     )).toArray());
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -374,12 +374,15 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
   @Test
   public void writeColumnSpec() {
-    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(
-        SchemaBuilder.int32().defaultValue(42).build(), "foo", true));
+    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", true));
     verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", false));
     verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", true));
+    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", false));
 
     quoteIdentfiiers = QuoteMethod.NEVER;
+    verifyWriteColumnSpec("foo DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", true));
+    verifyWriteColumnSpec("foo DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", false));
+    verifyWriteColumnSpec("foo DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", true));
     verifyWriteColumnSpec("foo DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", false));
     verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", true));
     verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", false));

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -374,10 +374,10 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
   @Test
   public void writeColumnSpec() {
-    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(
+    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(
         SchemaBuilder.int32().defaultValue(42).build(), "foo", true));
-    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", false));
-    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", true));
+    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().defaultValue(42).build(), "foo", false));
+    verifyWriteColumnSpec("\"foo\" DUMMY DEFAULT 42 NOT NULL", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", true));
 
     quoteIdentfiiers = QuoteMethod.NEVER;
     verifyWriteColumnSpec("foo DUMMY DEFAULT 42", new SinkRecordField(SchemaBuilder.int32().optional().defaultValue(42).build(), "foo", false));


### PR DESCRIPTION
According to the SQL Specification, a primary key can not contain NULL.
Some SQL engines accept a column spec for primary key without "NOT NULL",
but some do not - for instance, in DB2 one cannot define a "PRIMARY KEY"
column without "NOT NULL".

References: https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.1.0/com.ibm.db2.luw.sql.ref.doc/doc/r0000927.html
> PRIMARY KEY (column-name,...)
> Defines a primary key that is composed of the identified columns. The clause must not be specified more than once, and the identified columns must be defined as NOT NULL.

https://docs.microsoft.com/en-us/sql/relational-databases/tables/create-primary-keys?view=sql-server-2017
> All columns defined within a PRIMARY KEY constraint must be defined as NOT NULL.

(and is essentially the same for all other DBMS dialects that I checked)