### PR TITLE
CC-4423 Remove semicolon from Db2 dialect timestamp query

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialect.java
@@ -61,7 +61,7 @@ public class Db2DatabaseDialect extends GenericDatabaseDialect {
 
   @Override
   protected String currentTimestampDatabaseQuery() {
-    return "SELECT CURRENT_TIMESTAMP(12) FROM SYSIBM.SYSDUMMY1;";
+    return "SELECT CURRENT_TIMESTAMP(12) FROM SYSIBM.SYSDUMMY1";
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
@@ -29,6 +29,7 @@ import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> {
 
@@ -350,5 +351,15 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
         "jdbc:db2://sysmvs1.stl.ibm.com:5021/STLEC1:password=****;user=dbadm;"
         + "traceLevel=all"
     );
+  }
+
+  @Test
+  public void testCurrentTimestampDatabaseQuery() {
+    assertFalse(dialect.currentTimestampDatabaseQuery().contains(";"));
+  }
+
+  @Test
+  public void testCheckConnectionQuery() {
+    assertFalse(dialect.checkConnectionQuery().contains(";"));
   }
 }


### PR DESCRIPTION
This fix was included in 4.1.x
https://github.com/confluentinc/kafka-connect-jdbc/blob/4.1.x/src/main/java/io/confluent/connect/jdbc/util/JdbcUtils.java#L249

but lost when the code was refactored from 5.0.x to 5.1.x


One big shortcoming here is that there seems to be no testing against this, but the only way to really know would be to have an integration test that spins up a DB2 instance. Any other tests against this are kind of over-specific, and what we really want to know is that this works against DB2. Sadly this is pressing issue for users so no time to write integration test.