### PR TITLE
Enable CURRENT_TIMESTAMP for SAP HANA JDBC

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialect.java
@@ -61,6 +61,11 @@ public class SapHanaDatabaseDialect extends GenericDatabaseDialect {
   public SapHanaDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
+  
+  @Override
+  protected String currentTimestampDatabaseQuery() {
+    return "SELECT CURRENT_TIMESTAMP FROM DUMMY";
+  }
 
   @Override
   protected String checkConnectionQuery() {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
@@ -103,6 +103,13 @@ public class SapHanaDatabaseDialectTest extends BaseDialectTest<SapHanaDatabaseD
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }
+  
+   @Test
+  public void shouldReturnCurrentTimestampDatabaseQuery() {
+     String expected = "SELECT CURRENT_TIMESTAMP FROM DUMMY";
+     String sql = dialect.currentTimestampDatabaseQuery();
+     assertEquals(expected, sql);
+  }
 
   @Test
   public void shouldBuildAlterTableStatement() {


### PR DESCRIPTION
https://github.com/confluentinc/kafka-connect-jdbc/issues/445
Get CURRENT_TIMESTAMP not working for SAP HANA JDBC because the SAP HANA Dialect does build a correct SQL statement for getting CURRENT_TIMESTAMP.