### PR TITLE
Backport db.timzeone config to 4.1.x

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -85,7 +85,8 @@ public class BufferedRecords {
           config.pkMode,
           schemaPair,
           fieldsMetadata,
-          config.insertMode
+          config.insertMode,
+          config.timeZone
       );
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -27,8 +27,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import io.confluent.connect.jdbc.util.StringUtils;
+import io.confluent.connect.jdbc.util.TimeZoneValidator;
+
 import org.apache.kafka.common.config.types.Password;
 
 public class JdbcSinkConfig extends AbstractConfig {
@@ -174,6 +177,13 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String DDL_GROUP = "DDL Support";
   private static final String RETRIES_GROUP = "Retries";
 
+  public static final String DB_TIMEZONE_CONFIG = "db.timezone";
+  public static final String DB_TIMEZONE_DEFAULT = "UTC";
+  private static final String DB_TIMEZONE_CONFIG_DOC =
+      "Name of the JDBC timezone that should be used in the connector when "
+          + "inserting time-based values. Defaults to UTC.";
+  private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB Time Zone";
+
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
       // Connection
       .define(CONNECTION_URL, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,
@@ -221,7 +231,20 @@ public class JdbcSinkConfig extends AbstractConfig {
       .define(RETRY_BACKOFF_MS, ConfigDef.Type.INT, RETRY_BACKOFF_MS_DEFAULT,
               NON_NEGATIVE_INT_VALIDATOR,
               ConfigDef.Importance.MEDIUM, RETRY_BACKOFF_MS_DOC,
-              RETRIES_GROUP, 2, ConfigDef.Width.SHORT, RETRY_BACKOFF_MS_DISPLAY);
+              RETRIES_GROUP, 2, ConfigDef.Width.SHORT, RETRY_BACKOFF_MS_DISPLAY)
+       .define(
+          DB_TIMEZONE_CONFIG,
+          ConfigDef.Type.STRING,
+          DB_TIMEZONE_DEFAULT,
+          TimeZoneValidator.INSTANCE,
+          ConfigDef.Importance.MEDIUM,
+          DB_TIMEZONE_CONFIG_DOC,
+          DATAMAPPING_GROUP,
+          5,
+          ConfigDef.Width.MEDIUM,
+          DB_TIMEZONE_CONFIG_DISPLAY
+        );
+
 
   public final String connectionUrl;
   public final String connectionUser;
@@ -236,6 +259,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final PrimaryKeyMode pkMode;
   public final List<String> pkFields;
   public final Set<String> fieldsWhitelist;
+
+  public final TimeZone timeZone;
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
@@ -252,6 +277,8 @@ public class JdbcSinkConfig extends AbstractConfig {
     pkMode = PrimaryKeyMode.valueOf(getString(PK_MODE).toUpperCase());
     pkFields = getList(PK_FIELDS);
     fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
+    String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
+    timeZone = TimeZone.getTimeZone(dbTimeZone);
   }
 
   private String getPasswordValue(String key) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -47,7 +47,8 @@ public class JdbcSinkTask extends SinkTask {
   }
 
   void initWriter() {
-    final DbDialect dbDialect = DbDialect.fromConnectionString(config.connectionUrl);
+    final DbDialect dbDialect = DbDialect.fromConnectionString(config.connectionUrl)
+        .withTimeZone(config.timeZone);
     final DbStructure dbStructure = new DbStructure(dbDialect);
     log.info("Initializing writer using SQL dialect: {}", dbDialect.getClass().getSimpleName());
     writer = new JdbcDbWriter(config, dbDialect, dbStructure);

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.TimeZone;
 
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
@@ -42,19 +43,22 @@ public class PreparedStatementBinder {
   private final SchemaPair schemaPair;
   private final FieldsMetadata fieldsMetadata;
   private final JdbcSinkConfig.InsertMode insertMode;
+  private final TimeZone timeZone;
 
   public PreparedStatementBinder(
       PreparedStatement statement,
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      JdbcSinkConfig.InsertMode insertMode
+      JdbcSinkConfig.InsertMode insertMode,
+      TimeZone timeZone
   ) {
     this.pkMode = pkMode;
     this.statement = statement;
     this.schemaPair = schemaPair;
     this.fieldsMetadata = fieldsMetadata;
     this.insertMode = insertMode;
+    this.timeZone = timeZone;
   }
 
   public void bindRecord(SinkRecord record) throws SQLException {
@@ -143,7 +147,7 @@ public class PreparedStatementBinder {
     bindField(statement, index, schema, value);
   }
 
-  static void bindField(
+  void bindField(
       PreparedStatement statement,
       int index,
       Schema schema,
@@ -197,7 +201,7 @@ public class PreparedStatementBinder {
     }
   }
 
-  static boolean maybeBindLogical(
+  boolean maybeBindLogical(
       PreparedStatement statement,
       int index,
       Schema schema,
@@ -209,7 +213,7 @@ public class PreparedStatementBinder {
           statement.setDate(
               index,
               new java.sql.Date(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         case Decimal.LOGICAL_NAME:
@@ -219,14 +223,14 @@ public class PreparedStatementBinder {
           statement.setTime(
               index,
               new java.sql.Time(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         case Timestamp.LOGICAL_NAME:
           statement.setTimestamp(
               index,
               new java.sql.Timestamp(((java.util.Date) value).getTime()),
-              DateTimeUtils.UTC_CALENDAR.get()
+              DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;
         default:

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/DbDialect.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -43,10 +44,26 @@ public abstract class DbDialect {
 
   private final String escapeStart;
   private final String escapeEnd;
+  private TimeZone timeZone;
 
   DbDialect(String escapeStart, String escapeEnd) {
     this.escapeStart = escapeStart;
     this.escapeEnd = escapeEnd;
+  }
+
+  /**
+   * Must be called on a DbDialect object before doing anything else with it. Written this
+   * way to be minimally invasive on the public interfaces.
+   * Default not provided since an error is better than silently contradicting user
+   * configuration
+   * Added to support backport of "db.timezone" config.
+   *
+   * @param timeZone Timezone the user has configured for timestamps in their config file
+   * @return DbDialect instance
+   */
+  public DbDialect withTimeZone(TimeZone timeZone) {
+    this.timeZone = timeZone;
+    return this;
   }
 
   public final String getInsert(
@@ -180,15 +197,15 @@ public abstract class DbDialect {
           return;
         case Date.LOGICAL_NAME:
           builder.append("'")
-              .append(DateTimeUtils.formatUtcDate((java.util.Date) value)).append("'");
+              .append(DateTimeUtils.formatDate((java.util.Date) value, timeZone)).append("'");
           return;
         case Time.LOGICAL_NAME:
           builder.append("'")
-              .append(DateTimeUtils.formatUtcTime((java.util.Date) value)).append("'");
+              .append(DateTimeUtils.formatTime((java.util.Date) value, timeZone)).append("'");
           return;
         case Timestamp.LOGICAL_NAME:
           builder.append("'")
-              .append(DateTimeUtils.formatUtcTimestamp((java.util.Date) value)).append("'");
+              .append(DateTimeUtils.formatTimestamp((java.util.Date) value, timeZone)).append("'");
           return;
         default:
           // fall through to regular types

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -27,6 +27,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.TimeZone;
 
 import io.confluent.connect.jdbc.util.JdbcUtils;
 
@@ -37,10 +38,12 @@ import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.Numeric
  */
 public class BulkTableQuerier extends TableQuerier {
   private static final Logger log = LoggerFactory.getLogger(BulkTableQuerier.class);
+  private final TimeZone timeZone;
 
   public BulkTableQuerier(QueryMode mode, String name, String schemaPattern,
-                          String topicPrefix, NumericMapping mapNumerics) {
+                          String topicPrefix, NumericMapping mapNumerics, TimeZone timeZone) {
     super(mode, name, topicPrefix, schemaPattern, mapNumerics);
+    this.timeZone = timeZone;
   }
 
   @Override
@@ -68,7 +71,7 @@ public class BulkTableQuerier extends TableQuerier {
 
   @Override
   public SourceRecord extractRecord() throws SQLException {
-    Struct record = DataConverter.convertRecord(schema, resultSet, mapNumerics);
+    Struct record = DataConverter.convertRecord(schema, resultSet, mapNumerics, timeZone);
     // TODO: key from primary key? partition?
     final String topic;
     final Map<String, String> partition;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -44,6 +44,11 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import java.util.TimeZone;
+
+import io.confluent.connect.jdbc.util.TimeZoneValidator;
+
+
 public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceConnectorConfig.class);
@@ -216,6 +221,13 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + " from the last time we fetched until current time minus the delay.";
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
+
+  public static final String DB_TIMEZONE_CONFIG = "db.timezone";
+  public static final String DB_TIMEZONE_DEFAULT = "UTC";
+  private static final String DB_TIMEZONE_CONFIG_DOC =
+      "Name of the JDBC timezone that should be used in the connector when "
+          + "querying with time-based criteria. Defaults to UTC.";
+  private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
 
   public static final String DATABASE_GROUP = "Database";
   public static final String MODE_GROUP = "Mode";
@@ -492,7 +504,18 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         CONNECTOR_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY);
+        TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY
+    ).define(
+        DB_TIMEZONE_CONFIG,
+        Type.STRING,
+        DB_TIMEZONE_DEFAULT,
+        TimeZoneValidator.INSTANCE,
+        Importance.MEDIUM,
+        DB_TIMEZONE_CONFIG_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        DB_TIMEZONE_CONFIG_DISPLAY);
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();
@@ -706,6 +729,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   protected JdbcSourceConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> props) {
     super(subclassConfigDef, props);
+  }
+
+  public TimeZone timeZone() {
+    String dbTimeZone = getString(JdbcSourceTaskConfig.DB_TIMEZONE_CONFIG);
+    return TimeZone.getTimeZone(dbTimeZone);
   }
 
   public static void main(String[] args) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.util.TimeZone;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.SystemTime;
@@ -123,6 +124,7 @@ public class JdbcSourceTask extends SourceTask {
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+    TimeZone timeZone = config.timeZone();
 
     for (String tableOrQuery : tablesOrQuery) {
       final Map<String, String> partition;
@@ -154,19 +156,19 @@ public class JdbcSourceTask extends SourceTask {
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(new BulkTableQuerier(queryMode, tableOrQuery, schemaPattern,
-                topicPrefix, mapNumerics));
+                topicPrefix, mapNumerics, timeZone));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, null, incrementingColumn, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+                timestampDelayInterval, timeZone, schemaPattern, mapNumerics));
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, null, offset,
-                timestampDelayInterval, schemaPattern, mapNumerics));
+                timestampDelayInterval, timeZone, schemaPattern, mapNumerics));
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(new TimestampIncrementingTableQuerier(
             queryMode, tableOrQuery, topicPrefix, timestampColumn, incrementingColumn,
-                offset, timestampDelayInterval, schemaPattern, mapNumerics));
+                offset, timestampDelayInterval, timeZone, schemaPattern, mapNumerics));
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc.source;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -65,16 +66,19 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
   private String incrementingColumn;
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
+  private final TimeZone timeZone;
 
   public TimestampIncrementingTableQuerier(QueryMode mode, String name, String topicPrefix,
                                            String timestampColumn, String incrementingColumn,
                                            Map<String, Object> offsetMap, Long timestampDelay,
+                                           TimeZone timeZone,
                                            String schemaPattern, NumericMapping mapNumerics) {
     super(mode, name, topicPrefix, schemaPattern, mapNumerics);
     this.timestampColumn = timestampColumn;
     this.incrementingColumn = incrementingColumn;
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
+    this.timeZone = timeZone;
   }
 
   @Override
@@ -169,18 +173,18 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       Long incOffset = offset.getIncrementingOffset();
       final long currentDbTime = JdbcUtils.getCurrentTimeOnDB(
           stmt.getConnection(),
-          DateTimeUtils.UTC_CALENDAR.get()
+          DateTimeUtils.getTimeZoneCalendar(timeZone)
       ).getTime();
       Timestamp endTime = new Timestamp(currentDbTime - timestampDelay);
-      stmt.setTimestamp(1, endTime, DateTimeUtils.UTC_CALENDAR.get());
-      stmt.setTimestamp(2, tsOffset, DateTimeUtils.UTC_CALENDAR.get());
+      stmt.setTimestamp(1, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+      stmt.setTimestamp(2, tsOffset, DateTimeUtils.getTimeZoneCalendar(timeZone));
       stmt.setLong(3, incOffset);
-      stmt.setTimestamp(4, tsOffset, DateTimeUtils.UTC_CALENDAR.get());
+      stmt.setTimestamp(4, tsOffset, DateTimeUtils.getTimeZoneCalendar(timeZone));
       log.debug(
           "Executing prepared statement with start time value = {} end time = {} and incrementing"
           + " value = {}",
-          DateTimeUtils.formatUtcTimestamp(tsOffset),
-          DateTimeUtils.formatUtcTimestamp(endTime),
+          DateTimeUtils.formatTimestamp(tsOffset, timeZone),
+          DateTimeUtils.formatTimestamp(endTime, timeZone),
           incOffset
       );
     } else if (incrementingColumn != null) {
@@ -191,21 +195,21 @@ public class TimestampIncrementingTableQuerier extends TableQuerier {
       Timestamp tsOffset = offset.getTimestampOffset();
       final long currentDbTime = JdbcUtils.getCurrentTimeOnDB(
           stmt.getConnection(),
-          DateTimeUtils.UTC_CALENDAR.get()
+          DateTimeUtils.getTimeZoneCalendar(timeZone)
       ).getTime();
       Timestamp endTime = new Timestamp(currentDbTime - timestampDelay);
-      stmt.setTimestamp(1, tsOffset, DateTimeUtils.UTC_CALENDAR.get());
-      stmt.setTimestamp(2, endTime, DateTimeUtils.UTC_CALENDAR.get());
+      stmt.setTimestamp(1, tsOffset, DateTimeUtils.getTimeZoneCalendar(timeZone));
+      stmt.setTimestamp(2, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
       log.debug("Executing prepared statement with timestamp value = {} end time = {}",
-                DateTimeUtils.formatUtcTimestamp(tsOffset),
-                DateTimeUtils.formatUtcTimestamp(endTime));
+                DateTimeUtils.formatTimestamp(tsOffset, timeZone),
+                DateTimeUtils.formatTimestamp(endTime, timeZone));
     }
     return stmt.executeQuery();
   }
 
   @Override
   public SourceRecord extractRecord() throws SQLException {
-    final Struct record = DataConverter.convertRecord(schema, resultSet, mapNumerics);
+    final Struct record = DataConverter.convertRecord(schema, resultSet, mapNumerics, timeZone);
     offset = extractOffset(schema, record);
     // TODO: Key?
     final String topic;

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -20,56 +20,82 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 
 public class DateTimeUtils {
 
-  public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+  private static final ThreadLocal<Map<TimeZone, Calendar>> TIMEZONE_CALENDARS =
+      new ThreadLocal<Map<TimeZone, Calendar>>() {
+        @Override
+        public Map<TimeZone, Calendar> initialValue() {
+          return new HashMap<>();
+        }
+      };
 
-  public static final ThreadLocal<Calendar> UTC_CALENDAR = new ThreadLocal<Calendar>() {
-    @Override
-    protected Calendar initialValue() {
-      return new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_DATE_FORMATS =
+      new ThreadLocal<Map<TimeZone, SimpleDateFormat>>() {
+        @Override
+        public Map<TimeZone, SimpleDateFormat> initialValue() {
+          return new HashMap<>();
+        }
+      };
+
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIME_FORMATS =
+      new ThreadLocal<Map<TimeZone, SimpleDateFormat>>() {
+        @Override
+        public Map<TimeZone, SimpleDateFormat> initialValue() {
+          return new HashMap<>();
+        }
+      };
+
+  private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIMESTAMP_FORMATS =
+      new ThreadLocal<Map<TimeZone, SimpleDateFormat>>() {
+        @Override
+        public Map<TimeZone, SimpleDateFormat> initialValue() {
+          return new HashMap<>();
+        }
+    };
+
+  public static Calendar getTimeZoneCalendar(final TimeZone timeZone) {
+    Map<TimeZone, Calendar> map = TIMEZONE_CALENDARS.get();
+    if (!map.containsKey(timeZone)) {
+      map.put(timeZone, new GregorianCalendar(timeZone));
     }
-  };
-
-  private static final ThreadLocal<SimpleDateFormat> UTC_DATE_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
-
-  private static final ThreadLocal<SimpleDateFormat> UTC_TIME_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
-
-  private static final ThreadLocal<SimpleDateFormat> UTC_TIMESTAMP_FORMAT
-      = new ThreadLocal<SimpleDateFormat>() {
-        protected SimpleDateFormat initialValue() {
-          SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-          sdf.setTimeZone(UTC);
-          return sdf;
-        }
-      };
-
-  public static String formatUtcDate(Date date) {
-    return UTC_DATE_FORMAT.get().format(date);
+    return map.get(timeZone);
   }
 
-  public static String formatUtcTime(Date date) {
-    return UTC_TIME_FORMAT.get().format(date);
+  public static String formatDate(Date date, TimeZone timeZone) {
+    Map<TimeZone, SimpleDateFormat> map = TIMEZONE_DATE_FORMATS.get();
+    if (!map.containsKey(timeZone)) {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+      sdf.setTimeZone(timeZone);
+      map.put(timeZone, sdf);
+    }
+    return map.get(timeZone).format(date);
   }
 
-  public static String formatUtcTimestamp(Date date) {
-    return UTC_TIMESTAMP_FORMAT.get().format(date);
+  public static String formatTime(Date date, TimeZone timeZone) {
+    Map<TimeZone, SimpleDateFormat> map = TIMEZONE_TIME_FORMATS.get();
+    if (!map.containsKey(timeZone)) {
+      SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS");
+      sdf.setTimeZone(timeZone);
+      map.put(timeZone, sdf);
+    }
+    return map.get(timeZone).format(date);
   }
 
+  public static String formatTimestamp(Date date, TimeZone timeZone) {
+    Map<TimeZone, SimpleDateFormat> map = TIMEZONE_TIMESTAMP_FORMATS.get();
+    if (!map.containsKey(timeZone)) {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      sdf.setTimeZone(timeZone);
+      map.put(timeZone, sdf);
+    }
+    return map.get(timeZone).format(date);
+  }
+
+  private DateTimeUtils() {
+  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.util;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class TimeZoneValidator implements ConfigDef.Validator {
+
+  public static final TimeZoneValidator INSTANCE = new TimeZoneValidator();
+
+  @Override
+  public void ensureValid(String name, Object value) {
+    if (value != null) {
+      try {
+        ZoneId.of(value.toString());
+      } catch (DateTimeException e) {
+        throw new ConfigException(name, value, "Invalid time zone identifier");
+      }
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -19,6 +19,7 @@ package io.confluent.connect.jdbc.sink;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -32,15 +33,19 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
+
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+
 
 public class JdbcSinkTaskTest extends EasyMockSupport {
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
@@ -55,6 +60,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       .field("long", Schema.OPTIONAL_INT64_SCHEMA)
       .field("float", Schema.OPTIONAL_FLOAT32_SCHEMA)
       .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("modified", Timestamp.SCHEMA)
       .build();
 
   @Before
@@ -74,6 +80,9 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put("auto.create", "true");
     props.put("pk.mode", "kafka");
     props.put("pk.fields", "kafka_topic,kafka_partition,kafka_offset");
+    String timeZoneID = "America/Los_Angeles";
+    final TimeZone timeZone = TimeZone.getTimeZone(timeZoneID);
+    props.put("db.timezone", timeZoneID);
 
     JdbcSinkTask task = new JdbcSinkTask();
     task.initialize(mock(SinkTaskContext.class));
@@ -89,7 +98,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         .put("long", 12425436L)
         .put("float", (float) 2356.3)
         .put("double", -2436546.56457)
-        .put("age", 21);
+        .put("age", 21)
+        .put("modified", new Date(1474661402123L));
 
     final String topic = "atopic";
 
@@ -116,6 +126,11 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
                 assertEquals(struct.getInt64("long").longValue(), rs.getLong("long"));
                 assertEquals(struct.getFloat32("float"), rs.getFloat("float"), 0.01);
                 assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
+                java.sql.Timestamp dbTimestamp = rs.getTimestamp(
+                    "modified",
+                    DateTimeUtils.getTimeZoneCalendar(timeZone)
+                );
+                assertEquals(((java.util.Date) struct.get("modified")).getTime(), dbTimestamp.getTime());
               }
             }
         )
@@ -145,7 +160,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         "    long INTEGER," +
         "    float NUMERIC," +
         "    double NUMERIC," +
-        "    bytes BLOB, " +
+        "    bytes BLOB," +
+        "    modified DATETIME, "+
         "PRIMARY KEY (firstName, lastName));"
     );
 
@@ -158,7 +174,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
         .put("byte", (byte) -72)
         .put("long", 8594L)
         .put("double", 3256677.56457d)
-        .put("age", 28);
+        .put("age", 28)
+        .put("modified", new Date(1474661402123L));
 
     task.put(Collections.singleton(new SinkRecord(topic, 1, null, null, SCHEMA, struct, 43)));
 
@@ -178,6 +195,11 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
                 rs.getShort("float");
                 assertTrue(rs.wasNull());
                 assertEquals(struct.getFloat64("double"), rs.getDouble("double"), 0.01);
+                java.sql.Timestamp dbTimestamp = rs.getTimestamp(
+                    "modified",
+                    DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone("UTC"))
+                );
+                assertEquals(((java.util.Date) struct.get("modified")).getTime(), dbTimestamp.getTime());
               }
             }
         )

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -16,6 +16,8 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import java.util.Calendar;
+import java.util.TimeZone;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -33,7 +35,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -99,7 +100,8 @@ public class PreparedStatementBinderTest {
         pkMode,
         schemaPair,
         fieldsMetadata,
-        JdbcSinkConfig.InsertMode.INSERT
+        JdbcSinkConfig.InsertMode.INSERT,
+        TimeZone.getTimeZone("UTC")
     );
 
     binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -118,9 +120,19 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setDouble(index++, valueStruct.getFloat64("double"));
     verify(statement, times(1)).setBytes(index++, valueStruct.getBytes("bytes"));
     verify(statement, times(1)).setBigDecimal(index++, (BigDecimal) valueStruct.get("decimal"));
-    verify(statement, times(1)).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
-    verify(statement, times(1)).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
-    verify(statement, times(1)).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()), DateTimeUtils.UTC_CALENDAR.get());
+    Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone("UTC"));
+    verify(
+        statement,
+        times(1)
+    ).setDate(index++, new java.sql.Date(((java.util.Date) valueStruct.get("date")).getTime()), utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setTime(index++, new java.sql.Time(((java.util.Date) valueStruct.get("time")).getTime()), utcCalendar);
+    verify(
+        statement,
+        times(1)
+    ).setTimestamp(index++, new java.sql.Timestamp(((java.util.Date) valueStruct.get("timestamp")).getTime()), utcCalendar);
     // last field is optional and is null-valued in struct
     verify(statement, times(1)).setObject(index++, null);
   }
@@ -150,7 +162,8 @@ public class PreparedStatementBinderTest {
                 statement,
                 pkMode,
                 schemaPair,
-                fieldsMetadata, JdbcSinkConfig.InsertMode.UPSERT
+                fieldsMetadata, JdbcSinkConfig.InsertMode.UPSERT,
+                TimeZone.getTimeZone("UTC")
         );
 
         binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -188,7 +201,8 @@ public class PreparedStatementBinderTest {
                 statement,
                 pkMode,
                 schemaPair,
-                fieldsMetadata, JdbcSinkConfig.InsertMode.UPDATE
+                fieldsMetadata, JdbcSinkConfig.InsertMode.UPDATE,
+                TimeZone.getTimeZone("UTC")
         );
 
         binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -218,9 +232,11 @@ public class PreparedStatementBinderTest {
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
     verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
-    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date(0), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000), DateTimeUtils.UTC_CALENDAR.get());
-    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100), DateTimeUtils.UTC_CALENDAR.get());
+    verifyBindField(++index, Date.SCHEMA, new java.util.Date(0)).setDate(index, new java.sql.Date(0), DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone("UTC")));
+    verifyBindField(++index, Time.SCHEMA, new java.util.Date(1000)).setTime(index, new java.sql.Time(1000), DateTimeUtils.getTimeZoneCalendar(
+        TimeZone.getTimeZone("UTC")));
+    verifyBindField(++index, Timestamp.SCHEMA, new java.util.Date(100)).setTimestamp(index, new java.sql.Timestamp(100), DateTimeUtils.getTimeZoneCalendar(
+        TimeZone.getTimeZone("UTC")));
   }
 
   @Test
@@ -249,24 +265,34 @@ public class PreparedStatementBinderTest {
   @Test(expected = ConnectException.class)
   public void bindFieldStructUnsupported() throws SQLException {
     Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
-    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+    PreparedStatementBinder binder =
+        new PreparedStatementBinder(null, null, null, null, null, TimeZone.getTimeZone("UTC"));
+    binder.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
   }
 
   @Test(expected = ConnectException.class)
   public void bindFieldArrayUnsupported() throws SQLException {
     Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
-    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+    PreparedStatementBinder binder = new PreparedStatementBinder(
+        null, null, null, null, null,
+        TimeZone.getTimeZone("UTC")
+    );
+    binder.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
   }
 
   @Test(expected = ConnectException.class)
   public void bindFieldMapUnsupported() throws SQLException {
     Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
-    PreparedStatementBinder.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
+    PreparedStatementBinder binder =
+        new PreparedStatementBinder(null, null, null, null, null, TimeZone.getTimeZone("UTC"));
+    binder.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 
   private PreparedStatement verifyBindField(int index, Schema schema, Object value) throws SQLException {
     PreparedStatement statement = mock(PreparedStatement.class);
-    PreparedStatementBinder.bindField(statement, index, schema, value);
+    PreparedStatementBinder binder =
+        new PreparedStatementBinder(null, null, null, null, null, TimeZone.getTimeZone("UTC"));
+    binder.bindField(statement, index, schema, value);
     return verify(statement, times(1));
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/DbDialectTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.TimeZone;
 
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 
@@ -64,6 +65,7 @@ public class DbDialectTest {
 
   private void verifyFormatColumnValue(String expected, Schema schema, Object value) {
     final StringBuilder builder = new StringBuilder();
+    DUMMY_DIALECT.withTimeZone(TimeZone.getTimeZone("UTC"));
     DUMMY_DIALECT.formatColumnValue(builder, schema.name(), schema.parameters(), schema.type(), value);
     assertEquals(expected, builder.toString());
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
@@ -31,6 +31,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.List;
+import java.util.TimeZone;
 
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.NumericMapping;
 import static org.junit.Assert.assertEquals;
@@ -178,7 +179,8 @@ public class DataConverterTest {
     when(metadata.getScale(1)).thenReturn(scale);
 
     Schema schema = DataConverter.convertSchema("foo", metadata, numMapping);
-    Struct record = DataConverter.convertRecord(schema, resultSet, numMapping);
+    Struct record = DataConverter.convertRecord(schema, resultSet, numMapping,
+        TimeZone.getTimeZone("UTC"));
 
     Object value = record.get("PrimitiveField1");
     assertEquals(expectedValue, value);

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -16,6 +16,13 @@
 
 package io.confluent.connect.jdbc.source;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -34,9 +41,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import io.confluent.connect.jdbc.util.DateTimeUtils;
-import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 
@@ -49,6 +56,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   private static final Map<String, String> QUERY_SOURCE_PARTITION
       = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
                                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE);
+
+  private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
 
   @After
   public void tearDown() throws Exception {
@@ -172,16 +181,24 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     db.createTable(SINGLE_TABLE_NAME,
                    "modified", "TIMESTAMP NOT NULL",
                    "id", "INT");
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 1);
 
     startTask("modified", null, null);
     verifyTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
     // If there isn't enough resolution, this could miss some rows. In this case, we'll only see
     // IDs 3 & 4.
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 2);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(11L)), "id", 3);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(12L)), "id", 4);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+            "id", 2);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
+            "id", 3);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE),
+            "id", 4);
 
     verifyPoll(2, "id", Arrays.asList(3, 4), true, false, TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
@@ -199,9 +216,11 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
             "modified", "TIMESTAMP NOT NULL",
             "id", "INT");
 
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+            "id", 1);
 
