### PR TITLE
MINOR: Add TimeZoneValidator::toString.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -34,4 +34,9 @@ public class TimeZoneValidator implements ConfigDef.Validator {
       }
     }
   }
+
+  @Override
+  public String toString() {
+    return "Any valid JDK time zone";
+  }
 }


### PR DESCRIPTION
#628 mentioned specifying "Any valid JDK time zone" in the documentation.
This effects this change in the generated documentation:
```diff
-  * Valid Values: io.confluent.connect.jdbc.util.TimeZoneValidator@4c98385c
+  * Valid Values: Any valid JDK time zone
```
Signed-off-by: Greg Harris <gregh@confluent.io>