### PR TITLE
MINOR: Upgrade postgress jdbc driver to most recent bugfix release (9.4.1212)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
-        <postgresql.version>9.4-1206-jdbc41</postgresql.version>
+        <postgresql.version>9.4.1212</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <licenses.name>Apache License 2.0</licenses.name>
         <licenses.version>${project.version}</licenses.version>


### PR DESCRIPTION

Aims to fix https://github.com/confluentinc/kafka-connect-jdbc/issues/494
Version is only upgraded to a bugfix so it can be backported to 5.0.x and more recent