### PR TITLE
CC-7382: use true/false as default values for boolean type

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -16,10 +16,12 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
@@ -250,6 +252,21 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
            .transformedBy(transform)
            .of(nonKeyColumns);
     return builder.toString();
+  }
+
+  @Override
+  protected void formatColumnValue(
+      ExpressionBuilder builder,
+      String schemaName,
+      Map<String, String> schemaParameters,
+      Schema.Type type,
+      Object value
+  ) {
+    if (schemaName == null && Type.BOOLEAN.equals(type)) {
+      builder.append((Boolean) value ? "TRUE" : "FALSE");
+    } else {
+      super.formatColumnValue(builder, schemaName, schemaParameters, type, value);
+    }
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -106,6 +106,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
                                             .optional().build();
     Schema optionalDecimal = Decimal.builder(4).optional().parameter("p1", "v1")
                                     .parameter("p2", "v2").build();
+    Schema booleanWithDefault = SchemaBuilder.bool().defaultValue(true);
     tableId = new TableId(null, null, "myTable");
     columnPK1 = new ColumnId(tableId, "id1");
     columnPK2 = new ColumnId(tableId, "id2");
@@ -124,7 +125,8 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     SinkRecordField f6 = new SinkRecordField(optionalTimeWithDefault, "c6", false);
     SinkRecordField f7 = new SinkRecordField(optionalTsWithDefault, "c7", false);
     SinkRecordField f8 = new SinkRecordField(optionalDecimal, "c8", false);
-    sinkRecordFields = Arrays.asList(f1, f2, f3, f4, f5, f6, f7, f8);
+    SinkRecordField f9 = new SinkRecordField(booleanWithDefault, "c9", false);
+    sinkRecordFields = Arrays.asList(f1, f2, f3, f4, f5, f6, f7, f8, f9);
 
     dialect = createDialect();
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
@@ -96,6 +96,7 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
         + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
         + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
         + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
+        + "\"c9\" SMALLINT DEFAULT 1,\n"
         + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -116,6 +117,7 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
         + "c6 TIME DEFAULT '00:00:00.000',\n"
         + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
         + "c8 DECIMAL(31,4) NULL,\n"
+        + "c9 SMALLINT DEFAULT 1,\n"
         + "PRIMARY KEY(c1))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -132,7 +134,8 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
                     + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
                     + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
                     + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD \"c8\" DECIMAL(31,4) NULL"};
+                    + "ADD \"c8\" DECIMAL(31,4) NULL,\n"
+                    + "ADD \"c9\" SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
 
@@ -150,7 +153,8 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
                     + "ADD c5 DATE DEFAULT '2001-03-15',\n"
                     + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
                     + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD c8 DECIMAL(31,4) NULL"};
+                    + "ADD c8 DECIMAL(31,4) NULL,\n"
+                    + "ADD c9 SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
@@ -96,6 +96,7 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
         + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
         + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
         + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
+        + "\"c9\" SMALLINT DEFAULT 1,\n"
         + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -111,6 +112,7 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
         + "c3 VARCHAR(32672) NOT NULL,\nc4 VARCHAR(32672) NULL,\n"
         + "c5 DATE DEFAULT '2001-03-15',\nc6 TIME DEFAULT '00:00:00.000',\n"
         + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\nc8 DECIMAL(31,4) NULL,\n"
+        + "c9 SMALLINT DEFAULT 1,\n"
         + "PRIMARY KEY(c1))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -125,7 +127,8 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
                     + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
                     + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
                     + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD \"c8\" DECIMAL(31,4) NULL"};
+                    + "ADD \"c8\" DECIMAL(31,4) NULL,\n"
+                    + "ADD \"c9\" SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
 
@@ -143,7 +146,8 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
                     + "ADD c5 DATE DEFAULT '2001-03-15',\n"
                     + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
                     + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD c8 DECIMAL(31,4) NULL"};
+                    + "ADD c8 DECIMAL(31,4) NULL,\n"
+                    + "ADD c9 SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -97,7 +97,8 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
         "`c3` VARCHAR(256) NOT NULL,\n" + "`c4` VARCHAR(256) NULL,\n" +
         "`c5` DATE DEFAULT '2001-03-15',\n" + "`c6` TIME(3) DEFAULT '00:00:00.000',\n" +
         "`c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" + "`c8` DECIMAL(65,4) NULL,\n" +
