### PR TITLE
CC-6747: Replace static mocking for the CachedConnectionProvider

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -87,11 +87,7 @@ public class JdbcSourceConnector extends SourceConnector {
         dbUrl,
         config
     );
-    cachedConnectionProvider = new CachedConnectionProvider(
-        dialect,
-        maxConnectionAttempts,
-        connectionRetryBackoff
-    );
+    cachedConnectionProvider = connectionProvider(maxConnectionAttempts, connectionRetryBackoff);
 
     // Initial connection attempt
     cachedConnectionProvider.getConnection();
@@ -127,6 +123,10 @@ public class JdbcSourceConnector extends SourceConnector {
         blacklistSet
     );
     tableMonitorThread.start();
+  }
+
+  protected CachedConnectionProvider connectionProvider(int maxConnAttempts, long retryBackoff) {
+    return new CachedConnectionProvider(dialect, maxConnAttempts, retryBackoff);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -97,7 +97,7 @@ public class JdbcSourceTask extends SourceTask {
     }
     log.info("Using JDBC dialect {}", dialect.name());
 
-    cachedConnectionProvider = new CachedConnectionProvider(dialect, maxConnAttempts, retryBackoff);
+    cachedConnectionProvider = connectionProvider(maxConnAttempts, retryBackoff);
 
     List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
@@ -244,6 +244,10 @@ public class JdbcSourceTask extends SourceTask {
 
     running.set(true);
     log.info("Started JDBC source task");
+  }
+
+  protected CachedConnectionProvider connectionProvider(int maxConnAttempts, long retryBackoff) {
+    return new CachedConnectionProvider(dialect, maxConnAttempts, retryBackoff);
   }
 
   //This method returns a list of possible partition maps for different offset protocols

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -105,13 +105,15 @@ public class JdbcSourceConnectorTest {
   @Test
   public void testStartStop() throws Exception {
     CachedConnectionProvider mockCachedConnectionProvider = PowerMock.createMock(CachedConnectionProvider.class);
-    PowerMock.expectNew(
-        CachedConnectionProvider.class,
-        EasyMock.anyObject(DatabaseDialect.class),
-        EasyMock.eq(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT),
-        EasyMock.eq(JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT))
-             .andReturn(mockCachedConnectionProvider);
-
+    connector = new JdbcSourceConnector() {
+        @Override
+        protected CachedConnectionProvider connectionProvider(
+            int maxConnAttempts,
+            long retryBackoff
+        ) {
+            return mockCachedConnectionProvider;
+        }
+    };
     // Should request a connection, then should close it on stop(). The background thread may also
     // request connections any time it performs updates.
     Connection conn = PowerMock.createMock(Connection.class);

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -37,7 +37,6 @@ import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({JdbcSourceTask.class})
 @PowerMockIgnore("javax.management.*")
 public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
@@ -62,14 +61,17 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testStartStop() throws Exception {
+  public void testStartStop() {
     // Minimal start/stop functionality
-    PowerMock.expectNew(
-        CachedConnectionProvider.class,
-        EasyMock.anyObject(DatabaseDialect.class),
-        EasyMock.eq(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT),
-        EasyMock.eq(JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT))
-             .andReturn(mockCachedConnectionProvider);
+    task = new JdbcSourceTask(time) {
+      @Override
+      protected CachedConnectionProvider connectionProvider(
+          int maxConnAttempts,
+          long retryBackoff
+      ) {
+        return mockCachedConnectionProvider;
+      }
+    };
 
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -49,7 +49,6 @@ import io.confluent.connect.jdbc.util.DateTimeUtils;
 // Tests of polling that return data updates, i.e. verifies the different behaviors for getting
 // incremental data updates from the database
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({JdbcSourceTask.class})
 @PowerMockIgnore("javax.management.*")
 public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   private static final Map<String, String> QUERY_SOURCE_PARTITION


### PR DESCRIPTION
The CachedConnectionProvider was being mocked with PowerMock's `expectNew` function, which requires rewriting the binary classes that contain call sites for CachedConnectionProvider::new. It would be simpler to just isolate the construction of this dependency to a protected method than to use this high-power mocking functionality.

Signed-off-by: Greg Harris <gregh@confluent.io>