-    startTask("modified", null, null, 4L);
+    startTask("modified", null, null, 4L, "UTC");
     verifyTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
     Long currentTime = new Date().getTime();
@@ -233,15 +252,17 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     db.createTable(SINGLE_TABLE_NAME,
             "modified", "TIMESTAMP NOT NULL",
             "id", "INT NOT NULL");
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 1);
+    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 1);
 
     startTask("modified", "id", null);
     verifyIncrementingAndTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
     // Should be able to pick up id 2 because of ID despite same timestamp.
     // Note this is setup so we can reuse some validation code
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 3);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(11L)), "id", 1);
+    db.insert(SINGLE_TABLE_NAME, "modified",
+            DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 3);
+    db.insert(SINGLE_TABLE_NAME, "modified",
+            DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE), "id", 1);
 
     verifyPoll(2, "id", Arrays.asList(3, 1), true, true, TOPIC_PREFIX + SINGLE_TABLE_NAME);
 
@@ -249,15 +270,58 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testManualIncrementingRestoreOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
-    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
-            Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+  public void testTimestampInNonUTCTimezone() throws Exception {
+    expectInitializeNoOffsets(Arrays.asList(
+        SINGLE_TABLE_PARTITION)
+    );
 
     PowerMock.replayAll();
 
+    String timeZoneID = "America/Los_Angeles";
+    TimeZone timeZone = TimeZone.getTimeZone(timeZoneID);
+    // Manage these manually so we can verify the emitted values
     db.createTable(SINGLE_TABLE_NAME,
-            "id", "INT NOT NULL");
+        "modified", "TIMESTAMP NOT NULL",
+        "id", "INT NOT NULL");
+    String modifiedTimestamp = DateTimeUtils.formatTimestamp(new Timestamp(10L), timeZone);
+    db.insert(SINGLE_TABLE_NAME, "modified", modifiedTimestamp, "id", 1);
+
+    startTask("modified", "id", null, 0L, timeZoneID);
+    verifyIncrementingAndTimestampFirstPoll(TOPIC_PREFIX + SINGLE_TABLE_NAME);
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void testTimestampInInvalidTimezone() throws Exception {
+    String invalidTimeZoneID = "Europe/Invalid";
+    // Manage these manually so we can verify the emitted values
+    db.createTable(SINGLE_TABLE_NAME,
+        "modified", "TIMESTAMP NOT NULL",
+        "id", "INT NOT NULL");
+
+    try {
+      startTask("modified", "id", null, 0L, invalidTimeZoneID);
+      fail("A ConfigException should have been thrown");
+    } catch (ConnectException e) {
+      assertTrue(e.getCause() instanceof ConfigException);
+      ConfigException configException = (ConfigException) e.getCause();
+      assertThat(configException.getMessage(),
+          equalTo(
+              "Invalid value Europe/Invalid for configuration db.timezone: Invalid time zone identifier"));
+    }
+  }
+
+  @Test
+  public void testManualIncrementingRestoreOffset() throws
+      Exception {
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    expectInitialize(Arrays.asList(SINGLE_TABLE_PARTITION),
+        Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
+
+    PowerMock.replayAll();
+
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT NOT NULL");
     db.insert(SINGLE_TABLE_NAME, "id", 1);
     db.insert(SINGLE_TABLE_NAME, "id", 2);
     db.insert(SINGLE_TABLE_NAME, "id", 3);
@@ -308,9 +372,15 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
             "modified", "TIMESTAMP NOT NULL",
             "id", "INT");
     // id=2 will be ignored since it has the same timestamp as the initial offset.
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 2);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(11L)), "id", 3);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(12L)), "id", 4);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+        "id", 2);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
+        "id", 3);
+    db.insert(SINGLE_TABLE_NAME,
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE),
+        "id", 4);
 
     startTask("modified", null, null);
 
