### PR TITLE
'numeric.mapping' config to handle NUMERIC and DECIMAL fields

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -943,37 +943,18 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       }
 
       case Types.NUMERIC:
+      case Types.DECIMAL: {
+        log.debug("Converting {} with precision: '{}' and scale: '{}' using 'numeric.mapping': {}",
+                columnDefn.typeName(), precision, scale, mapNumerics);
         if (mapNumerics == NumericMapping.PRECISION_ONLY) {
-          log.debug("NUMERIC with precision: '{}' and scale: '{}'", precision, scale);
           if (scale == 0 && precision < 19) { // integer
-            Schema schema;
-            if (precision > 9) {
-              schema = (optional) ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
-            } else if (precision > 4) {
-              schema = (optional) ? Schema.OPTIONAL_INT32_SCHEMA : Schema.INT32_SCHEMA;
-            } else if (precision > 2) {
-              schema = (optional) ? Schema.OPTIONAL_INT16_SCHEMA : Schema.INT16_SCHEMA;
-            } else {
-              schema = (optional) ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
-            }
-            builder.field(fieldName, schema);
+            builder.field(fieldName, getIntegerSchema(optional, precision));
             break;
           }
         } else if (mapNumerics == NumericMapping.BEST_FIT) {
-          log.debug("NUMERIC with precision: '{}' and scale: '{}'", precision, scale);
           if (precision < 19) { // fits in primitive data types.
             if (scale < 1 && scale >= NUMERIC_TYPE_SCALE_LOW) { // integer
-              Schema schema;
-              if (precision > 9) {
-                schema = (optional) ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
-              } else if (precision > 4) {
-                schema = (optional) ? Schema.OPTIONAL_INT32_SCHEMA : Schema.INT32_SCHEMA;
-              } else if (precision > 2) {
-                schema = (optional) ? Schema.OPTIONAL_INT16_SCHEMA : Schema.INT16_SCHEMA;
-              } else {
-                schema = (optional) ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
-              }
-              builder.field(fieldName, schema);
+              builder.field(fieldName, getIntegerSchema(optional, precision));
               break;
             } else if (scale > 0) { // floating point - use double in all cases
               Schema schema = (optional) ? Schema.OPTIONAL_FLOAT64_SCHEMA : Schema.FLOAT64_SCHEMA;
@@ -982,10 +963,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
             }
           }
         }
-        // fallthrough
-
-      case Types.DECIMAL: {
-        log.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
         SchemaBuilder fieldBuilder = Decimal.builder(scale);
         if (optional) {
@@ -1064,6 +1041,20 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       }
     }
     return fieldName;
+  }
+
+  private Schema getIntegerSchema(boolean optional, int precision) {
+    Schema schema;
+    if (precision > 9) {
+      schema = (optional) ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA;
+    } else if (precision > 4) {
+      schema = (optional) ? Schema.OPTIONAL_INT32_SCHEMA : Schema.INT32_SCHEMA;
+    } else if (precision > 2) {
+      schema = (optional) ? Schema.OPTIONAL_INT16_SCHEMA : Schema.INT16_SCHEMA;
+    } else {
+      schema = (optional) ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
+    }
+    return schema;
   }
 
   @Override
@@ -1154,47 +1145,24 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       }
 
       case Types.NUMERIC:
+      case Types.DECIMAL: {
+        int precision = defn.precision();
+        int scale = defn.scale();
+        log.trace("Converting {} with precision: '{}' and scale: '{}' using 'numeric.mapping': {}",
+                mapping.columnDefn().typeName(), precision, scale, mapNumerics);
         if (mapNumerics == NumericMapping.PRECISION_ONLY) {
-          int precision = defn.precision();
-          int scale = defn.scale();
-          log.trace("NUMERIC with precision: '{}' and scale: '{}'", precision, scale);
           if (scale == 0 && precision < 19) { // integer
-            if (precision > 9) {
-              return rs -> rs.getLong(col);
-            } else if (precision > 4) {
-              return rs -> rs.getInt(col);
-            } else if (precision > 2) {
-              return rs -> rs.getShort(col);
-            } else {
-              return rs -> rs.getByte(col);
-            }
+            return getIntegralValue(col, precision);
           }
         } else if (mapNumerics == NumericMapping.BEST_FIT) {
-          int precision = defn.precision();
-          int scale = defn.scale();
-          log.trace("NUMERIC with precision: '{}' and scale: '{}'", precision, scale);
           if (precision < 19) { // fits in primitive data types.
             if (scale < 1 && scale >= NUMERIC_TYPE_SCALE_LOW) { // integer
-              if (precision > 9) {
-                return rs -> rs.getLong(col);
-              } else if (precision > 4) {
-                return rs -> rs.getInt(col);
-              } else if (precision > 2) {
-                return rs -> rs.getShort(col);
-              } else {
-                return rs -> rs.getByte(col);
-              }
+              return getIntegralValue(col, precision);
             } else if (scale > 0) { // floating point - use double in all cases
               return rs -> rs.getDouble(col);
             }
           }
         }
-        // fallthrough
-
-      case Types.DECIMAL: {
-        final int precision = defn.precision();
-        log.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, defn.scale());
-        final int scale = decimalScale(defn);
         return rs -> rs.getBigDecimal(col, scale);
       }
 