-        "`c9` TINYINT DEFAULT 1,\n" + "PRIMARY KEY(`c1`))";
+        "`c9` TINYINT DEFAULT 1,\n" +
+        "PRIMARY KEY(`c1`))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -97,7 +97,7 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
         "`c3` VARCHAR(256) NOT NULL,\n" + "`c4` VARCHAR(256) NULL,\n" +
         "`c5` DATE DEFAULT '2001-03-15',\n" + "`c6` TIME(3) DEFAULT '00:00:00.000',\n" +
         "`c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" + "`c8` DECIMAL(65,4) NULL,\n" +
-        "PRIMARY KEY(`c1`))";
+        "`c9` TINYINT DEFAULT 1,\n" + "PRIMARY KEY(`c1`))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }
@@ -110,7 +110,8 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
         "ADD `c3` VARCHAR(256) NOT NULL,\n" + "ADD `c4` VARCHAR(256) NULL,\n" +
         "ADD `c5` DATE DEFAULT '2001-03-15',\n" + "ADD `c6` TIME(3) DEFAULT '00:00:00.000',\n" +
         "ADD `c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" +
-        "ADD `c8` DECIMAL(65,4) NULL"};
+        "ADD `c8` DECIMAL(65,4) NULL,\n" +
+        "ADD `c9` TINYINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -95,7 +95,9 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
                       "\"c4\" CLOB NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
                       "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
                       "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-                      "\"c8\" NUMBER(*,4) NULL,\n" + "PRIMARY KEY(\"c1\"))";
+                      "\"c8\" NUMBER(*,4) NULL,\n" +
+                      "\"c9\" NUMBER(1,0) DEFAULT 1,\n" +
+                      "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }
@@ -112,7 +114,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
             "\"c5\" DATE DEFAULT '2001-03-15',\n" +
             "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
             "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-            "\"c8\" NUMBER(*,4) NULL)"
+            "\"c8\" NUMBER(*,4) NULL,\n" +
+            "\"c9\" NUMBER(1,0) DEFAULT 1)"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );
@@ -130,7 +133,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
             "c5 DATE DEFAULT '2001-03-15',\n" +
             "c6 DATE DEFAULT '00:00:00.000',\n" +
             "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-            "c8 NUMBER(*,4) NULL)"
+            "c8 NUMBER(*,4) NULL,\n" +
+            "c9 NUMBER(1,0) DEFAULT 1)"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -14,12 +14,16 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import java.util.ArrayList;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -30,6 +34,16 @@ import io.confluent.connect.jdbc.util.TableId;
 import static org.junit.Assert.assertEquals;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
+
+  @Override
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    Schema booleanWithDefault = SchemaBuilder.bool().defaultValue(true);
+    SinkRecordField f9 = new SinkRecordField(booleanWithDefault, "c9", false);
+    sinkRecordFields = new ArrayList<>(sinkRecordFields);
+    sinkRecordFields.add(f9);
+  }
 
   @Override
   protected PostgreSqlDatabaseDialect createDialect() {
@@ -101,6 +115,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
         + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
         + "\"c8\" DECIMAL NULL,\n"
+        + "\"c9\" BOOLEAN DEFAULT TRUE,\n"
         + "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -118,6 +133,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         + "c6 TIME DEFAULT '00:00:00.000',\n"
         + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
         + "c8 DECIMAL NULL,\n"
+        + "c9 BOOLEAN DEFAULT TRUE,\n"
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -135,7 +151,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
             + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
             + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "ADD \"c8\" DECIMAL NULL"
+            + "ADD \"c8\" DECIMAL NULL,\n"
+            + "ADD \"c9\" BOOLEAN DEFAULT TRUE"
         ),
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );
@@ -153,7 +170,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             + "ADD c5 DATE DEFAULT '2001-03-15',\n"
             + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
             + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "ADD c8 DECIMAL NULL"
+            + "ADD c8 DECIMAL NULL,\n"
+            + "ADD c9 BOOLEAN DEFAULT TRUE"
         ),
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -36,16 +36,6 @@ import static org.junit.Assert.assertEquals;
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
   @Override