@@ -334,11 +404,21 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
             "id", "INT NOT NULL");
     // id=3 will be ignored since it has the same timestamp + id as the initial offset, rest
     // should be included, including id=1 which is an old ID with newer timestamp
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(9L)), "id", 2);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 3);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(11L)), "id", 4);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(12L)), "id", 5);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(13L)), "id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(9L), UTC_TIME_ZONE),
+            "id", 2);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+            "id", 3);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
+            "id", 4);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE),
+            "id", 5);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(13L), UTC_TIME_ZONE),
+            "id", 1);
 
     startTask("modified", "id", null);
 
@@ -400,7 +480,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
             "modified", "TIMESTAMP NOT NULL",
             "id", "INT",
             "user_id", "INT");
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 1,
+    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE), "id", 1,
               "user_id", 1);
 
     startTask("modified", null, "SELECT \"test\".\"modified\", \"test\".\"id\", \"test\""
@@ -409,12 +489,18 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
     verifyTimestampFirstPoll(TOPIC_PREFIX);
 
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(10L)), "id", 2,
-              "user_id", 1);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(11L)), "id", 3,
-              "user_id", 2);
-    db.insert(SINGLE_TABLE_NAME, "modified", DateTimeUtils.formatUtcTimestamp(new Timestamp(12L)), "id", 4,
-              "user_id", 2);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(10L), UTC_TIME_ZONE),
+            "id", 2,
+            "user_id", 1);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(11L), UTC_TIME_ZONE),
+            "id", 3,
+            "user_id", 2);
+    db.insert(SINGLE_TABLE_NAME,
+            "modified", DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE),
+            "id", 4,
+            "user_id", 2);
 
     verifyPoll(2, "id", Arrays.asList(3, 4), true, false, TOPIC_PREFIX);
 
