### PR TITLE
added to handle String to Timestamp casting

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -215,7 +215,7 @@ public class TimestampIncrementingCriteria {
     for (ColumnId timestampColumn : timestampColumns) {
       Timestamp ts;
       Object timestampObject = record.get(timestampColumn.name());
-      if(timestampObject instanceof  String) {
+      if (timestampObject instanceof  String) {
         ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
       }
       else {

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -213,7 +213,14 @@ public class TimestampIncrementingCriteria {
       Struct record
   ) {
     for (ColumnId timestampColumn : timestampColumns) {
-      Timestamp ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
+      Timestamp ts;
+      Object timestampObject = record.get(timestampColumn.name());
+      if(timestampObject instanceof  String) {
+        ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
+      }
+      else {
+        ts = (Timestamp) record.get(timestampColumn.name());
+      }
       if (ts != null) {
         return ts;
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -213,7 +213,7 @@ public class TimestampIncrementingCriteria {
       Struct record
   ) {
     for (ColumnId timestampColumn : timestampColumns) {
-      Timestamp ts = (Timestamp) record.get(timestampColumn.name());
+      Timestamp ts = Timestamp.valueOf(record.get(timestampColumn.name()).toString());
       if (ts != null) {
         return ts;
       }


### PR DESCRIPTION
change was added to handle the String to Timestamp casting when the record.get() returned a String object.