### PR TITLE
Suffix config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@
 common {
   slackChannel = '#connect-warn'
   upstreamProjects = 'confluentinc/common'
+  pintMerge = true
 }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -285,7 +285,8 @@ public interface DatabaseDialect extends ConnectionProvider {
    */
   TimestampIncrementingCriteria criteriaFor(
       ColumnId incrementingColumn,
-      List<ColumnId> timestampColumns
+      List<ColumnId> timestampColumns,
+      String suffix
   );
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -830,9 +830,11 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   @Override
   public TimestampIncrementingCriteria criteriaFor(
       ColumnId incrementingColumn,
-      List<ColumnId> timestampColumns
+      List<ColumnId> timestampColumns,
+      String suffix
   ) {
-    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns, timeZone);
+    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns, timeZone,
+                                             suffix);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -28,14 +28,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
-import io.confluent.connect.jdbc.dialect.DatabaseDialects;
-import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
-import io.confluent.connect.jdbc.util.EnumRecommender;
-import io.confluent.connect.jdbc.util.QuoteMethod;
-import io.confluent.connect.jdbc.util.TableId;
-import io.confluent.connect.jdbc.util.TimeZoneValidator;
-
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -46,6 +38,14 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.dialect.DatabaseDialects;
+import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
+import io.confluent.connect.jdbc.util.EnumRecommender;
+import io.confluent.connect.jdbc.util.QuoteMethod;
+import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.TimeZoneValidator;
 
 public class JdbcSourceConnectorConfig extends AbstractConfig {
 
@@ -254,6 +254,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       "When to quote table names, column names, and other identifiers in SQL statements. "
       + "For backward compatibility, the default is 'always'.";
   public static final String QUOTE_SQL_IDENTIFIERS_DISPLAY = "Quote Identifiers";
+
+  public static final String QUERY_SUFFIX_CONFIG = "suffix.query";
+  public static final String QUERY_SUFFIX_DEFAULT = "";
+  public static final String QUERY_SUFFIX_DOC = 
+      "Suffix to append at the end of the generated query.";
+  public static final String QUERY_SUFFIX_DISPLAY = "Query suffix";
 
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
@@ -503,7 +509,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         QUOTE_SQL_IDENTIFIERS_DISPLAY,
-        QUOTE_METHOD_RECOMMENDER);
+        QUOTE_METHOD_RECOMMENDER
+    ).define(
+        QUERY_SUFFIX_CONFIG,
+        Type.STRING,
+        QUERY_SUFFIX_DEFAULT,
+        Importance.LOW,
+        QUERY_SUFFIX_DOC,
+        MODE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        QUERY_SUFFIX_DISPLAY);
   }
 
   private static final void addConnectorOptions(ConfigDef config) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -149,6 +149,7 @@ public class JdbcSourceTask extends SourceTask {
     boolean validateNonNulls
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
     TimeZone timeZone = config.timeZone();
+    String suffix = config.getString(JdbcSourceTaskConfig.QUERY_SUFFIX_CONFIG);
 
     for (String tableOrQuery : tablesOrQuery) {
       final List<Map<String, String>> tablePartitionsToCheck;
@@ -207,7 +208,8 @@ public class JdbcSourceTask extends SourceTask {
                 incrementingColumn,
                 offset,
                 timestampDelayInterval,
-                timeZone
+                timeZone,
+                suffix
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -221,7 +223,8 @@ public class JdbcSourceTask extends SourceTask {
                 null,
                 offset,
                 timestampDelayInterval,
-                timeZone
+                timeZone,
+                suffix
             )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -235,7 +238,8 @@ public class JdbcSourceTask extends SourceTask {
                 incrementingColumn,
                 offset,
                 timestampDelayInterval,
-                timeZone
+                timeZone,
+                suffix
             )
         );
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -72,17 +72,20 @@ public class TimestampIncrementingCriteria {
   protected final List<ColumnId> timestampColumns;
   protected final ColumnId incrementingColumn;
   protected final TimeZone timeZone;
+  protected final String suffix;
 
 
   public TimestampIncrementingCriteria(
       ColumnId incrementingColumn,
       List<ColumnId> timestampColumns,
-      TimeZone timeZone
+      TimeZone timeZone,
+      String suffix
   ) {
     this.timestampColumns =
         timestampColumns != null ? timestampColumns : Collections.<ColumnId>emptyList();
     this.incrementingColumn = incrementingColumn;
     this.timeZone = timeZone;
+    this.suffix = suffix;
   }
 
   protected boolean hasTimestampColumns() {
@@ -278,6 +281,12 @@ public class TimestampIncrementingCriteria {
     }
     return builder.toString();
   }
+  
+  protected void addSuffixIfPresent(ExpressionBuilder builder) {
+    if (!this.suffix.trim().isEmpty()) {
+      builder.append(" ").append(suffix);
+    }  
+  }
 
   protected void timestampIncrementingWhereClause(ExpressionBuilder builder) {
     // This version combines two possible conditions. The first checks timestamp == last
@@ -308,6 +317,7 @@ public class TimestampIncrementingCriteria {
     builder.append(",");
     builder.append(incrementingColumn);
     builder.append(" ASC");
+    addSuffixIfPresent(builder);
   }
 
   protected void incrementingWhereClause(ExpressionBuilder builder) {
@@ -317,6 +327,7 @@ public class TimestampIncrementingCriteria {
     builder.append(" ORDER BY ");
     builder.append(incrementingColumn);
     builder.append(" ASC");
+    addSuffixIfPresent(builder);
   }
 
   protected void timestampWhereClause(ExpressionBuilder builder) {
@@ -327,6 +338,7 @@ public class TimestampIncrementingCriteria {
     builder.append(" < ? ORDER BY ");
     coalesceTimestampColumns(builder);
     builder.append(" ASC");
+    addSuffixIfPresent(builder);
   }
 
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -71,13 +71,14 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   private final Map<String, String> partition;
   private final String topic;
   private final TimeZone timeZone;
+  private final String suffix;
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
                                            String topicPrefix,
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
-                                           TimeZone timeZone) {
+                                           TimeZone timeZone, String suffix) {
     super(dialect, mode, name, topicPrefix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
@@ -108,6 +109,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     }
 
     this.timeZone = timeZone;
+    this.suffix = suffix;
   }
 
   @Override
@@ -133,7 +135,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     }
 
     // Append the criteria using the columns ...
-    criteria = dialect.criteriaFor(incrementingColumn, timestampColumns);
+    criteria = dialect.criteriaFor(incrementingColumn, timestampColumns, suffix);
     criteria.whereClause(builder);
 
     String queryString = builder.toString();

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -46,6 +46,7 @@ public class TimestampIncrementingCriteriaTest {
   private static final ColumnId TS1_COLUMN = new ColumnId(TABLE_ID, "ts1");
   private static final ColumnId TS2_COLUMN = new ColumnId(TABLE_ID, "ts2");
   private static final List<ColumnId> TS_COLUMNS = Arrays.asList(TS1_COLUMN, TS2_COLUMN);
+  private static final String SUFFIX = "/* <OPTGUIDELINES><IXSCAN TABLE=’\"Tpcd\".PARTS’/></OPTGUIDELINES> */";
 
   private IdentifierRules rules;
   private QuoteMethod identifierQuoting;
@@ -60,10 +61,10 @@ public class TimestampIncrementingCriteriaTest {
 
   @Before
   public void beforeEach() {
-    criteria = new TimestampIncrementingCriteria(null, null, utcTimeZone);
-    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null, utcTimeZone);
-    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS, utcTimeZone);
-    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS, utcTimeZone);
+    criteria = new TimestampIncrementingCriteria(null, null, utcTimeZone, SUFFIX);
+    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null, utcTimeZone, SUFFIX);
+    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS, utcTimeZone, SUFFIX);
+    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS, utcTimeZone, SUFFIX);
     identifierQuoting = null;
     rules = null;
     builder = null;
@@ -141,7 +142,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaInc.incrementingWhereClause(builder);
     assertEquals(
-        " WHERE \"myTable\".\"id\" > ? ORDER BY \"myTable\".\"id\" ASC",
+        " WHERE \"myTable\".\"id\" > ? ORDER BY \"myTable\".\"id\" ASC " + SUFFIX,
         builder.toString()
     );
 
@@ -149,7 +150,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaInc.incrementingWhereClause(builder);
     assertEquals(
-        " WHERE myTable.id > ? ORDER BY myTable.id ASC",
+        " WHERE myTable.id > ? ORDER BY myTable.id ASC " + SUFFIX,
         builder.toString()
     );
   }
