### PR TITLE
CC-7265: Support SQL Server DateTimeOffset

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialects.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialects.java
@@ -169,19 +169,11 @@ public class DatabaseDialects {
   }
 
   static JdbcUrlInfo extractJdbcUrlInfo(final String url) {
-    JdbcUrlInfo result = extractJdbcUrlInfoOrNull(url);
-    if (result == null) {
-      throw new ConnectException("Not a valid JDBC URL: " + url);
-    }
-    return result;
-  }
-
-  static JdbcUrlInfo extractJdbcUrlInfoOrNull(final String url) {
     Matcher matcher = PROTOCOL_PATTERN.matcher(url);
     if (matcher.matches()) {
       return new JdbcUrlDetails(matcher.group(1), matcher.group(2), url);
     }
-    return null;
+    throw new ConnectException("Not a valid JDBC URL: " + url);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialects.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialects.java
@@ -169,11 +169,19 @@ public class DatabaseDialects {
   }
 
   static JdbcUrlInfo extractJdbcUrlInfo(final String url) {
+    JdbcUrlInfo result = extractJdbcUrlInfoOrNull(url);
+    if (result == null) {
+      throw new ConnectException("Not a valid JDBC URL: " + url);
+    }
+    return result;
+  }
+
+  static JdbcUrlInfo extractJdbcUrlInfoOrNull(final String url) {
     Matcher matcher = PROTOCOL_PATTERN.matcher(url);
     if (matcher.matches()) {
       return new JdbcUrlDetails(matcher.group(1), matcher.group(2), url);
     }
-    throw new ConnectException("Not a valid JDBC URL: " + url);
+    return null;
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -132,7 +132,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected final Set<String> tableTypes;
   protected final String jdbcUrl;
   protected final DatabaseDialectProvider.JdbcUrlInfo jdbcUrlInfo;
-
   private final QuoteMethod quoteSqlIdentifiers;
   private final IdentifierRules defaultIdentifierRules;
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -196,6 +196,10 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return getClass().getSimpleName().replace("DatabaseDialect", "");
   }
 
+  protected TimeZone timeZone() {
+    return timeZone;
+  }
+
   @Override
   public Connection getConnection() throws SQLException {
     // These config names are the same for both source and sink configs ...
@@ -242,8 +246,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     if (query != null) {
       try (Statement statement = connection.createStatement()) {
         if (statement.execute(query)) {
-          try (ResultSet rs = statement.getResultSet()) {
+          ResultSet rs = null;
+          try {
             // do nothing with the result set
+            rs = statement.getResultSet();
+          } finally {
+            if (rs != null) {
+              rs.close();
+            }
           }
         }
       }
@@ -868,6 +878,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    * @param optional   true if the field is to be optional as obtained from the column definition
    * @return the name of the field, or null if no field was added
    */
+  @SuppressWarnings("fallthrough")
   protected String addFieldToSchema(
       final ColumnDefinition columnDefn,
       final SchemaBuilder builder,
@@ -1088,7 +1099,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     );
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "fallthrough"})
   protected ColumnConverter columnConverterFor(
       final ColumnMapping mapping,
       final ColumnDefinition defn,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -131,6 +131,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected final String schemaPattern;
   protected final Set<String> tableTypes;
   protected final String jdbcUrl;
+  protected final DatabaseDialectProvider.JdbcUrlInfo jdbcUrlInfo;
+
   private final QuoteMethod quoteSqlIdentifiers;
   private final IdentifierRules defaultIdentifierRules;
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();
@@ -161,6 +163,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     this.config = config;
     this.defaultIdentifierRules = defaultIdentifierRules;
     this.jdbcUrl = config.getString(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
+    this.jdbcUrlInfo = DatabaseDialects.extractJdbcUrlInfoOrNull(jdbcUrl);
     if (config instanceof JdbcSinkConfig) {
       catalogPattern = JdbcSourceTaskConfig.CATALOG_PATTERN_DEFAULT;
       schemaPattern = JdbcSourceTaskConfig.SCHEMA_PATTERN_DEFAULT;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -163,7 +163,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     this.config = config;
     this.defaultIdentifierRules = defaultIdentifierRules;
     this.jdbcUrl = config.getString(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
-    this.jdbcUrlInfo = DatabaseDialects.extractJdbcUrlInfoOrNull(jdbcUrl);
+    this.jdbcUrlInfo = DatabaseDialects.extractJdbcUrlInfo(jdbcUrl);
     if (config instanceof JdbcSinkConfig) {
       catalogPattern = JdbcSourceTaskConfig.CATALOG_PATTERN_DEFAULT;
       schemaPattern = JdbcSourceTaskConfig.SCHEMA_PATTERN_DEFAULT;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -54,6 +54,11 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
    */
   private static final int DATETIMEOFFSET = -155;
 
+  /**
+   * This is the format of the string form of DATETIMEOFFSET values, and used to parse such
+   * string values into {@link java.sql.Timestamp} values.
+   * https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql
+   */
   private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSSS ZZZZZ";
   private static final DateTimeFormatter DATE_TIME_FORMATTER =
       DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
@@ -141,9 +146,9 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
    * JDBC driver supports SQL Server's DATETIMEOFFSET data type and converting to a
    * {@link java.sql.Timestamp} via {@link ResultSet#getTimestamp(int, Calendar)}.
    *
-   * @param rs the result set; never null
+   * @param rs  the result set; never null
    * @param col the column index
-   * @return the {@link java.sql.Timestamp} value
+   * @return the {@link java.sql.Timestamp} value; may be null
    * @throws SQLException if there is a problem getting the value
    */
   protected Object convertDateTimeOffset(ResultSet rs, int col) throws SQLException {
@@ -156,18 +161,28 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
    * (see https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql) is to
    * get the value in string form and then parse it into a timestamp.
    *
-   * @param rs the result set; never null
+   * @param rs  the result set; never null
    * @param col the column index
-   * @return the {@link java.sql.Timestamp} value
+   * @return the {@link java.sql.Timestamp} value; may be null
    * @throws SQLException if there is a problem getting the value
    */
   protected Object convertDateTimeOffsetFromString(
       ResultSet rs,
       int col
   ) throws SQLException {
-    return dateTimeOffsetFrom(rs.getString(col), timeZone());
+    String value = rs.getString(col);
+    return value == null ? null : dateTimeOffsetFrom(rs.getString(col), timeZone());
   }
 
+  /**
+   * Utility method to parse the string form of a SQL Server DATETIMEOFFSET value into a
+   * {@link java.sql.Timestamp} value.
+   *
+   * @param value    the string DATETIMEOFFSET value; never null
+   * @param timeZone the timezone in which the {@link java.sql.Timestamp} should be defined; may
+   *                 not be null
+   * @return the equivalent {@link java.sql.Timestamp}; never null
+   */
   protected static java.sql.Timestamp dateTimeOffsetFrom(String value, TimeZone timeZone) {
     ZonedDateTime zdt = ZonedDateTime.parse(value, DATE_TIME_FORMATTER);
     zdt = zdt.withZoneSameInstant(timeZone.toZoneId());

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -14,6 +14,13 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalField;
+import java.util.TimeZone;
+
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -34,6 +41,36 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     return new SqlServerDatabaseDialect(sourceConfigWithUrl("jdbc:sqlsserver://something"));
   }
 
+  @Test
+  public void shouldConvertFromDateTimeOffset() {
+    ZoneId utc = ZoneId.of("UTC");
+    TimeZone timeZone = TimeZone.getTimeZone(utc.getId());
+
+    String value = "2016-12-08 12:34:56.7850000 -07:00";
+    java.sql.Timestamp ts = SqlServerDatabaseDialect.dateTimeOffsetFrom(value, timeZone);
+    assertTimestamp(
+        ZonedDateTime.of(2016, 12, 8, 19, 34, 56, 785000000, utc),
+        ts
+    );
+
+    value = "2019-12-08 12:34:56.7850200 -00:00";
+    ts = SqlServerDatabaseDialect.dateTimeOffsetFrom(value, timeZone);
+    assertTimestamp(
+        ZonedDateTime.of(2019, 12, 8, 12, 34, 56, 785020000, utc),
+        ts
+    );
+  }
+
+  protected void assertTimestamp(ZonedDateTime expected, java.sql.Timestamp actual) {
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(actual.toInstant(), ZoneId.of("UTC"));
+    assertEquals(expected.getYear(), zdt.getYear());
+    assertEquals(expected.getMonthValue(), zdt.getMonthValue());
+    assertEquals(expected.getDayOfMonth(), zdt.getDayOfMonth());
+    assertEquals(expected.getHour(), zdt.getHour());
+    assertEquals(expected.getMinute(), zdt.getMinute());
+    assertEquals(expected.getSecond(), zdt.getSecond());
+    assertEquals(expected.getNano(), zdt.getNano());
+  }
 
   @Test
   public void shouldMapPrimitiveSchemaTypeToSqlTypes() {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -45,17 +45,11 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
 
     String value = "2016-12-08 12:34:56.7850000 -07:00";
     java.sql.Timestamp ts = SqlServerDatabaseDialect.dateTimeOffsetFrom(value, timeZone);
-    assertTimestamp(
-        ZonedDateTime.of(2016, 12, 8, 19, 34, 56, 785000000, utc),
-        ts
-    );
+    assertTimestamp(ZonedDateTime.of(2016, 12, 8, 19, 34, 56, 785000000, utc), ts);
 
     value = "2019-12-08 12:34:56.7850200 -00:00";
     ts = SqlServerDatabaseDialect.dateTimeOffsetFrom(value, timeZone);
-    assertTimestamp(
-        ZonedDateTime.of(2019, 12, 8, 12, 34, 56, 785020000, utc),
-        ts
-    );
+    assertTimestamp(ZonedDateTime.of(2019, 12, 8, 12, 34, 56, 785020000, utc), ts);
   }
 
   protected void assertTimestamp(ZonedDateTime expected, java.sql.Timestamp actual) {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -14,11 +14,8 @@
 
 package io.confluent.connect.jdbc.dialect;
 
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalField;
 import java.util.TimeZone;
 
 import org.apache.kafka.connect.data.Date;
@@ -38,7 +35,7 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
 
   @Override
   protected SqlServerDatabaseDialect createDialect() {
-    return new SqlServerDatabaseDialect(sourceConfigWithUrl("jdbc:sqlsserver://something"));
+    return new SqlServerDatabaseDialect(sourceConfigWithUrl("jdbc:jtds:sqlsserver://something"));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -109,7 +109,6 @@ public class BufferedRecordsTest {
   @Test
   public void testFlushSuccessNoInfo() throws SQLException {
     final String url = sqliteHelper.sqliteUri();
-
     final HashMap<Object, Object> props = new HashMap<>();
     props.put("connection.url", url);
     props.put("auto.create", true);
@@ -157,7 +156,6 @@ public class BufferedRecordsTest {
   @Test
   public void testInsertModeUpdate() throws SQLException {
     final String url = sqliteHelper.sqliteUri();
-
     final HashMap<Object, Object> props = new HashMap<>();
     props.put("connection.url", url);
     props.put("auto.create", true);

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -37,10 +37,12 @@ import java.util.HashMap;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
+import io.confluent.connect.jdbc.dialect.SqliteDatabaseDialect;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -165,6 +167,7 @@ public class BufferedRecordsTest {
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    assertTrue(dbDialect instanceof SqliteDatabaseDialect);
     final DbStructure dbStructureMock = mock(DbStructure.class);
     when(dbStructureMock.createOrAmendIfNecessary(Matchers.any(JdbcSinkConfig.class),
                                                   Matchers.any(Connection.class),
@@ -182,6 +185,8 @@ public class BufferedRecordsTest {
     final SinkRecord recordA = new SinkRecord("dummy", 0, null, null, schemaA, valueA, 0);
     buffer.add(recordA);
 
+    // Even though we're using the SQLite dialect, which uses backtick as the default quote
+    // character, the SQLite JDBC driver does return double quote as the quote characters.
     Mockito.verify(
         connectionMock,
         Mockito.times(1)

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -106,14 +106,15 @@ public class BufferedRecordsTest {
 
   @Test
   public void testFlushSuccessNoInfo() throws SQLException {
+    final String url = sqliteHelper.sqliteUri();
+
     final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", "");
+    props.put("connection.url", url);
     props.put("auto.create", true);
     props.put("auto.evolve", true);
     props.put("batch.size", 1000);
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
-    final String url = sqliteHelper.sqliteUri();
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
 
     int[] batchResponse = new int[2];
@@ -153,15 +154,16 @@ public class BufferedRecordsTest {
 
   @Test
   public void testInsertModeUpdate() throws SQLException {
+    final String url = sqliteHelper.sqliteUri();
+
     final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", "");
+    props.put("connection.url", url);
     props.put("auto.create", true);
     props.put("auto.evolve", true);
     props.put("batch.size", 1000);
     props.put("insert.mode", "update");
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
-    final String url = sqliteHelper.sqliteUri();
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
     final DbStructure dbStructureMock = mock(DbStructure.class);
     when(dbStructureMock.createOrAmendIfNecessary(Matchers.any(JdbcSinkConfig.class),
@@ -180,7 +182,10 @@ public class BufferedRecordsTest {
     final SinkRecord recordA = new SinkRecord("dummy", 0, null, null, schemaA, valueA, 0);
     buffer.add(recordA);
 
-    Mockito.verify(connectionMock, Mockito.times(1)).prepareStatement(Matchers.eq("UPDATE `dummy` SET `name` = ?"));
+    Mockito.verify(
+        connectionMock,
+        Mockito.times(1)
+    ).prepareStatement(Matchers.eq("UPDATE \"dummy\" SET \"name\" = ?"));
 
   }
 }


### PR DESCRIPTION
Added support for SQL Server’s DateTimeOffset type. 

This change supports the jTDS driver that we ship by default, and even the latest version of this driver (which is pretty old) doesn't have support for DateTimeOffset. Per [MS documentation](https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15), the dialect handles DateTimeOffset values by getting the string form of the DateTimeOffset and parsing them into a Timestamp.

The MS SQL Server JDBC driver does support the DateTimeOffset type, so when this driver is used the dialect simply delegates to the driver to get the timestamp for the column.

Fixes #614 for `5.0.x` and later. See #752 for a fix for the `4.0.x` and `4.1.x` branches.