-  @Before
-  public void setup() throws Exception {
-    super.setup();
-    Schema booleanWithDefault = SchemaBuilder.bool().defaultValue(true);
-    SinkRecordField f9 = new SinkRecordField(booleanWithDefault, "c9", false);
-    sinkRecordFields = new ArrayList<>(sinkRecordFields);
-    sinkRecordFields.add(f9);
-  }
-
-  @Override
   protected PostgreSqlDatabaseDialect createDialect() {
     return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:postgresql://something"));
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
@@ -98,7 +98,8 @@ public class SapHanaDatabaseDialectTest extends BaseDialectTest<SapHanaDatabaseD
         System.lineSeparator() + "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
         "\"c6\" DATE DEFAULT '00:00:00.000'," + System.lineSeparator() +
         "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
-        "\"c8\" DECIMAL NULL," + System.lineSeparator() + "PRIMARY KEY(\"c1\"))";
+        "\"c8\" DECIMAL NULL," + System.lineSeparator() +
+        "\"c9\" BOOLEAN DEFAULT 1," + System.lineSeparator() + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
   }
@@ -113,7 +114,8 @@ public class SapHanaDatabaseDialectTest extends BaseDialectTest<SapHanaDatabaseD
         System.lineSeparator() + "\"c5\" DATE DEFAULT '2001-03-15'," + System.lineSeparator() +
         "\"c6\" DATE DEFAULT '00:00:00.000'," + System.lineSeparator() +
         "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
-        "\"c8\" DECIMAL NULL)"};
+        "\"c8\" DECIMAL NULL," + System.lineSeparator() +
+        "\"c9\" BOOLEAN DEFAULT 1)"};
     assertStatements(sql, statements);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -128,7 +128,8 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
         + "[c5] date DEFAULT '2001-03-15',\n"
         + "[c6] time DEFAULT '00:00:00.000',\n"
         + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "[c8] decimal(38,4) NULL,\n" +
+        + "[c8] decimal(38,4) NULL,\n"
+        + "[c9] bit DEFAULT 1,\n" +
         "PRIMARY KEY([c1]))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -144,7 +145,8 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
         + "c5 date DEFAULT '2001-03-15',\n"
         + "c6 time DEFAULT '00:00:00.000',\n"
         + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 decimal(38,4) NULL,\n" +
+        + "c8 decimal(38,4) NULL,\n"
+        + "c9 bit DEFAULT 1,\n" +
         "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -162,7 +164,8 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
             + "[c5] date DEFAULT '2001-03-15',\n"
             + "[c6] time DEFAULT '00:00:00.000',\n"
             + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "[c8] decimal(38,4) NULL"
+            + "[c8] decimal(38,4) NULL,\n"
+            + "[c9] bit DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );
@@ -179,7 +182,8 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
             + "c5 date DEFAULT '2001-03-15',\n"
             + "c6 time DEFAULT '00:00:00.000',\n"
             + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "c8 decimal(38,4) NULL"
+            + "c8 decimal(38,4) NULL,\n"
+            + "c9 bit DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -128,6 +128,7 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
         + "`c6` NUMERIC DEFAULT '00:00:00.000',\n"
         + "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
         + "`c8` NUMERIC NULL,\n"
+        + "`c9` INTEGER DEFAULT 1,\n"
         + "PRIMARY KEY(`c1`))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -144,6 +145,7 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
         + "c6 NUMERIC DEFAULT '00:00:00.000',\n"
         + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
         + "c8 NUMERIC NULL,\n"
+        + "c9 INTEGER DEFAULT 1,\n"
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -160,7 +162,8 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
             "ALTER TABLE `myTable` ADD `c5` NUMERIC DEFAULT '2001-03-15'",
             "ALTER TABLE `myTable` ADD `c6` NUMERIC DEFAULT '00:00:00.000'",
             "ALTER TABLE `myTable` ADD `c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000'",
