### PR TITLE
[jdbc-source-connector] Fixed issue in CachedConnectionProvider, to enable retries when a connection is failed

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -77,7 +77,12 @@ public class CachedConnectionProvider implements ConnectionProvider {
       Connection connection,
       int timeout
   ) throws SQLException {
-    return provider.isConnectionValid(connection, timeout);
+    try {
+      return provider.isConnectionValid(connection, timeout);
+    } catch (SQLException sqle) {
+      log.error("Error trying to check if the underlying connection is valid", sqle);
+      return false;
+    }
   }
 
   private void newConnection() throws SQLException {

--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -80,7 +80,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
     try {
       return provider.isConnectionValid(connection, timeout);
     } catch (SQLException sqle) {
-      log.error("Error trying to check if the underlying connection is valid", sqle);
+      log.debug("Unable to check if the underlying connection is valid", sqle);
       return false;
     }
   }


### PR DESCRIPTION
This fix aims to address an issue that happens when the underlying connection is invalid and the JDBC driver when trying to validate the connection throws an exception instead of returning false (at io.confluent.connect.jdbc.dialect.GenericDatabaseDialect.isConnectionValid).
This behaviour caused the connector to stop, not allowing it to use the retry features inside the io.confluent.connect.jdbc.util.CachedConnectionProvider.newConnection.

Here is an example of the error (kafka connect 5.1.3):

```log
 ERROR WorkerConnector{id=mssql_source_connector} Connector raised an error (org.apache.kafka.connect.runtime.WorkerConnector:92)
 org.apache.kafka.connect.errors.ConnectException: java.sql.SQLException: I/O Error: Connection reset
 at io.confluent.connect.jdbc.util.CachedConnectionProvider.getConnection(CachedConnectionProvider.java:69)
 at io.confluent.connect.jdbc.source.TableMonitorThread.updateTables(TableMonitorThread.java:142)
 at io.confluent.connect.jdbc.source.TableMonitorThread.run(TableMonitorThread.java:77)
 Caused by: java.sql.SQLException: I/O Error: Connection reset
 at net.sourceforge.jtds.jdbc.TdsCore.executeSQL(TdsCore.java:1093)
 at net.sourceforge.jtds.jdbc.JtdsStatement.executeSQL(JtdsStatement.java:563)
 at net.sourceforge.jtds.jdbc.JtdsStatement.executeImpl(JtdsStatement.java:809)
 at net.sourceforge.jtds.jdbc.JtdsStatement.execute(JtdsStatement.java:1282)
 at io.confluent.connect.jdbc.dialect.GenericDatabaseDialect.isConnectionValid(GenericDatabaseDialect.java:243)
 at io.confluent.connect.jdbc.util.CachedConnectionProvider.isConnectionValid(CachedConnectionProvider.java:79)
 at io.confluent.connect.jdbc.util.CachedConnectionProvider.getConnection(CachedConnectionProvider.java:63)
 ... 2 more
 Suppressed: java.sql.SQLException: Invalid state, the Connection object is closed.
 at net.sourceforge.jtds.jdbc.TdsCore.checkOpen(TdsCore.java:481)
 at net.sourceforge.jtds.jdbc.TdsCore.clearResponseQueue(TdsCore.java:767)
 at net.sourceforge.jtds.jdbc.JtdsStatement.reset(JtdsStatement.java:722)
 at net.sourceforge.jtds.jdbc.JtdsStatement.close(JtdsStatement.java:966)
 at io.confluent.connect.jdbc.dialect.GenericDatabaseDialect.isConnectionValid(GenericDatabaseDialect.java:248)
 ... 4 more
 Caused by: java.net.SocketException: Connection reset
 at java.net.SocketInputStream.read(SocketInputStream.java:210)
 at java.net.SocketInputStream.read(SocketInputStream.java:141)
 at java.io.DataInputStream.readFully(DataInputStream.java:195)
 at java.io.DataInputStream.readFully(DataInputStream.java:169)
 at net.sourceforge.jtds.jdbc.SharedSocket.readPacket(SharedSocket.java:850)
 at net.sourceforge.jtds.jdbc.SharedSocket.getNetPacket(SharedSocket.java:731)
 at net.sourceforge.jtds.jdbc.ResponseStream.getPacket(ResponseStream.java:477)
 at net.sourceforge.jtds.jdbc.ResponseStream.read(ResponseStream.java:114)
 at net.sourceforge.jtds.jdbc.ResponseStream.peek(ResponseStream.java:99)
 at net.sourceforge.jtds.jdbc.TdsCore.wait(TdsCore.java:4127)
 at net.sourceforge.jtds.jdbc.TdsCore.executeSQL(TdsCore.java:1086)
 ... 8 more
 INFO Closing resources for JDBC source task (io.confluent.connect.jdbc.source.JdbcSourceTask:267)
 INFO Closing connection #1 to SqlServer (io.confluent.connect.jdbc.util.CachedConnectionProvider:113)
```