### PR TITLE
Add possibility to customize update clause in updset/update mode for Oracle db

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1400,13 +1400,13 @@ public class GenericDatabaseDialect implements DatabaseDialect {
              .delimitedBy(" AND ")
              .transformedBy(ExpressionBuilder.columnNamesWith(" = ?"))
              .of(keyColumns);
-      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
-        String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
+      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG)) {
+        String condition = config.getString(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG);
         builder.append(" AND ").append(condition);
       }
     } else {
-      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
-        String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
+      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG)) {
+        String condition = config.getString(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG);
         if (condition != null && !"".equals(condition)) {
           builder.append(" WHERE ").append(condition);
         }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1400,6 +1400,17 @@ public class GenericDatabaseDialect implements DatabaseDialect {
              .delimitedBy(" AND ")
              .transformedBy(ExpressionBuilder.columnNamesWith(" = ?"))
              .of(keyColumns);
+      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
+        String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
+        builder.append(" AND ").append(condition);
+      }
+    } else {
+      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
+        String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
+        if (condition != null && !"".equals(condition)) {
+          builder.append(" WHERE ").append(condition);
+        }
+      }
     }
     return builder.toString();
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -192,7 +193,11 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
       builder.appendList()
              .delimitedBy(",")
              .transformedBy(transform)
-             .of(nonKeyColumns);
+              .of(nonKeyColumns);
+      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
+        String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
+        builder.append(" ").append(condition);
+      }
     }
 
     builder.append(" when not matched then insert(");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -196,7 +196,9 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
               .of(nonKeyColumns);
       if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
         String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
-        builder.append(" ").append(condition);
+        if (condition != null && !"".equals(condition)) {
+          builder.append(" where ").append(condition);
+        }
       }
     }
 
@@ -212,6 +214,8 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     builder.append(")");
     return builder.toString();
   }
+
+
 
   @Override
   protected String sanitizedUrl(String url) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -194,8 +194,8 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
              .delimitedBy(",")
              .transformedBy(transform)
               .of(nonKeyColumns);
