### PR TITLE
CC-4946: changing log msgs on filtering and avoiding frequently retrying tasks when no tables

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -117,15 +117,14 @@ public class JdbcSourceConnector extends SourceConnector {
     String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
     List<Map<String, String>> taskConfigs;
     if (!query.isEmpty()) {
-      taskConfigs = new ArrayList<>(1);
       Map<String, String> taskProps = new HashMap<>(configProperties);
       taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, "");
-      taskConfigs.add(taskProps);
+      taskConfigs = Collections.singletonList(taskProps);
     } else {
       List<String> currentTables = tableMonitorThread.tables();
       if (currentTables.isEmpty()) {
-        taskConfigs = new ArrayList<>();
-        log.warn("No tasks are running because no tables were found");
+        taskConfigs = Collections.emptyList();
+        log.warn("No tasks will be run because no tables were found");
       } else {
         int numGroups = Math.min(currentTables.size(), maxTasks);
         List<List<String>> tablesGrouped = ConnectorUtils.groupPartitions(currentTables, numGroups);

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -115,25 +115,30 @@ public class JdbcSourceConnector extends SourceConnector {
   @Override
   public List<Map<String, String>> taskConfigs(int maxTasks) {
     String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
+    List<Map<String, String>> taskConfigs;
     if (!query.isEmpty()) {
-      List<Map<String, String>> taskConfigs = new ArrayList<>(1);
+      taskConfigs = new ArrayList<>(1);
       Map<String, String> taskProps = new HashMap<>(configProperties);
       taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, "");
       taskConfigs.add(taskProps);
-      return taskConfigs;
     } else {
       List<String> currentTables = tableMonitorThread.tables();
-      int numGroups = Math.min(currentTables.size(), maxTasks);
-      List<List<String>> tablesGrouped = ConnectorUtils.groupPartitions(currentTables, numGroups);
-      List<Map<String, String>> taskConfigs = new ArrayList<>(tablesGrouped.size());
-      for (List<String> taskTables : tablesGrouped) {
-        Map<String, String> taskProps = new HashMap<>(configProperties);
-        taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG,
-                      StringUtils.join(taskTables, ","));
-        taskConfigs.add(taskProps);
+      if (currentTables.isEmpty()) {
+        taskConfigs = new ArrayList<>();
+        log.warn("No tasks are running because no tables were found");
+      } else {
+        int numGroups = Math.min(currentTables.size(), maxTasks);
+        List<List<String>> tablesGrouped = ConnectorUtils.groupPartitions(currentTables, numGroups);
+        taskConfigs = new ArrayList<>(tablesGrouped.size());
+        for (List<String> taskTables : tablesGrouped) {
+          Map<String, String> taskProps = new HashMap<>(configProperties);
+          taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG,
+                  StringUtils.join(taskTables, ","));
+          taskConfigs.add(taskProps);
+        }
       }
-      return taskConfigs;
     }
+    return taskConfigs;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -112,7 +112,7 @@ public class TableMonitorThread extends Thread {
     final List<String> tables;
     try {
       tables = JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), schemaPattern, tableTypes);
-      log.debug("Got the following tables: " + Arrays.toString(tables.toArray()));
+      log.debug("Got the following tables: {}", Arrays.toString(tables.toArray()));
     } catch (SQLException e) {
       log.error("Error while trying to get updated table list, ignoring and waiting for next table poll interval", e);
       cachedConnectionProvider.closeQuietly();
@@ -140,10 +140,9 @@ public class TableMonitorThread extends Thread {
 
     if (!filteredTables.equals(this.tables)) {
       if (filteredTables.isEmpty()) {
-        log.debug("Based on the supplied filtering rules, there are no matching tables to read from: ");
+        log.debug("Based on the supplied filtering rules, there are no matching tables to read from");
       } else {
-        log.debug("Based on the supplied filtering rules, the tables available to read from include: "
-                + Arrays.toString(filteredTables.toArray()));
+        log.debug("Based on the supplied filtering rules, the tables available to read from include: {}",  Arrays.toString(filteredTables.toArray()));
       }
       List<String> previousTables = this.tables;
       this.tables = filteredTables;

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -139,7 +139,12 @@ public class TableMonitorThread extends Thread {
     }
 
     if (!filteredTables.equals(this.tables)) {
-      log.debug("After filtering we got tables: " + Arrays.toString(filteredTables.toArray()));
+      if (filteredTables.isEmpty()) {
+        log.debug("Based on the supplied filtering rules, there are no matching tables to read from: ");
+      } else {
+        log.debug("Based on the supplied filtering rules, the tables available to read from include: "
+                + Arrays.toString(filteredTables.toArray()));
+      }
       List<String> previousTables = this.tables;
       this.tables = filteredTables;
       notifyAll();

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -112,7 +111,7 @@ public class TableMonitorThread extends Thread {
     final List<String> tables;
     try {
       tables = JdbcUtils.getTables(cachedConnectionProvider.getValidConnection(), schemaPattern, tableTypes);
-      log.debug("Got the following tables: {}", Arrays.toString(tables.toArray()));
+      log.debug("Got the following tables: {}", tables);
     } catch (SQLException e) {
       log.error("Error while trying to get updated table list, ignoring and waiting for next table poll interval", e);
       cachedConnectionProvider.closeQuietly();
@@ -142,7 +141,7 @@ public class TableMonitorThread extends Thread {
       if (filteredTables.isEmpty()) {
         log.debug("Based on the supplied filtering rules, there are no matching tables to read from");
       } else {
-        log.debug("Based on the supplied filtering rules, the tables available to read from include: {}",  Arrays.toString(filteredTables.toArray()));
+        log.debug("Based on the supplied filtering rules, the tables available to read from include: {}",  tables);
       }
       List<String> previousTables = this.tables;
       this.tables = filteredTables;

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -44,6 +44,7 @@ import io.confluent.connect.jdbc.util.JdbcUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JdbcSourceConnector.class, JdbcUtils.class})
@@ -118,6 +119,16 @@ public class JdbcSourceConnectorTest {
     connector.stop();
 
     PowerMock.verifyAll();
+  }
+
+  @Test
+  public void testNoTablesNoTasks() throws Exception {
+    // Tests case where there are no readable tables and ensures that no tasks
+    // are returned to be run
+    connector.start(connProps);
+    List<Map<String, String>> configs = connector.taskConfigs(3);
+    assertTrue(configs.isEmpty());
+    connector.stop();
   }
 
   @Test


### PR DESCRIPTION
1) make log messages clearer after filtering tables
2) when no readable tables are available, don't run tasks and inform user via log