### PR TITLE
CC-7265: Add support for SQL Server DateTimeOffset type

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -50,6 +50,7 @@ public class DataConverter {
   private static final int NUMERIC_TYPE_SCALE_LOW = -84;
   private static final int NUMERIC_TYPE_SCALE_HIGH = 127;
   private static final int NUMERIC_TYPE_SCALE_UNSET = -127;
+  private static final int DATETIMEOFFSET = -155;
 
   public static Schema convertSchema(
       String tableName,
@@ -332,6 +333,7 @@ public class DataConverter {
       }
 
       // Timestamp is a date + time
+      case DATETIMEOFFSET:
       case Types.TIMESTAMP: {
         SchemaBuilder tsSchemaBuilder = Timestamp.builder();
         if (optional) {
@@ -520,6 +522,7 @@ public class DataConverter {
       }
 
       // Timestamp is a date + time
+      case DATETIMEOFFSET: // SQL Server with the MS JDBC driver
       case Types.TIMESTAMP: {
         colValue = resultSet.getTimestamp(col, DateTimeUtils.UTC_CALENDAR.get());
         break;


### PR DESCRIPTION
Added support for SQL Server’s DateTimeOffset type, relying upon the MS SQL Server JDBC driver that does support the DateTimeOffset type.

Fixes #614 for `4.0.x` and `4.1.x`. See #750 for the fix for `5.0.x` and later. 