### PR TITLE
Catch exception throw and return connection as invalid

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -219,15 +219,20 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       return connection.isValid(timeout);
     }
     // issue a test query ...
-    String query = checkConnectionQuery();
-    if (query != null) {
-      try (Statement statement = connection.createStatement()) {
-        if (statement.execute(query)) {
-          try (ResultSet rs = statement.getResultSet()) {
-            // do nothing with the result set
+    try {
+      String query = checkConnectionQuery();
+      if (query != null) {
+        try (Statement statement = connection.createStatement()) {
+          if (statement.execute(query)) {
+            try (ResultSet rs = statement.getResultSet()) {
+              // do nothing with the result set
+            }
           }
         }
       }
+    } catch (SQLException e) {
+      log.warn("Error running test query, {}", e);
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
May have found a bug in how the JDBC source connector verifies an existing connection. We found the AS400 JDBC would throw an exception when the connection had become stale, thus bypassing the connection retry attempts built in to the #newConnection method inside the JDBC driver - causing the task to fail.