### PR TITLE
Fix `ERROR Graceful stop of task failed`

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -186,10 +186,11 @@ public class JdbcSourceTask extends SourceTask {
       if (!querier.querying()) {
         // If not in the middle of an update, wait for next update time
         final long nextUpdate = querier.getLastUpdate() + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
-        final long untilNext = nextUpdate - time.milliseconds();
-        if (untilNext > 0) {
-          log.trace("Waiting {} ms to poll {} next", untilNext, querier.toString());
-          time.sleep(untilNext);
+        final long now = time.milliseconds();
+        final long sleepMs = Math.min(nextUpdate - now, 100);
+        if (sleepMs > 0) {
+          log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
+          time.sleep(sleepMs);
           continue; // Re-check stop flag before continuing
         }
       }


### PR DESCRIPTION
I've bumped into the problem:
```
[2019-07-08 20:05:06,314] ERROR Graceful stop of task deals-0 failed. (org.apache.kafka.connect.runtime.Worker)
```

Which leads to duplicates in kafka topics while rebalancing.

The reason is that JDBC source task is sleeping in `poll()` too much (exactly `POLL_INTERVAL_MS_CONFIG` which is 60000 ms in my case). And worker is unable to finish all tasks in `task.shutdown.graceful.timeout.ms` which is 5000 ms by default.

This can be seen in the log below (see `***` marks):

```
[2019-07-08 20:04:59,929] DEBUG WorkerSourceTask{id=deals-0} About to send 100 records to Kafka (org.apache.kafka.connect.runtime.WorkerSourceTask)
[2019-07-08 20:04:59,935] TRACE {} Polling for new data (io.confluent.connect.jdbc.source.JdbcSourceTask)
[2019-07-08 20:04:59,935] DEBUG Checking for next block of results from TimestampIncrementingTableQuerier{table=null, query='SELECT ...', topicPrefix='mt5real.deals', incrementingColumn='Timestamp', timestampColumns=[]} (io.confluent.connect.jdbc.source.JdbcSourceTask)
[2019-07-08 20:04:59,944] DEBUG Resetting querier TimestampIncrementingTableQuerier{table=null, query='SELECT ...', topicPrefix='deals', incrementingColumn='Timestamp', timestampColumns=[]} (io.confluent.connect.jdbc.source.JdbcSourceTask)
[2019-07-08 20:04:59,944] TRACE No updates for TimestampIncrementingTableQuerier{table=null, query='SELECT ...', topicPrefix='deals', incrementingColumn='Timestamp', timestampColumns=[]} (io.confluent.connect.jdbc.source.JdbcSourceTask)
*** [2019-07-08 20:04:59,945] TRACE Waiting 59999 ms to poll TimestampIncrementingTableQuerier{table=null, query='SELECT ...', topicPrefix='deals', incrementingColumn='Timestamp', timestampColumns=[]} next (io.confluent.connect.jdbc.source.JdbcSourceTask)


[2019-07-08 20:05:01,312] INFO Rebalance started (org.apache.kafka.connect.runtime.distributed.DistributedHerder)
[2019-07-08 20:05:01,312] INFO Stopping connector deals (org.apache.kafka.connect.runtime.Worker)
[2019-07-08 20:05:01,312] DEBUG Getting plugin class loader for connector: 'io.confluent.connect.jdbc.JdbcSourceConnector' (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader)
[2019-07-08 20:05:01,312] INFO Stopping table monitoring thread (io.confluent.connect.jdbc.JdbcSourceConnector)
[2019-07-08 20:05:01,312] INFO Shutting down thread monitoring tables. (io.confluent.connect.jdbc.source.TableMonitorThread)
*** [2019-07-08 20:05:01,312] INFO Stopping task deals-0 (org.apache.kafka.connect.runtime.Worker)
[2019-07-08 20:05:01,313] INFO Stopping JDBC source task (io.confluent.connect.jdbc.source.JdbcSourceTask)
[2019-07-08 20:05:01,313] INFO Closing connection #1 to PostgreSql (io.confluent.connect.jdbc.util.CachedConnectionProvider)
[2019-07-08 20:05:01,327] INFO Stopped connector deals (org.apache.kafka.connect.runtime.Worker)
*** [2019-07-08 20:05:06,314] ERROR Graceful stop of task deals-0 failed. (org.apache.kafka.connect.runtime.Worker)
[2019-07-08 20:05:06,314] INFO Finished stopping tasks in preparation for rebalance (org.apache.kafka.connect.runtime.distributed.DistributedHerder)
```

I propose to sleep no more than 100ms in order to be able to react on task shutdown.
