### PR TITLE
SqlServerDialect uses varchar(900) for primary key as string type

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -104,7 +104,12 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
       case BOOLEAN:
         return "bit";
       case STRING:
-        return "varchar(max)";
+        if (field.isPrimaryKey()) {
+          // Should be no more than 900 which is the MSSQL constraint
+          return "varchar(900)";
+        } else {
+          return "varchar(max)";
+        }
       case BYTES:
         return "varbinary(max)";
       default:

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -294,6 +294,12 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     )));
   }
 
+  protected void verifyCreateOneColOnePkAsString(String expected) {
+    assertEquals(expected, dialect.buildCreateTableStatement(tableId, Arrays.asList(
+            new SinkRecordField(Schema.STRING_SCHEMA, "pk1", true)
+    )));
+  }
+
   protected void verifyCreateThreeColTwoPk(String expected) {
     assertEquals(expected, dialect.buildCreateTableStatement(tableId, Arrays.asList(
         new SinkRecordField(Schema.INT32_SCHEMA, "pk1", true),

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -203,6 +203,13 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
   }
 
   @Test
+  public void createOneColOnePkInString() {
+    verifyCreateOneColOnePkAsString(
+        "CREATE TABLE [myTable] (" + System.lineSeparator() + "[pk1] varchar(900) NOT NULL," +
+          System.lineSeparator() + "PRIMARY KEY([pk1]))");
+  }
+
+  @Test
   public void createThreeColTwoPk() {
     verifyCreateThreeColTwoPk(
         "CREATE TABLE [myTable] (" + System.lineSeparator() + "[pk1] int NOT NULL," +


### PR DESCRIPTION
When sinking data to SqlServer with table auto-creation is enabled and primary key is string type, it was using varchar(max) for primary key, which leads to the exception:
```
com.microsoft.sqlserver.jdbc.SQLServerException: Column in table is of a type that is invalid for use as a key column in an index
```
https://github.com/confluentinc/kafka-connect-jdbc/issues/379

SqlServer 2012(and before) allows `varchar(900)` to be primary key. More than that is not acceptable.
As other RDBMS related sinks identify string type primary key and set it particularly, it makes sens to adapt it for MSSQL sink.


