### PR TITLE
MINOR: Avoid NPE when columns cannot be described

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
@@ -86,6 +86,8 @@ public class TableDefinitions {
     if (dbTable != null) {
       log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
       cache.put(dbTable.id(), dbTable);
+    } else {
+      log.warn("Failed to refresh metadata for table {}", tableId);
     }
     return dbTable;
   }

--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
@@ -83,8 +83,10 @@ public class TableDefinitions {
       TableId tableId
   ) throws SQLException {
     TableDefinition dbTable = dialect.describeTable(connection, tableId);
-    log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
-    cache.put(dbTable.id(), dbTable);
+    if (dbTable != null) {
+      log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
+      cache.put(dbTable.id(), dbTable);
+    }
     return dbTable;
   }
 }


### PR DESCRIPTION
This prevents shadowing table create permission exceptions

Signed-off-by: Greg Harris <gregh@confluent.io>