### PR TITLE
Implement the ability to validate config provider values

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialects.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialects.java
@@ -60,7 +60,7 @@ public class DatabaseDialects {
    *
    * <p>The subprotocol will be in group 1, and the subname will be in group 2.
    */
-  private static final Pattern PROTOCOL_PATTERN = Pattern.compile("jdbc:([^:]+):(.*)");
+  private static final Pattern PROTOCOL_PATTERN = Pattern.compile("jdbc:([^:]+):(.*)|\$\{(env|vault)");
   private static final Logger LOG = LoggerFactory.getLogger(DatabaseDialects.class);
   // Sort lexicographically to maintain order
   private static final ConcurrentMap<String, DatabaseDialectProvider> REGISTRY = new

--- a/src/test/java/io/confluent/connect/jdbc/dialect/DatabaseDialectsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/DatabaseDialectsTest.java
@@ -109,6 +109,16 @@ public class DatabaseDialectsTest {
     DatabaseDialects.extractJdbcUrlInfo("mysql://Server:port");
   }
 
+  @Test
+  public void shouldFindVaultConfigProviderPrefix() {
+    assertDialect(GenericDatabaseDialect.class, "${vault:path:key}");
+  }
+
+  @Test
+  public void shouldFindEnvConfigProviderPrefix() {
+    assertDialect(GenericDatabaseDialect.class, "${env:VAR}");
+  }
+
 
   private void assertDialect(
       Class<? extends DatabaseDialect> clazz,


### PR DESCRIPTION
Prior to this commit, the
https://docs.confluent.io/current/connect/references/restapi.html#put--connector-plugins-(string-name)-config-validate endpoint
wasn't capable to properly validate the `connection.url` property using vault or env config providers.

This should solve this issue: #738