-            "ALTER TABLE `myTable` ADD `c8` NUMERIC NULL"
+            "ALTER TABLE `myTable` ADD `c8` NUMERIC NULL",
+            "ALTER TABLE `myTable` ADD `c9` INTEGER DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );
@@ -176,7 +179,8 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
             "ALTER TABLE myTable ADD c5 NUMERIC DEFAULT '2001-03-15'",
             "ALTER TABLE myTable ADD c6 NUMERIC DEFAULT '00:00:00.000'",
             "ALTER TABLE myTable ADD c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000'",
-            "ALTER TABLE myTable ADD c8 NUMERIC NULL"
+            "ALTER TABLE myTable ADD c8 NUMERIC NULL",
+            "ALTER TABLE myTable ADD c9 INTEGER DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -110,7 +110,8 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
         + "\"c5\" date DEFAULT '2001-03-15',\n"
         + "\"c6\" time DEFAULT '00:00:00.000',\n"
         + "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" decimal(38,4) NULL,\n" +
+        + "\"c8\" decimal(38,4) NULL,\n"
+        + "\"c9\" bit DEFAULT 1,\n" +
         "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -126,7 +127,8 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
         + "c5 date DEFAULT '2001-03-15',\n"
         + "c6 time DEFAULT '00:00:00.000',\n"
         + "c7 datetime DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 decimal(38,4) NULL,\n" +
+        + "c8 decimal(38,4) NULL,\n"
+        + "c9 bit DEFAULT 1,\n" +
         "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -174,7 +176,8 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
         "ALTER TABLE \"myTable\" ADD\n" + "\"c1\" int NOT NULL,\n" + "\"c2\" bigint NOT NULL,\n" +
         "\"c3\" text NOT NULL,\n" + "\"c4\" text NULL,\n" +
         "\"c5\" date DEFAULT '2001-03-15',\n" + "\"c6\" time DEFAULT '00:00:00.000',\n" +
-        "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" decimal(38,4) NULL"};
+        "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" decimal(38,4) NULL,\n" +
+        "\"c9\" bit DEFAULT 1"};
     assertStatements(sql, statements);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
@@ -100,6 +100,7 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
         + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
         + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
         + "\"c8\" DECIMAL(18,4) NULL,\n"
+        + "\"c9\" BOOLEAN DEFAULT 1,\n"
         + "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -116,6 +117,7 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
         + "c6 TIME DEFAULT '00:00:00.000',\n"
         + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
         + "c8 DECIMAL(18,4) NULL,\n"
+        + "c9 BOOLEAN DEFAULT 1,\n"
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -132,7 +134,8 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
             "ALTER TABLE \"myTable\" ADD \"c5\" DATE DEFAULT '2001-03-15'",
             "ALTER TABLE \"myTable\" ADD \"c6\" TIME DEFAULT '00:00:00.000'",
             "ALTER TABLE \"myTable\" ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
-            "ALTER TABLE \"myTable\" ADD \"c8\" DECIMAL(18,4) NULL"
+            "ALTER TABLE \"myTable\" ADD \"c8\" DECIMAL(18,4) NULL",
+            "ALTER TABLE \"myTable\" ADD \"c9\" BOOLEAN DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );
@@ -148,7 +151,8 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
             "ALTER TABLE myTable ADD c5 DATE DEFAULT '2001-03-15'",
             "ALTER TABLE myTable ADD c6 TIME DEFAULT '00:00:00.000'",
             "ALTER TABLE myTable ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
-            "ALTER TABLE myTable ADD c8 DECIMAL(18,4) NULL"
+            "ALTER TABLE myTable ADD c8 DECIMAL(18,4) NULL",
+            "ALTER TABLE myTable ADD c9 BOOLEAN DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
     );


### PR DESCRIPTION
Addressing ticket CC-7382: https://confluentinc.atlassian.net/browse/CC-7382, which comes from triaging this issue https://github.com/confluentinc/kafka-connect-jdbc/issues/755. 

The issue is reporting a bug of postgres dialect of jdbc connector. When there is boolean column with default value, there will be an exception. The bug is caused by us using 0/1 as default values for boolean type, which is not recognized by postgres. 

My fix is to overwrite `formatColumnValue()` to do special handling on boolean default for postgres. And I extended the unit test to test the changes. 

My code passed unit tests, and I have manually tested on postgres instance. It works as intended.