### PR TITLE
MINOR: Remove the final keyword from JdbcSinkConnector

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -31,7 +31,7 @@ import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import io.confluent.connect.jdbc.sink.JdbcSinkTask;
 import io.confluent.connect.jdbc.util.Version;
 
-public final class JdbcSinkConnector extends SinkConnector {
+public class JdbcSinkConnector extends SinkConnector {
   private static final Logger log = LoggerFactory.getLogger(JdbcSinkConnector.class);
 
   private Map<String, String> configProps;


### PR DESCRIPTION
This will allow variants of the JdbcSinkConnector to extend the class
rather than being forced to delegate the functionality, or copy the code.
This is desirable for promoting code-reuse in new connectors under development.