### PR TITLE
CC-7414: Fix SqlServer column converter infinite loop & add column converter tests

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -140,12 +140,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   @Override
-  public ColumnConverter createColumnConverter(
-      ColumnMapping mapping
+  protected ColumnConverter columnConverterFor(
+      ColumnMapping mapping,
+      ColumnDefinition defn,
+      int col,
+      boolean isJdbc4
   ) {
     // First handle any PostgreSQL-specific types
     ColumnDefinition columnDefn = mapping.columnDefn();
-    int col = mapping.columnNumber();
     switch (columnDefn.type()) {
       case Types.BIT: {
         // PostgreSQL allows variable length bit strings, but when length is 1 then the driver
@@ -171,7 +173,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
 
     // Delegate for the remaining logic
-    return super.createColumnConverter(mapping);
+    return super.columnConverterFor(mapping, defn, col, isJdbc4);
   }
 
   protected boolean isJsonType(ColumnDefinition columnDefn) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -62,8 +62,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
-  private static final String JSON_TYPE_NAME = "json";
-  private static final String JSONB_TYPE_NAME = "jsonb";
+  static final String JSON_TYPE_NAME = "json";
+  static final String JSONB_TYPE_NAME = "jsonb";
 
   /**
    * Create a new dialect instance with the given connector configuration.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -52,7 +52,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
   /**
    * JDBC Type constant for SQL Server's custom data types.
    */
-  private static final int DATETIMEOFFSET = -155;
+  static final int DATETIMEOFFSET = -155;
 
   /**
    * This is the format of the string form of DATETIMEOFFSET values, and used to parse such

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -138,7 +138,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     }
 
     // Delegate for the remaining logic to handle the standard types
-    return super.createColumnConverter(mapping);
+    return super.columnConverterFor(mapping, defn, col, isJdbc4);
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -14,9 +14,15 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.source.ColumnMapping;
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnDefinition.Mutability;
+import io.confluent.connect.jdbc.util.ColumnDefinition.Nullability;
+import java.sql.Types;
 import java.time.ZoneOffset;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -52,6 +58,7 @@ import io.confluent.connect.jdbc.util.DateTimeUtils;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -240,6 +247,83 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   ) {
     Map<String, String> schemaProps = propertiesFromPairs(schemaParamPairs);
     assertMapping(expectedSqlType, type, schemaName, schemaProps);
+  }
+
+  /**
+   * Verify that column converters are defined and return non-null converter objects.
+   * These are inherited by most dialects from {@link GenericDatabaseDialect}, but cannot live
+   * inside {@link GenericDatabaseDialectTest} because specific dialect tests don't inherit from
+   * the generic test class.
+   */
+  @Test
+  public void testGenericColumnConverters() {
+    assertColumnConverter(Types.BOOLEAN, null, Schema.BOOLEAN_SCHEMA, Boolean.class);
+    assertColumnConverter(Types.BIT, null, Schema.INT8_SCHEMA, Byte.class);
+    assertColumnConverter(Types.TINYINT, null, Schema.INT8_SCHEMA, Byte.class);
+    assertColumnConverter(Types.SMALLINT, null, Schema.INT16_SCHEMA, Short.class);
+    assertColumnConverter(Types.INTEGER, null, Schema.INT32_SCHEMA, Integer.class);
+    assertColumnConverter(Types.BIGINT, null, Schema.INT64_SCHEMA, Long.class);
+    assertColumnConverter(Types.REAL, null, Schema.FLOAT32_SCHEMA, Float.class);
+    assertColumnConverter(Types.FLOAT, null, Schema.FLOAT64_SCHEMA, Double.class);
+    assertColumnConverter(Types.DOUBLE, null, Schema.FLOAT64_SCHEMA, Double.class);
+    assertColumnConverter(Types.NUMERIC, null, Schema.INT8_SCHEMA, Integer.class); // assume 0 precision and 0 scale
+    assertColumnConverter(Types.DECIMAL, null, Decimal.schema(0), Decimal.class);
+    assertColumnConverter(Types.CHAR, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.VARCHAR, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.LONGVARCHAR, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.NCHAR, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.NVARCHAR, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.LONGNVARCHAR, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.CLOB, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.NCLOB, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.DATALINK, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.SQLXML, null, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.BINARY, null, Schema.BYTES_SCHEMA, byte[].class);
+    assertColumnConverter(Types.BLOB, null, Schema.BYTES_SCHEMA, byte[].class);
+    assertColumnConverter(Types.VARBINARY, null, Schema.BYTES_SCHEMA, byte[].class);
+    assertColumnConverter(Types.LONGVARBINARY, null, Schema.BYTES_SCHEMA, byte[].class);
+    assertColumnConverter(Types.DATE, null, Date.SCHEMA, java.sql.Date.class);
+    assertColumnConverter(Types.TIME, null, Time.SCHEMA, java.sql.Time.class);
+    assertColumnConverter(Types.TIMESTAMP, null, Timestamp.SCHEMA, java.sql.Timestamp.class);
+  }
+
+
+  protected void assertColumnConverter(
+      int jdbcType,
+      String typeName,
+      Schema schema,
+      Class<?> clazz) {
+    ColumnMapping mapping = new ColumnMapping(
+        new ColumnDefinition(
+            columnA,
+            jdbcType,
+            typeName,
+            clazz.getCanonicalName(),
+            Nullability.NOT_NULL,
+            Mutability.UNKNOWN,
+            0,
+            0,
+            false,
+            1,
+            false,
+            false,
+            false,
+            false,
+            false
+        ),
+        1,
+        new Field(
+            "b",
+            1,
+            schema
+        )
+    );
+    assertNotNull(dialect.columnConverterFor(
+        mapping,
+        mapping.columnDefn(),
+        mapping.columnNumber(),
+        true
+    ));
   }
 
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -14,16 +14,13 @@
 
 package io.confluent.connect.jdbc.dialect;
 
-import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
-import java.util.ArrayList;
+import java.sql.Types;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -59,6 +56,12 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertDecimalMapping(3, "DECIMAL");
     assertDecimalMapping(4, "DECIMAL");
     assertDecimalMapping(5, "DECIMAL");
+  }
+
+  @Test
+  public void testCustomColumnConverters() {
+    assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.JSON_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.JSONB_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -52,6 +52,11 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     assertTimestamp(ZonedDateTime.of(2019, 12, 8, 12, 34, 56, 785020000, utc), ts);
   }
 
+  @Test
+  public void testCustomColumnConverters() {
+    assertColumnConverter(SqlServerDatabaseDialect.DATETIMEOFFSET, null, Timestamp.SCHEMA, Timestamp.class);
+  }
+
   protected void assertTimestamp(ZonedDateTime expected, java.sql.Timestamp actual) {
     ZonedDateTime zdt = ZonedDateTime.ofInstant(actual.toInstant(), ZoneId.of("UTC"));
     assertEquals(expected.getYear(), zdt.getYear());


### PR DESCRIPTION
This bug was introduced as part of #750, and manifests itself as a stack overflow between `GenericDatabaseDialect::createColumnConverter` and `SqlServerDatabaseDialect::columConverterFor`.

In addition to this fix, this PR includes:

- A unit test that would have caught this error for every dialect
- A unit test for the new functionality added in #750 
- Refactoring the column converter override method in PostgreSqlDatabaseDialect for testing
- A unit test for Postgres-specific column converters