### PR TITLE
Use Java 7 to valiate timezones

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -16,8 +16,9 @@
 
 package io.confluent.connect.jdbc.util;
 
-import java.time.DateTimeException;
-import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.TimeZone;
+
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
@@ -28,9 +29,7 @@ public class TimeZoneValidator implements ConfigDef.Validator {
   @Override
   public void ensureValid(String name, Object value) {
     if (value != null) {
-      try {
-        ZoneId.of(value.toString());
-      } catch (DateTimeException e) {
+      if (!Arrays.asList(TimeZone.getAvailableIDs()).contains(value.toString())) {
         throw new ConfigException(name, value, "Invalid time zone identifier");
       }
     }

--- a/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TimeZoneValidatorTest.java
@@ -26,8 +26,6 @@ public class TimeZoneValidatorTest {
         "Asia/Tokyo",
         "America/Los_Angeles",
         "UTC",
-        "GMT+01:00",
-        "UTC"
     };
 
     for (String timeZone: validTimeZones) {


### PR DESCRIPTION
Fixes build error since 4.1.x should support Java 7.
The behavior is slightly more limited than in the 5.x version, as demonstrated in the tests. The docs will reflect that in the 4.1.x version the valid timezones are listed by `TimeZone.getAvailableIDs()`