### PR TITLE
CC-7637: added logging of query to be executed at DEBUG level

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -176,6 +176,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   @Override
   protected ResultSet executeQuery() throws SQLException {
     criteria.setQueryParameters(stmt, this);
+    log.debug("Statement to execute: {}", stmt.toString());
     return stmt.executeQuery();
   }
 


### PR DESCRIPTION
Addressing ticket CC-7637 https://confluentinc.atlassian.net/browse/CC-7637.

Before the change, a DEBUG message logged in `createPreparedStatement()` which contains the prepared statement before variable bindings.

After the change, in addition to what we already have, there is also a DEBUG message logged in `executeQuery()` right before the statement got executed. I have checked manually: this message contains all the information acquired from the bindings. Hence, there is no longer "?" in the query. 

There are two implementation of `executeQuery()`: one in `BulkTableQuerier` class, and the other in `TimestampIncrementingTableQuerier` class. I only added the new logging to `TimestampIncrementingTableQuerier`'s implementation, because for `BulkTableQuerier`'s implementation, the statement contains no "?" to bind. Whether this is a good choice is open to debate.