@@ -422,10 +508,11 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   private void startTask(String timestampColumn, String incrementingColumn, String query) {
-    startTask(timestampColumn, incrementingColumn, query, 0L);
+    startTask(timestampColumn, incrementingColumn, query, 0L, "UTC");
   }
 
-  private void startTask(String timestampColumn, String incrementingColumn, String query, Long delay) {
+  private void startTask(String timestampColumn, String incrementingColumn,
+                         String query, Long delay, String timeZone) {
     String mode = null;
     if (timestampColumn != null && incrementingColumn != null) {
       mode = JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING;
@@ -450,6 +537,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
       taskConfig.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG, incrementingColumn);
     }
     taskConfig.put(JdbcSourceConnectorConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG, delay == null ? "0" : delay.toString());
+    if (timeZone != null) {
+      taskConfig.put(JdbcSourceConnectorConfig.DB_TIMEZONE_CONFIG, timeZone);
+    }
     task.start(taskConfig);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -71,7 +71,7 @@ public class TimestampIncrementingTableQuerierTest {
 
   private TimestampIncrementingTableQuerier newQuerier() {
     return new TimestampIncrementingTableQuerier(TableQuerier.QueryMode.TABLE, null, "", null, "id",
-        Collections.<String, Object>emptyMap(), 0L, null, JdbcSourceConnectorConfig.NumericMapping.NONE);
+        Collections.<String, Object>emptyMap(), 0L, null, "", JdbcSourceConnectorConfig.NumericMapping.NONE);
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.jdbc.util;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Test;
+
+public class TimeZoneValidatorTest {
+
+  @Test
+  public void testAccuracy() {
+    String[] validTimeZones = new String[]{
+        "Europe/Vienna",
+        "Asia/Tokyo",
+        "America/Los_Angeles",
+        "UTC",
+        "GMT+01:00",
+        "UTC"
+    };
+
+    for (String timeZone: validTimeZones) {
+      TimeZoneValidator.INSTANCE.ensureValid("db.timezone", timeZone);
+    }
+  }
+
+  @Test
+  public void testTimeZoneNotSpecified() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", null);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidTimeZone() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", "invalid");
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testEmptyTimeZone() {
+    TimeZoneValidator.INSTANCE.ensureValid("db.timezone", "");
+  }
+}


### PR DESCRIPTION
Date/time/timestamp values read from the source DB will be
instantiated into the specified timezone.

Backports https://github.com/confluentinc/kafka-connect-jdbc/pull/505/files

4.1.x must support Java 7, explaining some of the deviations from the original.

The strategy is to minimize changing public interfaces of the 4.1.x branch, even if it requires deviation from the 5.x feature and changes to the tests files in 4.1.x. Notably, I decided that `DbDialect.withTimeZone(TimeZone)` is the best way to provide timezones to the Column Formatters, even though it opens the potential for NPE if the DbDialect object is never given a timezone, since it is impossible for the user to misconfigure it is an acceptable tradeoff.