### PR TITLE
Change TableQuerier log to use real class name for file

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -39,7 +39,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     QUERY // User-specified query
   }
 
-  private final Logger log = LoggerFactory.getLogger(getClass()); // use concrete subclass
+  private final Logger log = LoggerFactory.getLogger(TableQuerier.class);
 
   protected final DatabaseDialect dialect;
   protected final QueryMode mode;


### PR DESCRIPTION
As-is, the SLF4J logger created and used by the `TableQuerier` class produces confusing log messages that end in, for example, `BulkTableQuerier:140`, which is counterintuitive since the `BulkTableQuerier` file has fewer than 140 lines.

This change alters that logger to refer to the `TableQuerier` class instead.