### PR TITLE
Add the possibility to specify a custom TopicNameProvider to convert table name to topic name on the fly

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.TopicNameProvider;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -41,9 +42,10 @@ public class BulkTableQuerier extends TableQuerier {
       DatabaseDialect dialect,
       QueryMode mode,
       String name,
-      String topicPrefix
+      String topicPrefix,
+      TopicNameProvider topicNameProvider
   ) {
-    super(dialect, mode, name, topicPrefix);
+    super(dialect, mode, name, topicPrefix, topicNameProvider);
   }
 
   @Override
@@ -90,7 +92,7 @@ public class BulkTableQuerier extends TableQuerier {
       case TABLE:
         String name = tableId.tableName(); // backwards compatible
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.TABLE_NAME_KEY, name);
-        topic = topicPrefix + name;
+        topic = topicNameProvider.getTopicName(topicPrefix, name);
         break;
       case QUERY:
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -223,6 +223,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "to, or in the case of a custom query, the full name of the topic to publish to.";
   private static final String TOPIC_PREFIX_DISPLAY = "Topic Prefix";
 
+  public static final String TOPIC_NAME_PROVIDER_CLASS_CONFIG = "topic.name.provider.class";
+  private static final String TOPIC_NAME_PROVIDER_CLASS_DOC =
+      "A fully-qualified class name of a user-defined class implementing TopicNameProvider that "
+      + "can provide the topic names from topic.prefix and table names for source connectors, i.e. "
+      + "reformatting table names, replacing unwanted chars, checking maximum length, etc. "
+      + "By default the topic names are the concatenation of topic.prefix & table names without any"
+      + " additional character in between";
+  public static final String TOPIC_NAME_PROVIDER_CLASS_DEFAULT =
+      "io.confluent.connect.jdbc.util.DefaultTopicNameProvider";
+  private static final String TOPIC_NAME_PROVIDER_CLASS_DISPLAY = "Topic Name Provider class";
+
   public static final String VALIDATE_NON_NULL_CONFIG = "validate.non.null";
   private static final String VALIDATE_NON_NULL_DOC =
       "By default, the JDBC connector will validate that all incrementing and timestamp tables "
