### PR TITLE
allow multiple rows with same incrementing id to be picked by criteria

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -197,7 +197,7 @@ public class TimestampIncrementingCriteria {
       // If we are only using an incrementing column, then this must be incrementing.
       // If we are also using a timestamp, then we may see updates to older rows.
       assert previousOffset == null || previousOffset.getIncrementingOffset() == -1L
-             || extractedId > previousOffset.getIncrementingOffset() || hasTimestampColumns();
+             || extractedId >= previousOffset.getIncrementingOffset() || hasTimestampColumns();
     }
     return new TimestampIncrementingOffset(extractedTimestamp, extractedId);
   }


### PR DESCRIPTION
Addressing an #582 
The main idea is to allow sourcing with "incrementing" mode from table with non-unique values in incrementing column.