-      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CONDITION_CONFIG)) {
-        String condition = config.getString(JdbcSinkConfig.UPDATE_CONDITION_CONFIG);
+      if (config.values().containsKey(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG)) {
+        String condition = config.getString(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG);
         if (condition != null && !"".equals(condition)) {
           builder.append(" where ").append(condition);
         }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -219,11 +219,11 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
-  public static final String UPDATE_CONDITION_CONFIG = "update.clause";
-  public static final String UPDATE_CONDITION_DEFAULT = "";
-  private static final String UPDATE_CONDITION_CONFIG_DOC =
+  public static final String UPDATE_CLAUSE_CONFIG = "update.clause";
+  public static final String UPDATE_CLAUSE_DEFAULT = "";
+  private static final String UPDATE_CLAUSE_CONFIG_DOC =
           "Use in update query clause in upsert and update mode";
-  private static final String UPDATE_CONDITION_DISPLAY = "Update Condition";
+  private static final String UPDATE_CLAUSE_DISPLAY = "Update Condition";
 
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
         // Connection
@@ -366,15 +366,15 @@ public class JdbcSinkConfig extends AbstractConfig {
           DB_TIMEZONE_CONFIG_DISPLAY
         )
          .define(
-           UPDATE_CONDITION_CONFIG,
+                 UPDATE_CLAUSE_CONFIG,
            ConfigDef.Type.STRING,
-           "",
+                 UPDATE_CLAUSE_DEFAULT,
            ConfigDef.Importance.LOW,
-           UPDATE_CONDITION_CONFIG_DOC,
+                 UPDATE_CLAUSE_CONFIG_DOC,
            DATAMAPPING_GROUP,
            6,
            ConfigDef.Width.LONG,
-           UPDATE_CONDITION_DISPLAY
+                 UPDATE_CLAUSE_DISPLAY
          )
         //
         .define(

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -219,7 +219,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
-  public static final String UPDATE_CONDITION_CONFIG = "update.condition";
+  public static final String UPDATE_CONDITION_CONFIG = "update.clause";
   public static final String UPDATE_CONDITION_DEFAULT = "";
   private static final String UPDATE_CONDITION_CONFIG_DOC =
           "Use in update query clause in upsert and update mode";
@@ -237,17 +237,6 @@ public class JdbcSinkConfig extends AbstractConfig {
             1,
             ConfigDef.Width.LONG,
             CONNECTION_URL_DISPLAY
-        )
-        .define(
-            UPDATE_CONDITION_CONFIG,
-            ConfigDef.Type.STRING,
-            ConfigDef.NO_DEFAULT_VALUE,
-            ConfigDef.Importance.LOW,
-            UPDATE_CONDITION_CONFIG_DOC,
-            DATAMAPPING_GROUP,
-            6,
-            ConfigDef.Width.LONG,
-            UPDATE_CONDITION_DISPLAY
         )
         .define(
             CONNECTION_USER,
@@ -376,7 +365,18 @@ public class JdbcSinkConfig extends AbstractConfig {
           ConfigDef.Width.MEDIUM,
           DB_TIMEZONE_CONFIG_DISPLAY
         )
-        // DDL
+         .define(
+           UPDATE_CONDITION_CONFIG,
+           ConfigDef.Type.STRING,
+           "",
+           ConfigDef.Importance.LOW,
+           UPDATE_CONDITION_CONFIG_DOC,
+           DATAMAPPING_GROUP,
+           6,
+           ConfigDef.Width.LONG,
+           UPDATE_CONDITION_DISPLAY
+         )
+        //
         .define(
             AUTO_CREATE,
             ConfigDef.Type.BOOLEAN,

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -219,6 +219,12 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
+  public static final String UPDATE_CONDITION_CONFIG = "update.condition";
+  public static final String UPDATE_CONDITION_DEFAULT = "";
+  private static final String UPDATE_CONDITION_CONFIG_DOC =
+          "Use in update query clause in upsert and update mode";
+  private static final String UPDATE_CONDITION_DISPLAY = "Update Condition";
+
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
         // Connection
         .define(
@@ -231,6 +237,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             1,
             ConfigDef.Width.LONG,
             CONNECTION_URL_DISPLAY
+        )
+        .define(
+            UPDATE_CONDITION_CONFIG,
+            ConfigDef.Type.STRING,
+            ConfigDef.NO_DEFAULT_VALUE,
+            ConfigDef.Importance.LOW,
+            UPDATE_CONDITION_CONFIG_DOC,
+            DATAMAPPING_GROUP,
+            6,
+            ConfigDef.Width.LONG,
+            UPDATE_CONDITION_DISPLAY
         )
         .define(
             CONNECTION_USER,

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -173,6 +173,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     return new JdbcSourceConnectorConfig(connProps);
   }
 
+
   /**
    * Create a {@link JdbcSinkConfig} with the specified URL and optional config props.
    *

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -35,7 +35,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Override
   protected OracleDatabaseDialect createDialect() {
     final JdbcSourceConnectorConfig config = sourceConfigWithUrl("jdbc:oracle:thin://something",
-            JdbcSinkConfig.UPDATE_CONDITION_CONFIG, "\"ARTICLE\".\"body\" <> incoming.\"body\" ");
+            JdbcSinkConfig.UPDATE_CLAUSE_CONFIG, "\"ARTICLE\".\"body\" <> incoming.\"body\" ");
     return new OracleDatabaseDialect(config);
   }
 
@@ -230,7 +230,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
   @Test
   public void upsertUpdateCondition() {
-    OracleDatabaseDialect sinkDialect = createSinkDialect(JdbcSinkConfig.UPDATE_CONDITION_CONFIG, "\"ARTICLE\".\"body\" <> incoming.\"body\" ");
+    OracleDatabaseDialect sinkDialect = createSinkDialect(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG, "\"ARTICLE\".\"body\" <> incoming.\"body\" ");
     TableId article = tableId("ARTICLE");
     String expected = "merge into \"ARTICLE\" " +
             "using (select ? \"title\", ? \"author\", ? \"body\" FROM dual) incoming on" +
@@ -248,7 +248,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
   @Test
   public void update() {
-    OracleDatabaseDialect sinkDialect = createSinkDialect(JdbcSinkConfig.UPDATE_CONDITION_CONFIG, "change_date > sysdate");
+    OracleDatabaseDialect sinkDialect = createSinkDialect(JdbcSinkConfig.UPDATE_CLAUSE_CONFIG, "change_date > sysdate");
     TableId article = tableId("ARTICLE");
     String expected =
             "UPDATE \"ARTICLE\" SET \"title\" = ?, \"change_date\" = ? WHERE \"id\" = ? AND change_date > sysdate";


### PR DESCRIPTION
In order to solve problem, when we need compare some field in merge(update) clause with field in DB, I suggest new property:
update.clause, where clause set for example: 
update.clause= "PRODUCTS"."CHANGE_DATE" < incoming."CHANGE_DATE" 
incoming - it's constant

This enhancement give possibility to merge without additional querying from DB 