@@ -557,6 +568,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         TOPIC_PREFIX_DISPLAY
+    ).define(
+        TOPIC_NAME_PROVIDER_CLASS_CONFIG,
+        Type.STRING,
+        TOPIC_NAME_PROVIDER_CLASS_DEFAULT,
+        Importance.MEDIUM,
+        TOPIC_NAME_PROVIDER_CLASS_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TOPIC_NAME_PROVIDER_CLASS_DISPLAY
     ).define(
         TIMESTAMP_DELAY_INTERVAL_MS_CONFIG,
         Type.LONG,

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.TopicNameProvider;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +46,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected final String query;
   protected final String topicPrefix;
   protected final TableId tableId;
+  protected final TopicNameProvider topicNameProvider;
 
   // Mutable state
 
@@ -58,13 +60,15 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       DatabaseDialect dialect,
       QueryMode mode,
       String nameOrQuery,
-      String topicPrefix
+      String topicPrefix,
+      TopicNameProvider topicNameProvider
   ) {
     this.dialect = dialect;
     this.mode = mode;
     this.tableId = mode.equals(QueryMode.TABLE) ? dialect.parseTableIdentifier(nameOrQuery) : null;
     this.query = mode.equals(QueryMode.QUERY) ? nameOrQuery : null;
     this.topicPrefix = topicPrefix;
+    this.topicNameProvider = topicNameProvider;
     this.lastUpdate = 0;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -16,6 +16,8 @@
 package io.confluent.connect.jdbc.source;
 
 import java.util.TimeZone;
+
+import io.confluent.connect.jdbc.util.TopicNameProvider;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -74,11 +76,12 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
                                            String topicPrefix,
+                                           TopicNameProvider topicNameProvider,
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
                                            TimeZone timeZone) {
-    super(dialect, mode, name, topicPrefix);
+    super(dialect, mode, name, topicPrefix, topicNameProvider);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
                                 ? timestampColumnNames : Collections.<String>emptyList();
@@ -95,7 +98,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     switch (mode) {
       case TABLE:
         String tableName = tableId.tableName();
-        topic = topicPrefix + tableName;// backward compatible
+        topic = topicNameProvider.getTopicName(topicPrefix, tableName);// backward compatible
         partition = OffsetProtocols.sourcePartitionForProtocolV1(tableId);
         break;
       case QUERY:

--- a/src/main/java/io/confluent/connect/jdbc/util/DefaultTopicNameProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DefaultTopicNameProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+
+public class DefaultTopicNameProvider implements TopicNameProvider {
+
+  @Override
+  public String getTopicName(String prefix, String tableName) {
+    return prefix + tableName;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/TopicNameProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TopicNameProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+public interface TopicNameProvider {
+  String getTopicName(String prefix, String tableName);
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTopicNameProviderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTopicNameProviderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.util.TopicNameProvider;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+// Tests of polling that return data updates, i.e. verifies the different behaviors with a custom Topic Name Provider
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({JdbcSourceTask.class})
+@PowerMockIgnore("javax.management.*")
+public class JdbcSourceTaskTopicNameProviderTest extends JdbcSourceTaskTestBase {
+
+    private static final String SINGLE_TABLE_NAME_REPLACED = "test_replaced";
+    private static final String SECOND_TABLE_NAME_REPLACED = "test2_replaced";
+
+    @After
+    public void tearDown() throws Exception {
+        task.stop();
+        super.tearDown();
+    }
+
+    @Test
+    public void testSingleTableShouldHaveCorrectTopicName() throws Exception {
+        db.createTable(SINGLE_TABLE_NAME, "id", "INT");
+
+        Map<String, String> taskConfig = singleTableConfig();
+        taskConfig.put(JdbcSourceConnectorConfig.TOPIC_NAME_PROVIDER_CLASS_CONFIG, TestTopicNameProvider.class.getName());
+        task.start(taskConfig);
+
+        db.insert(SINGLE_TABLE_NAME, "id", 1);
+        db.insert(SINGLE_TABLE_NAME, "id", 2);
+
+        List<SourceRecord> records = task.poll();
+        validatePollResultTopic(records, 2, taskConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG)+ SINGLE_TABLE_NAME_REPLACED);
+    }
+
+    @Test
+    public void testMultipleTableShouldHaveCorrectTopicName() throws Exception {
+        db.createTable(SINGLE_TABLE_NAME, "id", "INT");
+        db.createTable(SECOND_TABLE_NAME, "id", "INT");
+
+        Map<String, String> taskConfig = twoTableConfig();
+        taskConfig.put(JdbcSourceConnectorConfig.TOPIC_NAME_PROVIDER_CLASS_CONFIG, TestTopicNameProvider.class.getName());
+        task.start(taskConfig);
+
+        db.insert(SINGLE_TABLE_NAME, "id", 1);
+        db.insert(SECOND_TABLE_NAME, "id", 2);
+
+        // Both tables should be polled, in order
+        List<SourceRecord> records = task.poll();
+        validatePollResultTopic(records, 1, taskConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG)+ SINGLE_TABLE_NAME_REPLACED);
+
+        records = task.poll();
+        validatePollResultTopic(records, 1, taskConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG)+ SECOND_TABLE_NAME_REPLACED);
+    }
+
+    private static void validatePollResultTopic(List<SourceRecord> records,
+        int expected, String topic) {
+        assertEquals(expected, records.size());
+        for (SourceRecord record : records) {
+            assertEquals(topic, record.topic());
+        }
+    }
+
+    private static class TestTopicNameProvider implements TopicNameProvider {
+
+        public TestTopicNameProvider() {
+        }
+
+        @Override
+        public String getTopicName(String prefix, String tableName) {
+            if (tableName.equals(SINGLE_TABLE_NAME)) {
+                return prefix + SINGLE_TABLE_NAME_REPLACED;
+            } else if(tableName.equals(SECOND_TABLE_NAME)) {
+                return prefix + SECOND_TABLE_NAME_REPLACED;
+            } else {
+                return prefix + "empty_topic_name";
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR aim to allow the user to specify a custom TopicNameProvider that can generate the topic name from the table name on the fly. 

To give you an example, my team and I were unable to use the `table.whitelist` & `table.blacklist` feature of this connector because of the different naming convention between Kafka & DBMSs.

As we run a multitenant Kafka cluster managed by an API, the naming convention play a huge role, and with the actual version of the kafka-connect-jdbc, it's for example impossible to lowercase the table name, replacing '_' by '-', etc. 

The proposed solution allow the user to fully customised the mapping between table name & topic name based on his own naming convention. 