### PR TITLE
Onboarding with for the pint auto merge in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@
 common {
   slackChannel = '#connect-warn'
   upstreamProjects = 'confluentinc/common'
+  pintMerge = true
 }


### PR DESCRIPTION
Currently developers are running pint merge manually for the commits to
merge back the commits to the master and then jenkins is verifying if
the pint merge is already done or not.

Recently dev tools team made a change to run pint merge within Jenkins
ci without any effort from developers until there is a conflict. This
commit is to onboard this repo with the pint ci auto merge.

## Test
- Verified the PR job has the  pintMerge option enabled.
