### PR TITLE
CC-7628 Set conservative timeout for JDBC to stop trying to reach drive

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -218,6 +218,10 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       properties.setProperty("password", dbPassword.value());
     }
     properties = addConnectionProperties(properties);
+    // Timeout is 40 seconds to be as long as possible for customer to have a long connection
+    // handshake, while still giving enough time to validate once in the follower worker,
+    // and again in the leader worker and still be under 90s REST serving timeout
+    DriverManager.setLoginTimeout(40);
     Connection connection = DriverManager.getConnection(jdbcUrl, properties);
     if (jdbcDriverInfo == null) {
       jdbcDriverInfo = createJdbcDriverInfo(connection);


### PR DESCRIPTION
By default, the driver has no limit for timing out trying to make
a connection (https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#setLoginTimeout(int))
This fix will set to 1 minute.

Without this fix, the connect framework may hang in the main thread (perhaps when
validating a connector config during Table Recommender), and block the entire
node's REST API. A framework-level fix is ideal, but this fix will alleviate
the issue in the short-term and on older worker versions.

Also considered making this configurable, but 1 minute is pretty conservative