### PR TITLE
Backport db.timzeone config

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -16,6 +16,8 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.data.Date;
@@ -134,6 +136,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();
   private final Queue<Connection> connections = new ConcurrentLinkedQueue<>();
   private volatile JdbcDriverInfo jdbcDriverInfo;
+  private final TimeZone timeZone;
 
   /**
    * Create a new dialect instance with the given connector configuration.
@@ -177,6 +180,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       mapNumerics = ((JdbcSourceConnectorConfig)config).numericMapping();
     } else {
       mapNumerics = NumericMapping.NONE;
+    }
+
+    if (config instanceof JdbcSourceConnectorConfig) {
+      timeZone = ((JdbcSourceConnectorConfig) config).timeZone();
+    } else if (config instanceof JdbcSinkConfig) {
+      timeZone = ((JdbcSinkConfig) config).timeZone;
+    } else {
+      timeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
     }
   }
 
@@ -822,7 +833,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       ColumnId incrementingColumn,
       List<ColumnId> timestampColumns
   ) {
-    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns);
+    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns, timeZone);
   }
 
   /**
@@ -1207,19 +1218,19 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         return rs -> rs.getBytes(col);
       }
 
-      // Date is day + moth + year
+      // Date is day + month + year
       case Types.DATE: {
-        return rs -> rs.getDate(col, DateTimeUtils.UTC_CALENDAR.get());
+        return rs -> rs.getDate(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Time is a time of day -- hour, minute, seconds, nanoseconds
       case Types.TIME: {
-        return rs -> rs.getTime(col, DateTimeUtils.UTC_CALENDAR.get());
+        return rs -> rs.getTime(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Timestamp is a date + time
       case Types.TIMESTAMP: {
-        return rs -> rs.getTimestamp(col, DateTimeUtils.UTC_CALENDAR.get());
+        return rs -> rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Datalink is basically a URL -> string
@@ -1488,7 +1499,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           statement.setDate(
               index,
               new java.sql.Date(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         case Decimal.LOGICAL_NAME:
@@ -1498,14 +1509,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           statement.setTime(
               index,
               new java.sql.Time(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME:
           statement.setTimestamp(
               index,
               new java.sql.Timestamp(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         default:
@@ -1647,13 +1658,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           builder.append(value);
           return;
         case Date.LOGICAL_NAME:
-          builder.appendStringQuoted(DateTimeUtils.formatUtcDate((java.util.Date) value));
+          builder.appendStringQuoted(DateTimeUtils.formatDate((java.util.Date) value, timeZone));
           return;
         case Time.LOGICAL_NAME:
-          builder.appendStringQuoted(DateTimeUtils.formatUtcTime((java.util.Date) value));
+          builder.appendStringQuoted(DateTimeUtils.formatTime((java.util.Date) value, timeZone));
           return;
         case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME:
-          builder.appendStringQuoted(DateTimeUtils.formatUtcTimestamp((java.util.Date) value));
+          builder.appendStringQuoted(
+              DateTimeUtils.formatTimestamp((java.util.Date) value, timeZone)
+          );
           return;
         default:
           // fall through to regular types

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,12 +24,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.EnumRecommender;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.StringUtils;
+import io.confluent.connect.jdbc.util.TimeZoneValidator;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -189,6 +192,13 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "specific dialect. All properly-packaged dialects in the JDBC connector plugin "
       + "can be used.";
 
+  public static final String DB_TIMEZONE_CONFIG = "db.timezone";
+  public static final String DB_TIMEZONE_DEFAULT = "UTC";
+  private static final String DB_TIMEZONE_CONFIG_DOC =
+      "Name of the JDBC timezone that should be used in the connector when "
+          + "inserting time-based values. Defaults to UTC.";
+  private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB Time Zone";
+
   public static final String QUOTE_SQL_IDENTIFIERS_CONFIG =
       JdbcSourceConnectorConfig.QUOTE_SQL_IDENTIFIERS_CONFIG;
   public static final String QUOTE_SQL_IDENTIFIERS_DEFAULT =
@@ -317,6 +327,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             4,
             ConfigDef.Width.LONG,
             FIELDS_WHITELIST_DISPLAY
+        ).define(
+          DB_TIMEZONE_CONFIG,
+          ConfigDef.Type.STRING,
+          DB_TIMEZONE_DEFAULT,
+          TimeZoneValidator.INSTANCE,
+          ConfigDef.Importance.MEDIUM,
+          DB_TIMEZONE_CONFIG_DOC,
+          DATAMAPPING_GROUP,
+          5,
+          ConfigDef.Width.MEDIUM,
+          DB_TIMEZONE_CONFIG_DISPLAY
         )
         // DDL
         .define(
@@ -390,6 +411,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final List<String> pkFields;
   public final Set<String> fieldsWhitelist;
   public final String dialectName;
+  public final TimeZone timeZone;
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
@@ -407,6 +429,8 @@ public class JdbcSinkConfig extends AbstractConfig {
     pkFields = getList(PK_FIELDS);
     dialectName = getString(DIALECT_NAME_CONFIG);
     fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
+    String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
+    timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
   }
 
   private String getPasswordValue(String key) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -16,6 +16,27 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.dialect.DatabaseDialects;
+import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
+import io.confluent.connect.jdbc.util.EnumRecommender;
+import io.confluent.connect.jdbc.util.QuoteMethod;
+import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.TimeZoneValidator;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -26,24 +47,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
-import io.confluent.connect.jdbc.dialect.DatabaseDialects;
-import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
-import io.confluent.connect.jdbc.util.EnumRecommender;
-import io.confluent.connect.jdbc.util.QuoteMethod;
-import io.confluent.connect.jdbc.util.TableId;
 
 public class JdbcSourceConnectorConfig extends AbstractConfig {
 
@@ -238,6 +241,13 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + " from the last time we fetched until current time minus the delay.";
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
+
+  public static final String DB_TIMEZONE_CONFIG = "db.timezone";
+  public static final String DB_TIMEZONE_DEFAULT = "UTC";
+  private static final String DB_TIMEZONE_CONFIG_DOC =
+      "Name of the JDBC timezone that should be used in the connector when "
+          + "querying with time-based criteria. Defaults to UTC.";
+  private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
 
   public static final String QUOTE_SQL_IDENTIFIERS_CONFIG = "quote.sql.identifiers";
   public static final String QUOTE_SQL_IDENTIFIERS_DEFAULT = QuoteMethod.ALWAYS.name().toString();
@@ -557,7 +567,18 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         CONNECTOR_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);
+        TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY
+    ).define(
+        DB_TIMEZONE_CONFIG,
+        Type.STRING,
+        DB_TIMEZONE_DEFAULT,
+        TimeZoneValidator.INSTANCE,
+        Importance.MEDIUM,
+        DB_TIMEZONE_CONFIG_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        DB_TIMEZONE_CONFIG_DISPLAY);
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();
@@ -731,6 +752,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public NumericMapping numericMapping() {
     return NumericMapping.get(this);
+  }
+
+  public TimeZone timeZone() {
+    String dbTimeZone = getString(JdbcSourceTaskConfig.DB_TIMEZONE_CONFIG);
+    return TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.TimeZone;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -148,6 +149,7 @@ public class JdbcSourceTask extends SourceTask {
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+    TimeZone timeZone = config.timeZone();
 
     for (String tableOrQuery : tablesOrQuery) {
       final List<Map<String, String>> tablePartitionsToCheck;
@@ -205,7 +207,8 @@ public class JdbcSourceTask extends SourceTask {
                 null,
                 incrementingColumn,
                 offset,
-                timestampDelayInterval
+                timestampDelayInterval,
+                timeZone
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -218,7 +221,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampColumns,
                 null,
                 offset,
-                timestampDelayInterval
+                timestampDelayInterval,
+                timeZone
             )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -231,7 +235,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampColumns,
                 incrementingColumn,
                 offset,
-                timestampDelayInterval
+                timestampDelayInterval,
+                timeZone
             )
         );
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -69,15 +70,18 @@ public class TimestampIncrementingCriteria {
   protected final Logger log = LoggerFactory.getLogger(getClass());
   protected final List<ColumnId> timestampColumns;
   protected final ColumnId incrementingColumn;
+  protected final TimeZone timeZone;
 
 
   public TimestampIncrementingCriteria(
       ColumnId incrementingColumn,
-      List<ColumnId> timestampColumns
+      List<ColumnId> timestampColumns,
+      TimeZone timeZone
   ) {
     this.timestampColumns =
         timestampColumns != null ? timestampColumns : Collections.<ColumnId>emptyList();
     this.incrementingColumn = incrementingColumn;
+    this.timeZone = timeZone;
   }
 
   protected boolean hasTimestampColumns() {
@@ -131,14 +135,14 @@ public class TimestampIncrementingCriteria {
     Timestamp beginTime = values.beginTimetampValue();
     Timestamp endTime = values.endTimetampValue();
     Long incOffset = values.lastIncrementedValue();
-    stmt.setTimestamp(1, endTime, DateTimeUtils.UTC_CALENDAR.get());
-    stmt.setTimestamp(2, beginTime, DateTimeUtils.UTC_CALENDAR.get());
+    stmt.setTimestamp(1, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    stmt.setTimestamp(2, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setLong(3, incOffset);
-    stmt.setTimestamp(4, beginTime, DateTimeUtils.UTC_CALENDAR.get());
+    stmt.setTimestamp(4, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     log.debug(
         "Executing prepared statement with start time value = {} end time = {} and incrementing"
-        + " value = {}", DateTimeUtils.formatUtcTimestamp(beginTime),
-        DateTimeUtils.formatUtcTimestamp(endTime), incOffset
+        + " value = {}", DateTimeUtils.formatTimestamp(beginTime, timeZone),
+        DateTimeUtils.formatTimestamp(endTime, timeZone), incOffset
     );
   }
 
@@ -157,10 +161,11 @@ public class TimestampIncrementingCriteria {
   ) throws SQLException {
     Timestamp beginTime = values.beginTimetampValue();
     Timestamp endTime = values.endTimetampValue();
-    stmt.setTimestamp(1, beginTime, DateTimeUtils.UTC_CALENDAR.get());
-    stmt.setTimestamp(2, endTime, DateTimeUtils.UTC_CALENDAR.get());
+    stmt.setTimestamp(1, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    stmt.setTimestamp(2, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     log.debug("Executing prepared statement with timestamp value = {} end time = {}",
-              DateTimeUtils.formatUtcTimestamp(beginTime), DateTimeUtils.formatUtcTimestamp(endTime)
+        DateTimeUtils.formatTimestamp(beginTime, timeZone),
+        DateTimeUtils.formatTimestamp(endTime, timeZone)
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -70,12 +71,14 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   private TimestampIncrementingCriteria criteria;
   private final Map<String, String> partition;
   private final String topic;
+  private final TimeZone timeZone;
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
                                            String topicPrefix,
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
-                                           Map<String, Object> offsetMap, Long timestampDelay) {
+                                           Map<String, Object> offsetMap, Long timestampDelay,
+                                           TimeZone timeZone) {
     super(dialect, mode, name, topicPrefix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
@@ -104,6 +107,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       default:
         throw new ConnectException("Unexpected query mode: " + mode);
     }
+
+    this.timeZone = timeZone;
   }
 
   @Override
@@ -198,7 +203,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   public Timestamp endTimetampValue()  throws SQLException {
     final long currentDbTime = dialect.currentTimeOnDB(
         stmt.getConnection(),
-        DateTimeUtils.UTC_CALENDAR.get()
+        DateTimeUtils.getTimeZoneCalendar(timeZone)
     ).getTime();
     return new Timestamp(currentDbTime - timestampDelay);
   }

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -20,56 +20,52 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 
 public class DateTimeUtils {
 
-  public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+  private static final ThreadLocal<Map<TimeZone, Calendar>> TIMEZONE_CALENDARS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  public static final ThreadLocal<Calendar> UTC_CALENDAR = new ThreadLocal<Calendar>() {
-    @Override
-    protected Calendar initialValue() {
-      return new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-    }
-  };
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_DATE_FORMATS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  private static final ThreadLocal<SimpleDateFormat> UTC_DATE_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIME_FORMATS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  private static final ThreadLocal<SimpleDateFormat> UTC_TIME_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIMESTAMP_FORMATS =
+      ThreadLocal.withInitial(HashMap::new);
 
-  private static final ThreadLocal<SimpleDateFormat> UTC_TIMESTAMP_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
-
-  public static String formatUtcDate(Date date) {
-    return UTC_DATE_FORMAT.get().format(date);
+  public static Calendar getTimeZoneCalendar(final TimeZone timeZone) {
+    return TIMEZONE_CALENDARS.get().computeIfAbsent(timeZone, GregorianCalendar::new);
   }
 
-  public static String formatUtcTime(Date date) {
-    return UTC_TIME_FORMAT.get().format(date);
+  public static String formatDate(Date date, TimeZone timeZone) {
+    return TIMEZONE_DATE_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
   }
 
-  public static String formatUtcTimestamp(Date date) {
-    return UTC_TIMESTAMP_FORMAT.get().format(date);
+  public static String formatTime(Date date, TimeZone timeZone) {
+    return TIMEZONE_TIME_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
   }
 
+  public static String formatTimestamp(Date date, TimeZone timeZone) {
+    return TIMEZONE_TIMESTAMP_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
+  }
+
+  private DateTimeUtils() {
+  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.util;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class TimeZoneValidator implements ConfigDef.Validator {
+
+  public static final TimeZoneValidator INSTANCE = new TimeZoneValidator();
+
+  @Override
+  public void ensureValid(String name, Object value) {
+    if (value != null) {
+      try {
+        ZoneId.of(value.toString());
+      } catch (DateTimeException e) {
+        throw new ConfigException(name, value, "Invalid time zone identifier");
+      }
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.time.ZoneOffset;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -327,11 +328,27 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
-    verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date
-        (0), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100), DateTimeUtils.UTC_CALENDAR.get());
+    verifyBindField(
+        ++index,
+        Decimal.schema(0),
+        new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)
+    ).setBigDecimal(index, new BigDecimal(2));
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
+    verifyBindField(
+      ++index,
+      Date.SCHEMA,
+      new java.util.Date(0)
+    ).setDate(index, new java.sql.Date(0), utcCalendar);
+    verifyBindField(
+      ++index,
+      Time.SCHEMA,
+      new java.util.Date(1000)
+    ).setTime(index, new java.sql.Time(1000), utcCalendar);
+    verifyBindField(
+      ++index,
+      Timestamp.SCHEMA,
+      new java.util.Date(100)
+    ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -44,6 +45,7 @@ import static org.junit.Assert.assertEquals;
 public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDialect> {
 
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+  private TimeZone utcTimeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
 
   @Before
   public void beforeEach() throws Exception {
@@ -285,7 +287,7 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
 
   @Test
   public void useCurrentTimestampValue() throws SQLException {
-    Calendar cal = DateTimeUtils.UTC_CALENDAR.get();
+    Calendar cal = DateTimeUtils.getTimeZoneCalendar(utcTimeZone);
 
     //Regular expression to check if the timestamp is of the format %Y-%m-%d %H:%M:%S.%f
     Pattern p = Pattern.compile("(\\p{Nd}++)\\Q-\\E(\\p{Nd}++)\\Q-\\E(\\p{Nd}++)\\Q \\E(\\p{Nd}++)"

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -14,6 +14,21 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ThreadLocalRandom;
+
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.QuoteMethod;
+import io.confluent.connect.jdbc.util.TableId;
+
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -21,18 +36,6 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
-
-import io.confluent.connect.jdbc.util.DateTimeUtils;
-import io.confluent.connect.jdbc.util.QuoteMethod;
-import io.confluent.connect.jdbc.util.TableId;
-
-import static org.junit.Assert.assertEquals;
 
 public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDialect> {
 
@@ -333,10 +336,22 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
     verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date
-        (0), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100), DateTimeUtils.UTC_CALENDAR.get());
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
+    verifyBindField(
+      ++index,
+      Date.SCHEMA,
+      new java.util.Date(0)
+    ).setDate(index, new java.sql.Date(0), utcCalendar);
+    verifyBindField(
+      ++index,
+      Time.SCHEMA,
+      new java.util.Date(1000)
+    ).setTime(index, new java.sql.Time(1000), utcCalendar);
+    verifyBindField(
+      ++index,
+      Timestamp.SCHEMA,
+      new java.util.Date(100)
+    ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -16,9 +16,26 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -28,18 +45,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static org.easymock.EasyMock.expectLastCall;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import io.confluent.connect.jdbc.util.DateTimeUtils;
 
 public class JdbcSinkTaskTest extends EasyMockSupport {
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
@@ -54,6 +60,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       .field("long", Schema.OPTIONAL_INT64_SCHEMA)
       .field("float", Schema.OPTIONAL_FLOAT32_SCHEMA)
       .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("modified", Timestamp.SCHEMA)
       .build();
 
   @Before
@@ -73,6 +80,9 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put("auto.create", "true");
     props.put("pk.mode", "kafka");
     props.put("pk.fields", "kafka_topic,kafka_partition,kafka_offset");
+    String timeZoneID = "America/Los_Angeles";
+    TimeZone timeZone = TimeZone.getTimeZone(timeZoneID);
+    props.put("db.timezone", timeZoneID);
 
     JdbcSinkTask task = new JdbcSinkTask();
     task.initialize(mock(SinkTaskContext.class));
@@ -88,7 +98,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         .put("long", 12425436L)
         .put("float", (float) 2356.3)
         .put("double", -2436546.56457)
-        .put("age", 21);
+        .put("age", 21)
+        .put("modified", new Date(1474661402123L));
 
     final String topic = "atopic";
 
@@ -115,6 +126,11 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
                 assertEquals(struct.getInt64("long").longValue(), rs.getLong("long"));
                 assertEquals(struct.getFloat32("float"), rs.getFloat("float"), 0.01);
                 assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
+                java.sql.Timestamp dbTimestamp = rs.getTimestamp(
+                    "modified",
+                    DateTimeUtils.getTimeZoneCalendar(timeZone)
+                );
+                assertEquals(((java.util.Date) struct.get("modified")).getTime(), dbTimestamp.getTime());
               }
             }
         )
@@ -144,7 +160,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         "    long INTEGER," +
         "    float NUMERIC," +
         "    double NUMERIC," +
-        "    bytes BLOB, " +
+        "    bytes BLOB," +
+        "    modified DATETIME, "+
         "PRIMARY KEY (firstName, lastName));"
     );
 
@@ -157,7 +174,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         .put("byte", (byte) -72)
         .put("long", 8594L)
         .put("double", 3256677.56457d)
-        .put("age", 28);
+        .put("age", 28)
+        .put("modified", new Date(1474661402123L));
 
     task.put(Collections.singleton(new SinkRecord(topic, 1, null, null, SCHEMA, struct, 43)));
 
@@ -177,6 +195,11 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
                 rs.getShort("float");
                 assertTrue(rs.wasNull());
                 assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
+                java.sql.Timestamp dbTimestamp = rs.getTimestamp(
+                    "modified",
+                    DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC))
+                );
+                assertEquals(((java.util.Date) struct.get("modified")).getTime(), dbTimestamp.getTime());
               }
             }
         )

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -16,6 +16,9 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -137,9 +140,19 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setDouble(index++, valueStruct.getFloat64("double"));
     verify(statement, times(1)).setBytes(index++, valueStruct.getBytes("bytes"));
     verify(statement, times(1)).setBigDecimal(index++, (BigDecimal) valueStruct.get("decimal"));
-    verify(statement, times(1)).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
-    verify(statement, times(1)).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
-    verify(statement, times(1)).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
+    verify(
+        statement,
+        times(1)
+    ).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()), utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()), utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()), utcCalendar);
     // last field is optional and is null-valued in struct
     verify(statement, times(1)).setObject(index++, null);
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -14,6 +14,8 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -53,14 +55,14 @@ public class TimestampIncrementingCriteriaTest {
   private TimestampIncrementingCriteria criteriaIncTs;
   private Schema schema;
   private Struct record;
+  private TimeZone utcTimeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
 
   @Before
   public void beforeEach() {
-    criteria = new TimestampIncrementingCriteria(null, null);
-    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null);
-    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS);
-    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS);
-    identifierQuoting = null;
+    criteria = new TimestampIncrementingCriteria(null, null, utcTimeZone);
+    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null, utcTimeZone);
+    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS, utcTimeZone);
+    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS, utcTimeZone);    identifierQuoting = null;
     rules = null;
     builder = null;
   }

--- a/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Test;
+
+public class TimeZoneValidatorTest {
+
+  @Test
+  public void testAccuracy() {
+    String[] validTimeZones = new String[]{
+        "Europe/Vienna",
+        "Asia/Tokyo",
+        "America/Los_Angeles",
+        "UTC",
+        "GMT+01:00",
+        "UTC"
+    };
+
+    Stream.of(validTimeZones)
+        .forEach(timeZone -> TimeZoneValidator.INSTANCE.ensureValid("db.timezone", timeZone));
+  }
+
+  @Test
+  public void testTimeZoneNotSpecified() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", null);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidTimeZone() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", "invalid");
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testEmptyTimeZone() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", "");
+  }
+}


### PR DESCRIPTION
Date/time/timestamp values read from the source DB will be
instantiated into the specified timezone

Original PR: https://github.com/confluentinc/kafka-connect-jdbc/pull/505/commits

https://confluentinc.atlassian.net/browse/ESCALATION-910

Follow-on task will be to further backport to 4.1.x