### PR TITLE
Fix Postgres OOM by limiting fetch size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>1.2.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -223,6 +229,34 @@
                             </tags>
 
                             <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--normal integration tests should not run the memory-restricted tests -->
+                        <id>integration-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*OOM*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test-memory-restricted</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <!-- out-of-memory tests should have a restricted heap size-->
+                            <argLine>@{argLine} -Djava.awt.headless=true -Xmx128M</argLine>
+                            <includes>
+                                <include>**/*OOM*.java</include>
+                            </includes>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
                         </goals>
                         <configuration>
                             <!-- out-of-memory tests should have a restricted heap size-->
-                            <argLine>@{argLine} -Djava.awt.headless=true -Xmx128M</argLine>
+                            <argLine>@{argLine} -Djava.awt.headless=true -Xmx256M</argLine>
                             <includes>
                                 <include>**/*OOM*.java</include>
                             </includes>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -81,6 +82,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver to allow it to
    * scroll more efficiently through the result set and prevent out of memory errors.
    *
+   * <p>This method also sets the {@link PreparedStatement#setFetchSize(int) fetch size} to
+   * the {@link JdbcSourceConnectorConfig#BATCH_MAX_ROWS_CONFIG batch size} of the connector.
+   * This will bound the memory usage of the connector for large tables.
+   *
    * @param stmt the prepared statement; never null
    * @throws SQLException the error that might result from initialization
    */
@@ -88,6 +93,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
     log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
     stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+    stmt.setFetchSize(config.getInt(JdbcSourceConnectorConfig.BATCH_MAX_ROWS_CONFIG));
   }
 
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -121,7 +121,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       try {
         db.commit();
       } catch (SQLException e) {
-        // intentionally ignored
+        log.warn("Error while committing read transaction, database locks may still be held", e);
       }
     }
     db = null;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -74,7 +74,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     };
 
     // Should request a connection, then should close it on stop()
-    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection()).times(2);
+    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
 
     PowerMock.expectLastCall();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -74,7 +74,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     };
 
     // Should request a connection, then should close it on stop()
-    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
+    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection()).times(2);
 
     PowerMock.expectLastCall();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/PostgresOOMIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/PostgresOOMIT.java
@@ -1,0 +1,163 @@
+package io.confluent.connect.jdbc.source.integration;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import io.confluent.connect.jdbc.source.JdbcSourceTask;
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
+import io.zonky.test.db.postgres.junit.SingleInstancePostgresRule;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for Postgres OOM conditions
+ * Expects to be run with -Xmx64M or -Xmx128M for minimum runtime
+ * but will behave correctly with any heap size (just with less performance)
+ */
+@Category(IntegrationTest.class)
+public class PostgresOOMIT {
+
+  private static Logger log = LoggerFactory.getLogger(PostgresOOMIT.class);
+
+  public static final long MAX_MEMORY = Runtime.getRuntime().maxMemory();
+
+  public static final int BYTES_PER_ROW = 1024;
+  // enough rows to take up the whole heap
+  public static final long LARGE_QUERY_ROW_COUNT = MAX_MEMORY / BYTES_PER_ROW;
+
+  public static final String LARGE_QUERY;
+
+  static {
+    StringBuilder qb = new StringBuilder();
+    qb.append("select");
+    qb.append(" '");
+      for (int i = 0; i < BYTES_PER_ROW; i++) {
+        qb.append('a');
+      }
+    qb.append("' ");
+    qb.append("from generate_series(1, ");
+    qb.append(LARGE_QUERY_ROW_COUNT);
+    qb.append(") s(i)");
+    LARGE_QUERY = qb.toString();
+    log.info(
+        "Large query will generate "
+            + MAX_MEMORY
+            + " bytes across "
+            + LARGE_QUERY_ROW_COUNT + " rows"
+    );
+  }
+
+  @Rule
+  public SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
+
+  public Map<String, String> props;
+  public JdbcSourceTask task;
+
+  @Before
+  public void before() {
+    props = new HashMap<>();
+    String jdbcURL = String.format("jdbc:postgresql://localhost:%s/postgres", pg.getEmbeddedPostgres().getPort());
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, jdbcURL);
+    props.put(JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG, "postgres");
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
+    props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, "topic_");
+  }
+
+  public void startTask() {
+
+    task = new JdbcSourceTask();
+    task.start(props);
+  }
+
+  @After
+  public void after() {
+    if (task != null) {
+      task.stop();
+    }
+  }
+
+  @Test(expected = OutOfMemoryError.class)
+  public void assertOutOfMemoryWithLargeBatch() throws InterruptedException {
+    props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "");
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, LARGE_QUERY);
+    props.put(JdbcSourceConnectorConfig.BATCH_MAX_ROWS_CONFIG, Long.toString(LARGE_QUERY_ROW_COUNT));
+    startTask();
+    task.poll();
+  }
+
+  @Test
+  public void testStreamingReads() throws InterruptedException {
+    props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "");
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, LARGE_QUERY);
+    startTask();
+    assertTrue(task.poll().size() > 0);
+  }
+
+  @Test
+  public void testTableLocksWithStreamingReads() throws InterruptedException, SQLException {
+    createTestTable();
+    props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "test_table");
+    startTask();
+    assertNoLocksOpen(task);
+    assertTrue(task.poll().size() > 0);
+    assertNoLocksOpen(task);
+    task.stop();
+    assertNoLocksOpen(task);
+  }
+
+  private void createTestTable() throws SQLException {
+    log.info("Creating test table");
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        s.execute("CREATE TABLE test_table ( c1 text )");
+        s.execute("INSERT INTO test_table VALUES ( 'Hello World' )");
+      }
+    }
+    log.info("Created table");
+  }
+
+  private void assertNoLocksOpen(JdbcSourceTask task) throws SQLException {
+    log.info("Checking for orphaned locks");
+    int count = 0;
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery(
+            "select * from pg_stat_activity where state like 'idle in%'"
+        )) {
+          int columnCount = rs.getMetaData().getColumnCount();
+          StringBuilder header = new StringBuilder();
+          for (int i = 1; i <= columnCount; i++) {
+            header.append(rs.getMetaData().getColumnName(i));
+            header.append("\t");
+          }
+          log.debug(header.toString());
+          while (rs.next()) {
+            count++;
+            StringBuilder row = new StringBuilder();
+            for (int i = 1; i <= columnCount; i++) {
+              row.append(rs.getObject(i));
+              row.append("\t");
+            }
+            log.debug(row.toString());
+          }
+        }
+      }
+    }
+    assertEquals("Found idle locks left open", 0, count);
+    log.info("No locks found");
+  }
+}


### PR DESCRIPTION
This PR adds an integration test with an embedded postgres instance.
There are three tests:
1. Verify that the test setup produces OOM exceptions with large batch sizes.
2. Verify that the test setup does _not_ produce OOM exceptions with small batch sizes.
3. Verify that tables are not left locked when autoCommit is disabled. 

Test 3 addresses a side-effect of autoCommit that was called out in #466, where read-only queries with autoCommit disabled would leave open locks on the database. This test verifies that the `JdbcSourceTask` does not leave open locks from any operations.

#466 specifically observed that the TableMonitorThread would leave open locks if auto-commit was disabled on that connection. This PR circumvents that issue by leaving the TableMonitorThread connection as-is, with autoCommit enabled. There are no tests covering the Connector or TableMonitorThread, because the behavior of those classes is unaffected by these changes. A connector test would also have some extra complication as the TableMonitorThread is asynchronous.

Fixes #34 .