### PR TITLE
Fixes #127. Added delete support for sink.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -361,6 +361,21 @@ public interface DatabaseDialect extends ConnectionProvider {
   );
 
   /**
+   * Build the DELETE prepared statement expression for the given table and its columns. Variables
+   * for each key column should also appear in the WHERE clause of the statement.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @return the delete statement; may not be null
+   * @throws UnsupportedOperationException if the dialect does not support upserts
+   */
+  String buildDeleteStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns
+  );
+
+  /**
    * Build the DROP TABLE statement expression for the given table.
    *
    * @param table   the identifier of the table; may not be null

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -368,12 +368,14 @@ public interface DatabaseDialect extends ConnectionProvider {
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @return the delete statement; may not be null
-   * @throws UnsupportedOperationException if the dialect does not support upserts
+   * @throws UnsupportedOperationException if the dialect does not support deletes
    */
-  String buildDeleteStatement(
+  default String buildDeleteStatement(
       TableId table,
       Collection<ColumnId> keyColumns
-  );
+  ) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Build the DROP TABLE statement expression for the given table.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1401,6 +1401,24 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
+  public final String buildDeleteStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("DELETE FROM ");
+    builder.append(table);
+    if (!keyColumns.isEmpty()) {
+      builder.append(" WHERE ");
+      builder.appendList()
+          .delimitedBy(" AND ")
+          .transformedBy(ExpressionBuilder.columnNamesWith(" = ?"))
+          .of(keyColumns);
+    }
+    return builder.toString();
+  }
+
+  @Override
   public StatementBinder statementBinder(
       PreparedStatement statement,
       PrimaryKeyMode pkMode,

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -26,8 +27,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
@@ -36,6 +38,10 @@ import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.TableId;
+
+import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.InsertMode.INSERT;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 public class BufferedRecords {
   private static final Logger log = LoggerFactory.getLogger(BufferedRecords.class);
@@ -47,10 +53,14 @@ public class BufferedRecords {
   private final Connection connection;
 
   private List<SinkRecord> records = new ArrayList<>();
-  private SchemaPair currentSchemaPair;
+  private Schema keySchema;
+  private Schema valueSchema;
   private FieldsMetadata fieldsMetadata;
-  private PreparedStatement preparedStatement;
-  private StatementBinder preparedStatementBinder;
+  private PreparedStatement updatePreparedStatement;
+  private PreparedStatement deletePreparedStatement;
+  private StatementBinder updateStatementBinder;
+  private StatementBinder deleteStatementBinder;
+  private boolean deletesInBatch = false;
 
   public BufferedRecords(
       JdbcSinkConfig config,
@@ -67,20 +77,46 @@ public class BufferedRecords {
   }
 
   public List<SinkRecord> add(SinkRecord record) throws SQLException {
-    final SchemaPair schemaPair = new SchemaPair(
-        record.keySchema(),
-        record.valueSchema()
-    );
+    final List<SinkRecord> flushed = new ArrayList<>();
 
-    if (currentSchemaPair == null) {
-      currentSchemaPair = schemaPair;
+    boolean schemaChanged = false;
+    if (!Objects.equals(keySchema, record.keySchema())) {
+      keySchema = record.keySchema();
+      schemaChanged = true;
+    }
+    if (isNull(record.valueSchema())) {
+      // For deletes, both the value and value schema come in as null.
+      // We don't want to treat this as a schema change if key schemas is the same
+      // otherwise we flush unnecessarily.
+      if (config.deleteEnabled) {
+        deletesInBatch = true;
+      }
+    } else if (Objects.equals(valueSchema, record.valueSchema())) {
+      if (config.deleteEnabled && deletesInBatch) {
+        // flush so an insert after a delete of same record isn't lost
+        flushed.addAll(flush());
+      }
+    } else {
+      // value schema is not null and has changed. This is a real schema change.
+      valueSchema = record.valueSchema();
+      schemaChanged = true;
+    }
+
+    if (schemaChanged) {
+      // Each batch needs to have the same schemas, so get the buffered records out
+      flushed.addAll(flush());
+
       // re-initialize everything that depends on the record schema
+      final SchemaPair schemaPair = new SchemaPair(
+          record.keySchema(),
+          record.valueSchema()
+      );
       fieldsMetadata = FieldsMetadata.extract(
           tableId.tableName(),
           config.pkMode,
           config.pkFields,
           config.fieldsWhitelist,
-          currentSchemaPair
+          schemaPair
       );
       dbStructure.createOrAmendIfNecessary(
           config,
@@ -88,43 +124,40 @@ public class BufferedRecords {
           tableId,
           fieldsMetadata
       );
-
-      final String sql = getInsertSql();
+      final String insertSql = getInsertSql();
+      final String deleteSql = getDeleteSql();
       log.debug(
-          "{} sql: {}",
+          "{} sql: {} deleteSql: {} meta: {}",
           config.insertMode,
-          sql
+          insertSql,
+          deleteSql,
+          fieldsMetadata
       );
       close();
-      preparedStatement = connection.prepareStatement(sql);
-      preparedStatementBinder = dbDialect.statementBinder(
-          preparedStatement,
+      // should this be using dbDialect.createPreparedStatement ?
+      updatePreparedStatement = connection.prepareStatement(insertSql);
+      updateStatementBinder = dbDialect.statementBinder(
+          updatePreparedStatement,
           config.pkMode,
           schemaPair,
           fieldsMetadata,
           config.insertMode
       );
-    }
-
-    final List<SinkRecord> flushed;
-    if (currentSchemaPair.equals(schemaPair)) {
-      // Continue with current batch state
-      records.add(record);
-      if (records.size() >= config.batchSize) {
-        log.debug("Flushing buffered records after exceeding configured batch size {}.",
-            config.batchSize);
-        flushed = flush();
-      } else {
-        flushed = Collections.emptyList();
+      if (config.deleteEnabled && nonNull(deleteSql)) {
+        deletePreparedStatement = connection.prepareStatement(deleteSql);
+        deleteStatementBinder = dbDialect.statementBinder(
+            deletePreparedStatement,
+            config.pkMode,
+            schemaPair,
+            fieldsMetadata,
+            config.insertMode
+        );
       }
-    } else {
-      // Each batch needs to have the same SchemaPair, so get the buffered records out, reset
-      // state and re-attempt the add
-      log.debug("Flushing buffered records after due to unequal schema pairs: "
-          + "current schemas: {}, next schemas: {}", currentSchemaPair, schemaPair);
-      flushed = flush();
-      currentSchemaPair = null;
-      flushed.addAll(add(record));
+    }
+    records.add(record);
+
+    if (records.size() >= config.batchSize) {
+      flushed.addAll(flush());
     }
     return flushed;
   }
@@ -136,39 +169,26 @@ public class BufferedRecords {
     }
     log.debug("Flushing {} buffered records", records.size());
     for (SinkRecord record : records) {
-      preparedStatementBinder.bindRecord(record);
-    }
-    int totalUpdateCount = 0;
-    boolean successNoInfo = false;
-    for (int updateCount : preparedStatement.executeBatch()) {
-      if (updateCount == Statement.SUCCESS_NO_INFO) {
-        successNoInfo = true;
-        continue;
-      }
-      totalUpdateCount += updateCount;
-    }
-    if (totalUpdateCount != records.size() && !successNoInfo) {
-      switch (config.insertMode) {
-        case INSERT:
-          throw new ConnectException(String.format(
-              "Update count (%d) did not sum up to total number of records inserted (%d)",
-              totalUpdateCount,
-              records.size()
-          ));
-        case UPSERT:
-        case UPDATE:
-          log.debug(
-              "{} records:{} resulting in in totalUpdateCount:{}",
-              config.insertMode,
-              records.size(),
-              totalUpdateCount
-          );
-          break;
-        default:
-          throw new ConnectException("Unknown insert mode: " + config.insertMode);
+      if (isNull(record.value()) && nonNull(deleteStatementBinder)) {
+        deleteStatementBinder.bindRecord(record);
+      } else {
+        updateStatementBinder.bindRecord(record);
       }
     }
-    if (successNoInfo) {
+    Optional<Long> totalUpdateCount = executeUpdates();
+    long totalDeleteCount = executeDeletes();
+
+    final long expectedCount = updateRecordCount();
+    log.trace("{} records:{} resulting in totalUpdateCount:{} totalDeleteCount:{}",
+        config.insertMode, records.size(), totalUpdateCount, totalDeleteCount);
+    if (totalUpdateCount.filter(total -> total != expectedCount).isPresent()
+        && config.insertMode == INSERT) {
+      throw new ConnectException(String.format(
+          "Update count (%d) did not sum up to total number of records inserted (%d)",
+          totalUpdateCount.get(),
+          expectedCount));
+    }
+    if (!totalUpdateCount.isPresent()) {
       log.info(
           "{} records:{} , but no count of the number of rows it affected is available",
           config.insertMode,
@@ -178,14 +198,58 @@ public class BufferedRecords {
 
     final List<SinkRecord> flushedRecords = records;
     records = new ArrayList<>();
+    deletesInBatch = false;
     return flushedRecords;
   }
 
+  /**
+   * @return an optional count of all updated rows or an empty optional if no info is available
+   */
+  private Optional<Long> executeUpdates() throws SQLException {
+    Optional<Long> count = Optional.empty();
+    for (int updateCount : updatePreparedStatement.executeBatch()) {
+      if (updateCount != Statement.SUCCESS_NO_INFO) {
+        count = count.isPresent()
+            ? count.map(total -> total + updateCount)
+            : Optional.of((long)updateCount);
+      }
+    }
+    return count;
+  }
+
+  private long executeDeletes() throws SQLException {
+    long totalDeleteCount = 0;
+    if (nonNull(deletePreparedStatement)) {
+      for (int updateCount : deletePreparedStatement.executeBatch()) {
+        if (updateCount != Statement.SUCCESS_NO_INFO) {
+          totalDeleteCount += updateCount;
+        }
+      }
+    }
+    return totalDeleteCount;
+  }
+
+  private long updateRecordCount() {
+    return records
+        .stream()
+        // ignore deletes
+        .filter(record -> nonNull(record.value()) || !config.deleteEnabled)
+        .count();
+  }
+
   public void close() throws SQLException {
-    log.info("Closing BufferedRecords with preparedStatement: {}", preparedStatement);
-    if (preparedStatement != null) {
-      preparedStatement.close();
-      preparedStatement = null;
+    log.info(
+        "Closing BufferedRecords with updatePreparedStatement: {} deletePreparedStatement: {}",
+        updatePreparedStatement,
+        deletePreparedStatement
+    );
+    if (nonNull(updatePreparedStatement)) {
+      updatePreparedStatement.close();
+      updatePreparedStatement = null;
+    }
+    if (nonNull(deletePreparedStatement)) {
+      deletePreparedStatement.close();
+      deletePreparedStatement = null;
     }
   }
 
@@ -227,6 +291,26 @@ public class BufferedRecords {
       default:
         throw new ConnectException("Invalid insert mode");
     }
+  }
+
+  private String getDeleteSql() {
+    String sql = null;
+    if (config.deleteEnabled) {
+      switch (config.pkMode) {
+        case RECORD_KEY:
+          if (fieldsMetadata.keyFieldNames.isEmpty()) {
+            throw new ConnectException("Require primary keys to support delete");
+          }
+          sql = dbDialect.buildDeleteStatement(
+              tableId,
+              asColumns(fieldsMetadata.keyFieldNames)
+          );
+          break;
+        default:
+          throw new ConnectException("Deletes are only supported for pk.mode record_key");
+      }
+    }
+    return sql;
   }
 
   private Collection<ColumnId> asColumns(Collection<String> names) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -131,8 +131,10 @@ public class DbStructure {
     for (SinkRecordField missingField: missingFields) {
       if (!missingField.isOptional() && missingField.defaultValue() == null) {
         throw new ConnectException(
-            "Cannot ALTER to add missing field " + missingField
-            + ", as it is not optional and does not have a default value"
+            String.format(
+                "Cannot ALTER %s to add missing field %s, as it is not optional and "
+                    + "does not have a default value",
+                tableId, missingField)
         );
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -102,6 +102,13 @@ public class JdbcSinkConfig extends AbstractConfig {
       + " table, when possible.";
   private static final String BATCH_SIZE_DISPLAY = "Batch Size";
 
+  public static final String DELETE_ENABLED = "delete.enabled";
+  private static final String DELETE_ENABLED_DEFAULT = "false";
+  private static final String DELETE_ENABLED_DOC =
+      "Whether to treat ``null`` record values as deletes. Requires ``pk.mode`` "
+      + "to be ``record_key``.";
+  private static final String DELETE_ENABLED_DISPLAY = "Enable deletes";
+
   public static final String AUTO_CREATE = "auto.create";
   private static final String AUTO_CREATE_DEFAULT = "false";
   private static final String AUTO_CREATE_DOC =
@@ -282,6 +289,16 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.SHORT,
             BATCH_SIZE_DISPLAY
         )
+        .define(
+            DELETE_ENABLED,
+            ConfigDef.Type.BOOLEAN,
+            DELETE_ENABLED_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            DELETE_ENABLED_DOC, WRITES_GROUP,
+            3,
+            ConfigDef.Width.SHORT,
+            DELETE_ENABLED_DISPLAY
+        )
         // Data Mapping
         .define(
             TABLE_NAME_FORMAT,
@@ -401,6 +418,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionPassword;
   public final String tableNameFormat;
   public final int batchSize;
+  public final boolean deleteEnabled;
   public final int maxRetries;
   public final int retryBackoffMs;
   public final boolean autoCreate;
@@ -419,6 +437,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
+    deleteEnabled = getBoolean(DELETE_ENABLED);
     maxRetries = getInt(MAX_RETRIES);
     retryBackoffMs = getInt(RETRY_BACKOFF_MS);
     autoCreate = getBoolean(AUTO_CREATE);

--- a/src/main/java/io/confluent/connect/jdbc/util/DeleteEnabledRecommender.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DeleteEnabledRecommender.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.PK_MODE;
+
+public class DeleteEnabledRecommender implements ConfigDef.Recommender {
+
+  public static final DeleteEnabledRecommender INSTANCE = new DeleteEnabledRecommender();
+
+  private static final List<Object> ALL_VALUES = Arrays.asList(Boolean.TRUE, Boolean.FALSE);
+  private static final List<Object> DISABLED = Collections.singletonList(Boolean.FALSE);
+
+  @Override
+  public List<Object> validValues(final String name, final Map<String, Object> parsedConfig) {
+    return isRecordKeyPKMode(parsedConfig) ? ALL_VALUES : DISABLED;
+  }
+
+  @Override
+  public boolean visible(final String name, final Map<String, Object> parsedConfig) {
+    return isRecordKeyPKMode(parsedConfig);
+  }
+
+  private static boolean isRecordKeyPKMode(final Map<String, Object> parsedConfig) {
+    return JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY.name()
+        .equalsIgnoreCase(String.valueOf(parsedConfig.get(PK_MODE)));
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/PrimaryKeyModeRecommender.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/PrimaryKeyModeRecommender.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.DELETE_ENABLED;
+
+public class PrimaryKeyModeRecommender implements ConfigDef.Recommender {
+
+  public static final PrimaryKeyModeRecommender INSTANCE = new PrimaryKeyModeRecommender();
+
+  private static final List<Object> ALL_VALUES =
+      Arrays.stream(JdbcSinkConfig.PrimaryKeyMode.values())
+          .map(mode -> mode.name().toLowerCase())
+          .collect(Collectors.toList());
+  private static final List<Object> RECORD_KEY_ONLY =
+      Collections.singletonList(JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY.name().toLowerCase());
+
+  @Override
+  public List<Object> validValues(final String name, final Map<String, Object> parsedConfig) {
+    final boolean deleteEnabled = (Boolean) parsedConfig.getOrDefault(DELETE_ENABLED, false);
+    return deleteEnabled ? RECORD_KEY_ONLY : ALL_VALUES;
+  }
+
+  @Override
+  public boolean visible(final String name, final Map<String, Object> parsedConfig) {
+    return true;
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -204,6 +204,23 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
     assertEquals("INTEGER", defn.definitionForColumn("id").typeName());
   }
 
+  @Test
+  public void testBuildCreateTableStatement() {
+    newDialectFor(TABLE_TYPES, null);
+    assertEquals(
+        "INSERT INTO \"myTable\"(\"id1\",\"id2\",\"columnA\",\"columnB\",\"columnC\",\"columnD\") VALUES(?,?,?,?,?,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD));
+  }
+
+  @Test
+  public void testBuildDeleteStatement() {
+    newDialectFor(TABLE_TYPES, null);
+    assertEquals(
+        "DELETE FROM \"myTable\" WHERE \"id1\" = ? AND \"id2\" = ?",
+        dialect.buildDeleteStatement(tableId, pkColumns)
+    );
+  }
+
   protected void assertTableNames(
       Set<String> tableTypes,
       String schemaPattern,

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -33,6 +34,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Random;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
@@ -103,6 +105,18 @@ public class BufferedRecordsTest {
     assertEquals(Collections.singletonList(recordA), buffer.flush());
   }
 
+  @Test(expected = ConfigException.class)
+  public void configParsingFailsIfDeleteWithWrongPKMode() {
+    final HashMap<Object, Object> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", true);
+    props.put("auto.evolve", true);
+    props.put("delete.enabled", true);
+    props.put("insert.mode", "upsert");
+    props.put("pk.mode", "kafka"); // wrong pk mode for deletes
+    new JdbcSinkConfig(props);
+  }
+
   @Test
   public void insertThenDeleteInBatchNoFlush() throws SQLException {
     final HashMap<Object, Object> props = new HashMap<>();
@@ -153,8 +167,10 @@ public class BufferedRecordsTest {
     // delete should not cause a flush (i.e. not treated as a schema change)
     assertEquals(Collections.emptyList(), buffer.add(recordADelete));
 
+    // schema change should trigger flush
     assertEquals(Arrays.asList(recordA, recordA, recordADelete), buffer.add(recordB));
 
+    // second schema change should trigger flush
     assertEquals(Collections.singletonList(recordB), buffer.add(recordA));
 
     assertEquals(Collections.singletonList(recordA), buffer.flush());
@@ -201,23 +217,79 @@ public class BufferedRecordsTest {
         .put("age", 4);
     final SinkRecord recordB = new SinkRecord("dummy", 1, keySchemaA, keyA, schemaB, valueB, 1);
 
-    // test records are batched correctly based on schema equality as records are added
-    //   (schemaA,schemaA,schemaA,schemaB,schemaA) -> ([schemaA,schemaA,schemaA],[schemaB],[schemaA])
-
     assertEquals(Collections.emptyList(), buffer.add(recordA));
     assertEquals(Collections.emptyList(), buffer.add(recordA));
 
     // delete should not cause a flush (i.e. not treated as a schema change)
     assertEquals(Collections.emptyList(), buffer.add(recordADelete));
 
-    // insert after default should flush to insure insert isn't lost in batching
+    // insert after delete should flush to insure insert isn't lost in batching
     assertEquals(Arrays.asList(recordA, recordA, recordADelete), buffer.add(recordA));
 
+    // schema change should trigger flush
     assertEquals(Collections.singletonList(recordA), buffer.add(recordB));
 
+    // second schema change should trigger flush
     assertEquals(Collections.singletonList(recordB), buffer.add(recordA));
 
     assertEquals(Collections.singletonList(recordA), buffer.flush());
+  }
+
+  @Test
+  public void testMultipleDeletesBatchedTogether() throws SQLException {
+    final HashMap<Object, Object> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", true);
+    props.put("auto.evolve", true);
+    props.put("delete.enabled", true);
+    props.put("insert.mode", "upsert");
+    props.put("pk.mode", "record_key");
+    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "dummy");
+    final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
+
+    final Schema keySchemaA = SchemaBuilder.struct()
+        .field("id", Schema.INT64_SCHEMA)
+        .build();
+    final Schema valueSchemaA = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .build();
+    final Struct keyA = new Struct(keySchemaA)
+        .put("id", 1234L);
+    final Struct valueA = new Struct(valueSchemaA)
+        .put("name", "cuba");
+    final SinkRecord recordA = new SinkRecord("dummy", 0, keySchemaA, keyA, valueSchemaA, valueA, 0);
+    final SinkRecord recordADelete = new SinkRecord("dummy", 0, keySchemaA, keyA, null, null, 0);
+
+    final Schema schemaB = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        .build();
+    final Struct valueB = new Struct(schemaB)
+        .put("name", "cuba")
+        .put("age", 4);
+    final SinkRecord recordB = new SinkRecord("dummy", 1, keySchemaA, keyA, schemaB, valueB, 1);
+    final SinkRecord recordBDelete = new SinkRecord("dummy", 1, keySchemaA, keyA, null, null, 1);
+
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+
+    // schema change should trigger flush
+    assertEquals(Collections.singletonList(recordA), buffer.add(recordB));
+
+    // deletes should not cause a flush (i.e. not treated as a schema change)
+    assertEquals(Collections.emptyList(), buffer.add(recordADelete));
+    assertEquals(Collections.emptyList(), buffer.add(recordBDelete));
+
+    // insert after delete should flush to insure insert isn't lost in batching
+    assertEquals(Arrays.asList(recordB, recordADelete, recordBDelete), buffer.add(recordB));
+
+    assertEquals(Collections.singletonList(recordB), buffer.flush());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -104,6 +104,123 @@ public class BufferedRecordsTest {
   }
 
   @Test
+  public void insertThenDeleteInBatchNoFlush() throws SQLException {
+    final HashMap<Object, Object> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", true);
+    props.put("auto.evolve", true);
+    props.put("delete.enabled", true);
+    props.put("insert.mode", "upsert");
+    props.put("pk.mode", "record_key");
+    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "dummy");
+    final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
+
+    final Schema keySchemaA = SchemaBuilder.struct()
+        .field("id", Schema.INT64_SCHEMA)
+        .build();
+    final Schema valueSchemaA = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .build();
+    final Struct keyA = new Struct(keySchemaA)
+        .put("id", 1234L);
+    final Struct valueA = new Struct(valueSchemaA)
+        .put("name", "cuba");
+    final SinkRecord recordA = new SinkRecord("dummy", 0, keySchemaA, keyA, valueSchemaA, valueA, 0);
+    final SinkRecord recordADelete = new SinkRecord("dummy", 0, keySchemaA, keyA, null, null, 0);
+
+    final Schema schemaB = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        .build();
+    final Struct valueB = new Struct(schemaB)
+        .put("name", "cuba")
+        .put("age", 4);
+    final SinkRecord recordB = new SinkRecord("dummy", 1, keySchemaA, keyA, schemaB, valueB, 1);
+
+    // test records are batched correctly based on schema equality as records are added
+    //   (schemaA,schemaA,schemaA,schemaB,schemaA) -> ([schemaA,schemaA,schemaA],[schemaB],[schemaA])
+
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+
+    // delete should not cause a flush (i.e. not treated as a schema change)
+    assertEquals(Collections.emptyList(), buffer.add(recordADelete));
+
+    assertEquals(Arrays.asList(recordA, recordA, recordADelete), buffer.add(recordB));
+
+    assertEquals(Collections.singletonList(recordB), buffer.add(recordA));
+
+    assertEquals(Collections.singletonList(recordA), buffer.flush());
+  }
+
+  @Test
+  public void insertThenDeleteThenInsertInBatchFlush() throws SQLException {
+    final HashMap<Object, Object> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", true);
+    props.put("auto.evolve", true);
+    props.put("delete.enabled", true);
+    props.put("insert.mode", "upsert");
+    props.put("pk.mode", "record_key");
+    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "dummy");
+    final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
+
+    final Schema keySchemaA = SchemaBuilder.struct()
+        .field("id", Schema.INT64_SCHEMA)
+        .build();
+    final Schema valueSchemaA = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .build();
+    final Struct keyA = new Struct(keySchemaA)
+        .put("id", 1234L);
+    final Struct valueA = new Struct(valueSchemaA)
+        .put("name", "cuba");
+    final SinkRecord recordA = new SinkRecord("dummy", 0, keySchemaA, keyA, valueSchemaA, valueA, 0);
+    final SinkRecord recordADelete = new SinkRecord("dummy", 0, keySchemaA, keyA, null, null, 0);
+
+    final Schema schemaB = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        .build();
+    final Struct valueB = new Struct(schemaB)
+        .put("name", "cuba")
+        .put("age", 4);
+    final SinkRecord recordB = new SinkRecord("dummy", 1, keySchemaA, keyA, schemaB, valueB, 1);
+
+    // test records are batched correctly based on schema equality as records are added
+    //   (schemaA,schemaA,schemaA,schemaB,schemaA) -> ([schemaA,schemaA,schemaA],[schemaB],[schemaA])
+
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+    assertEquals(Collections.emptyList(), buffer.add(recordA));
+
+    // delete should not cause a flush (i.e. not treated as a schema change)
+    assertEquals(Collections.emptyList(), buffer.add(recordADelete));
+
+    // insert after default should flush to insure insert isn't lost in batching
+    assertEquals(Arrays.asList(recordA, recordA, recordADelete), buffer.add(recordA));
+
+    assertEquals(Collections.singletonList(recordA), buffer.add(recordB));
+
+    assertEquals(Collections.singletonList(recordB), buffer.add(recordA));
+
+    assertEquals(Collections.singletonList(recordA), buffer.flush());
+  }
+
+  @Test
   public void testFlushSuccessNoInfo() throws SQLException {
     final HashMap<Object, Object> props = new HashMap<>();
     props.put("connection.url", "");

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -206,6 +206,99 @@ public class JdbcDbWriterTest {
   }
 
   @Test
+  public void idempotentDeletes() throws SQLException {
+    String topic = "books";
+    int partition = 7;
+    long offset = 42;
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("delete.enabled", "true");
+    props.put("pk.mode", "record_key");
+    props.put("insert.mode", "upsert");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+        .field("id", SchemaBuilder.INT64_SCHEMA);
+
+    Struct keyStruct = new Struct(keySchema).put("id", 0L);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+
+    SinkRecord record = new SinkRecord(topic, partition, keySchema, keyStruct, valueSchema, valueStruct, offset);
+
+    writer.write(Collections.nCopies(2, record));
+
+    SinkRecord deleteRecord = new SinkRecord(topic, partition, keySchema, keyStruct, null, null, offset);
+    writer.write(Collections.nCopies(2, deleteRecord));
+
+    assertEquals(
+        1,
+        sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+          @Override
+          public void read(ResultSet rs) throws SQLException {
+            assertEquals(0, rs.getInt(1));
+          }
+        })
+    );
+  }
+
+  @Test
+  public void insertDeleteInsertSameRecord() throws SQLException {
+    String topic = "books";
+    int partition = 7;
+    long offset = 42;
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("delete.enabled", "true");
+    props.put("pk.mode", "record_key");
+    props.put("insert.mode", "upsert");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+        .field("id", SchemaBuilder.INT64_SCHEMA);
+
+    Struct keyStruct = new Struct(keySchema).put("id", 0L);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+
+    SinkRecord record = new SinkRecord(topic, partition, keySchema, keyStruct, valueSchema, valueStruct, offset);
+    SinkRecord deleteRecord = new SinkRecord(topic, partition, keySchema, keyStruct, null, null, offset);
+    writer.write(Collections.singletonList(record));
+    writer.write(Collections.singletonList(deleteRecord));
+    writer.write(Collections.singletonList(record));
+
+    assertEquals(
+        1,
+        sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+          @Override
+          public void read(ResultSet rs) throws SQLException {
+            assertEquals(1, rs.getInt(1));
+          }
+        })
+    );
+  }
+
+  @Test
   public void sameRecordNTimes() throws SQLException {
     String testId = "sameRecordNTimes";
     String createTable = "CREATE TABLE " + testId + " (" +

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -43,9 +43,7 @@ import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class JdbcDbWriterTest {
 
@@ -240,6 +238,51 @@ public class JdbcDbWriterTest {
 
     SinkRecord deleteRecord = new SinkRecord(topic, partition, keySchema, keyStruct, null, null, offset);
     writer.write(Collections.nCopies(2, deleteRecord));
+
+    assertEquals(
+        1,
+        sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+          @Override
+          public void read(ResultSet rs) throws SQLException {
+            assertEquals(0, rs.getInt(1));
+          }
+        })
+    );
+  }
+
+  @Test
+  public void insertDeleteSameRecord() throws SQLException {
+    String topic = "books";
+    int partition = 7;
+    long offset = 42;
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("delete.enabled", "true");
+    props.put("pk.mode", "record_key");
+    props.put("insert.mode", "upsert");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+        .field("id", SchemaBuilder.INT64_SCHEMA);
+
+    Struct keyStruct = new Struct(keySchema).put("id", 0L);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+
+    SinkRecord record = new SinkRecord(topic, partition, keySchema, keyStruct, valueSchema, valueStruct, offset);
+    SinkRecord deleteRecord = new SinkRecord(topic, partition, keySchema, keyStruct, null, null, offset);
+    writer.write(Collections.singletonList(record));
+    writer.write(Collections.singletonList(deleteRecord));
 
     assertEquals(
         1,


### PR DESCRIPTION
A record with `null` value is considered a tombstone event and result in deleting the corresponding row in the destination table.
Deletes are disabled by default. Set config `delete.enabled` to `true` to enable. Also requires `pk.mode = record_key` otherwise it can't find the record to delete.

Tested against Postgres

Fixes #607 and fixes #127