@@ -1321,6 +1289,18 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       }
     }
     return null;
+  }
+
+  private ColumnConverter getIntegralValue(int col, int precision) {
+    if (precision > 9) {
+      return rs -> rs.getLong(col);
+    } else if (precision > 4) {
+      return rs -> rs.getInt(col);
+    } else if (precision > 2) {
+      return rs -> rs.getShort(col);
+    } else {
+      return rs -> rs.getByte(col);
+    }
   }
 
   protected int decimalScale(ColumnDefinition defn) {
@@ -1532,7 +1512,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         case org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME:
           statement.setTimestamp(
               index,
-              new java.sql.Timestamp(((java.util.Date) value).getTime()),
+              new Timestamp(((java.util.Date) value).getTime()),
               DateTimeUtils.getTimeZoneCalendar(timeZone)
           );
           return true;

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -101,7 +101,8 @@ public class BulkTableQuerier extends TableQuerier {
       default:
         throw new ConnectException("Unexpected query mode: " + mode);
     }
-    return new SourceRecord(partition, null, topic, record.schema(), record);
+    return new SourceRecord(partition, null, topic, null,null,null,
+              record.schema(), record,System.currentTimeMillis());
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -101,15 +101,15 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "Precision (deprecated)";
 
   private static final String NUMERIC_MAPPING_DOC =
-      "Map NUMERIC values by precision and optionally scale to integral or decimal types. Use "
-      + "``none`` if all NUMERIC columns are to be represented by Connect's DECIMAL logical "
-      + "type. Use ``best_fit`` if NUMERIC columns should be cast to Connect's INT8, INT16, "
-      + "INT32, INT64, or FLOAT64 based upon the column's precision and scale. Or use "
-      + "``precision_only`` to map NUMERIC columns based only on the column's precision "
-      + "assuming that column's scale is 0. The ``none`` option is the default, but may lead "
-      + "to serialization issues with Avro since Connect's DECIMAL type is mapped to its "
-      + "binary representation, and ``best_fit`` will often be preferred since it maps to the"
-      + " most appropriate primitive type.";
+      "Map NUMERIC/DECIMAL values by precision and optionally scale to integral or decimal types."
+      + " Use ``none`` if all NUMERIC/DECIMAL columns are to be represented by Connect's DECIMAL "
+      + "logical type. Use ``best_fit`` if NUMERIC/DECIMAL columns should be cast to "
+      + "Connect's INT8, INT16, INT32, INT64, or FLOAT64 based upon the column's precision "
+      + "and scale. Or use ``precision_only`` to map NUMERIC/DECIMAL columns based only on the "
+      + "column's precision assuming that column's scale is 0. The ``none`` option "
+      + "is the default, but may lead to serialization issues with Avro since Connect's "
+      + "DECIMAL type is mapped to its binary representation, and ``best_fit`` will often be "
+      + "preferred since it maps to the most appropriate primitive type.";
 
   public static final String NUMERIC_MAPPING_DEFAULT = null;
   private static final String NUMERIC_MAPPING_DISPLAY = "Map Numeric Values, Integral "

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -190,7 +190,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       }
     }
     offset = criteria.extractValues(schemaMapping.schema(), record, offset);
-    return new SourceRecord(partition, offset.toMap(), topic, record.schema(), record);
+    return new SourceRecord(partition, offset.toMap(), topic, null,null,null,
+            record.schema(), record,System.currentTimeMillis());
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
@@ -82,8 +82,12 @@ public class TableDefinitions {
       TableId tableId
   ) throws SQLException {
     TableDefinition dbTable = dialect.describeTable(connection, tableId);
-    log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
-    cache.put(dbTable.id(), dbTable);
+    if (dbTable != null) {
+      log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
+      cache.put(dbTable.id(), dbTable);
+    } else {
+      log.warn("Failed to refresh metadata for table {}", tableId);
+    }
     return dbTable;
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -221,16 +221,18 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   public void testDecimal() throws Exception {
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-                   Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
+            !extendedMapping ? Decimal.schema(2) :  Schema.FLOAT64_SCHEMA,
+            !extendedMapping ? new BigDecimal(new BigInteger("12345"), 2) : 123.45);
   }
 
   @Test
   public void testNullableDecimal() throws Exception {
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-                   Decimal.builder(2).optional().build(),
-                   new BigDecimal(new BigInteger("12345"), 2));
-    typeConversion("DECIMAL(5,2)", true, null, Decimal.builder(2).optional().build(),
+            !extendedMapping ? Decimal.builder(2).optional().build() : Schema.OPTIONAL_FLOAT64_SCHEMA,
+            !extendedMapping ? new BigDecimal(new BigInteger("12345"), 2) : 123.45);
+    typeConversion("DECIMAL(5,2)", true, null,
+            !extendedMapping ? Decimal.builder(2).optional().build() : Schema.OPTIONAL_FLOAT64_SCHEMA,
                    null);
   }
 


### PR DESCRIPTION
This PR contains changes for `numeric.mapping` config to support both NUMERIC and DECIMAL fields. It resolves open issues [563](https://github.com/confluentinc/kafka-connect-jdbc/issues/563) and [311](https://github.com/confluentinc/kafka-connect-jdbc/issues/311).

