### PR TITLE
Add option for dropping an invalid batch of messages

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -219,6 +219,13 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
+  public static final String DROP_INVALID_BATCH_CONFIG = "drop.invalid.batch";
+  private static final String DROP_INVALID_BATCH_DEFAULT = "false";
+  private static final String DROP_INVALID_BATCH_DOC =
+          "Whether to drop a message batch that fails beyond maximum retries "
+          + "rather than stopping the connector.";
+  private static final String DROP_INVALID_BATCH_DISPLAY = "Drop Invalid Batch";
+
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
         // Connection
         .define(
@@ -415,6 +422,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             2,
             ConfigDef.Width.SHORT,
             RETRY_BACKOFF_MS_DISPLAY
+        )
+        .define(
+                DROP_INVALID_BATCH_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+                DROP_INVALID_BATCH_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+                DROP_INVALID_BATCH_DOC,
+            RETRIES_GROUP,
+            3,
+            ConfigDef.Width.SHORT,
+                DROP_INVALID_BATCH_DISPLAY
         );
 
   public final String connectionUrl;
@@ -433,6 +451,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final Set<String> fieldsWhitelist;
   public final String dialectName;
   public final TimeZone timeZone;
+  public final boolean dropInvalidBatch;
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
@@ -453,6 +472,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
     String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
     timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
+    dropInvalidBatch = getBoolean(DROP_INVALID_BATCH_CONFIG);
 
     if (deleteEnabled && pkMode != PrimaryKeyMode.RECORD_KEY) {
       throw new ConfigException(

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -84,7 +84,18 @@ public class JdbcSinkTask extends SinkTask {
         sqleAllMessages += e + System.lineSeparator();
       }
       if (remainingRetries == 0) {
-        throw new ConnectException(new SQLException(sqleAllMessages));
+        if (config.dropInvalidBatch) {
+          log.error(
+                  "Can't write records. First record from topic/partition/offset {}/{}/{}. "
+                          + "Error message: {}",
+                  first.topic(),
+                  first.kafkaPartition(),
+                  first.kafkaOffset(),
+                  sqle.getMessage()
+          );
+        } else {
+          throw new ConnectException(new SQLException(sqleAllMessages));
+        }
       } else {
         writer.closeQuietly();
         initWriter();


### PR DESCRIPTION
`drop.invalid.batch`
Add option for dropping an invalid batch of messages - rather than ending up in a poison pill situation requiring manual intervention.
https://rmoff.net/2019/10/15/skipping-bad-records-with-the-kafka-connect-jdbc-sink-connector/

Quick resiliency similar to the basic elasticsearch connector approach:
https://github.com/confluentinc/kafka-connect-elasticsearch/blob/master/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchWriter.java#L307

DLQ support can still be enhanced in future.