### PR TITLE
Fix NPE when auto.create and incorrect access privileges

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
@@ -83,6 +83,10 @@ public class TableDefinitions {
       TableId tableId
   ) throws SQLException {
     TableDefinition dbTable = dialect.describeTable(connection, tableId);
+    if (dbTable == null) {
+      log.error("Unable to refresh metadata for table {}", tableId);
+      return null;
+    }
     log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
     cache.put(dbTable.id(), dbTable);
     return dbTable;


### PR DESCRIPTION
Made a simple change in `TableDefinitions.java` (against the 5.0.x branch) to handle the situation where `dbTable` can be null, and cause a NPE from the `TableDefinitions.refresh(...)` method (as per the suggestion from rhauch in the issue comments).

Verified that the _original exception_ from the attempt to create the table with insufficient permissions gets re-thrown (and not the NPE).
