### PR TITLE
MINOR: Expose SinkRecordField schema to database dialects

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
@@ -32,6 +32,10 @@ public class SinkRecordField {
     this.isPrimaryKey = isPrimaryKey;
   }
 
+  public Schema schema() {
+    return schema;
+  }
+
   public String schemaName() {
     return schema.name();
   }


### PR DESCRIPTION
This will allow for database dialects to make deeper inspections of SinkRecord fields (`ARRAY`, `STRUCT`, and `MAP` types), when previously only the broad type of the schema was known.

Signed-off-by: Greg Harris <gregh@confluent.io>