@@ -165,7 +166,7 @@ public class TimestampIncrementingCriteriaTest {
         + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") < ? "
         + "ORDER BY "
         + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") "
-        + "ASC",
+        + "ASC " + SUFFIX,
         builder.toString()
     );
 
@@ -179,7 +180,7 @@ public class TimestampIncrementingCriteriaTest {
         + "COALESCE(myTable.ts1,myTable.ts2) < ? "
         + "ORDER BY "
         + "COALESCE(myTable.ts1,myTable.ts2) "
-        + "ASC",
+        + "ASC " + SUFFIX,
         builder.toString()
     );
   }
@@ -196,7 +197,7 @@ public class TimestampIncrementingCriteriaTest {
         + "OR "
         + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") > ?) "
         + "ORDER BY COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\"),"
-        + "\"myTable\".\"id\" ASC",
+        + "\"myTable\".\"id\" ASC " + SUFFIX,
         builder.toString()
     );
 
@@ -211,7 +212,7 @@ public class TimestampIncrementingCriteriaTest {
         + "OR "
         + "COALESCE(myTable.ts1,myTable.ts2) > ?) "
         + "ORDER BY COALESCE(myTable.ts1,myTable.ts2),"
-        + "myTable.id ASC",
+        + "myTable.id ASC " + SUFFIX,
         builder.toString()
     );
   }


### PR DESCRIPTION
DB2 requires hints ([optguidelines](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.1.0/com.ibm.db2.luw.admin.perf.doc/doc/c0070117.html)) to be at the end of the statement.

Added a suffix query config.