### PR TITLE
Use of valueOf() method instead of typecasting

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -213,7 +213,14 @@ public class TimestampIncrementingCriteria {
       Struct record
   ) {
     for (ColumnId timestampColumn : timestampColumns) {
-      Timestamp ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
+      Timestamp ts;
+      Object timestampObject = record.get(timestampColumn.name());
+      if(timestampObject instanceof  String) {
+        ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
+      }
+      else {
+        ts = (Timestamp) record.get(timestampColumn.name());
+      }
       if (ts != null) {
         return ts;
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -213,7 +213,7 @@ public class TimestampIncrementingCriteria {
       Struct record
   ) {
     for (ColumnId timestampColumn : timestampColumns) {
-      Timestamp ts = (Timestamp) record.get(timestampColumn.name());
+      Timestamp ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
       if (ts != null) {
         return ts;
       }


### PR DESCRIPTION
Change was made to overcome the below error that was being faced during Connector creation involving MSSQL2012 DB:

java.lang.ClassCastException: java.lang.String cannot be cast to java.sql.Timestamp
	at io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.extractOffsetTimestamp(TimestampIncrementingCriteria.java:211)
	at io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.extractValues(TimestampIncrementingCriteria.java:181)
	at io.confluent.connect.jdbc.source.TimestampIncrementingTableQuerier.extractRecord(TimestampIncrementingTableQuerier.java:183)
	at io.confluent.connect.jdbc.source.JdbcSourceTask.poll(JdbcSourceTask.java:297)
	...