### PR TITLE
Make metadata allFields ordered consistently with the valueSchema.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -20,6 +20,8 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -131,9 +133,25 @@ public class FieldsMetadata {
     }
 
     final Map<String, SinkRecordField> allFieldsOrdered = new LinkedHashMap<>();
-    for (Field field : valueSchema.fields()) {
-      String fieldName = field.name();
+    for (String fieldName : JdbcSinkConfig.DEFAULT_KAFKA_PK_NAMES) {
       if (allFields.containsKey(fieldName)) {
+        allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+      }
+    }
+
+    if (valueSchema != null) {
+      for (Field field : valueSchema.fields()) {
+        String fieldName = field.name();
+        if (allFields.containsKey(fieldName)) {
+          allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+        }
+      }
+    }
+
+    ArrayList<String> fieldKeys = new ArrayList<>(allFields.keySet());
+    Collections.sort(fieldKeys);
+    for (String fieldName : fieldKeys) {
+      if (!allFieldsOrdered.containsKey(fieldName)) {
         allFieldsOrdered.put(fieldName, allFields.get(fieldName));
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -148,11 +148,13 @@ public class FieldsMetadata {
       }
     }
 
-    ArrayList<String> fieldKeys = new ArrayList<>(allFields.keySet());
-    Collections.sort(fieldKeys);
-    for (String fieldName : fieldKeys) {
-      if (!allFieldsOrdered.containsKey(fieldName)) {
-        allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+    if (allFieldsOrdered.size() < allFields.size()) {
+      ArrayList<String> fieldKeys = new ArrayList<>(allFields.keySet());
+      Collections.sort(fieldKeys);
+      for (String fieldName : fieldKeys) {
+        if (!allFieldsOrdered.containsKey(fieldName)) {
+          allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+        }
       }
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -129,7 +130,15 @@ public class FieldsMetadata {
       );
     }
 
-    return new FieldsMetadata(keyFieldNames, nonKeyFieldNames, allFields);
+    final Map<String, SinkRecordField> allFieldsOrdered = new LinkedHashMap<>();
+    for (Field field : valueSchema.fields()) {
+      String fieldName = field.name();
+      if (allFields.containsKey(fieldName)) {
+        allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+      }
+    }
+
+    return new FieldsMetadata(keyFieldNames, nonKeyFieldNames, allFieldsOrdered);
   }
 
   private static void extractKafkaPk(

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -257,6 +258,37 @@ public class FieldsMetadataTest {
 
     assertEquals(Collections.singleton("field1"), metadata.keyFieldNames);
     assertEquals(new HashSet<>(Arrays.asList("field2", "field4")), metadata.nonKeyFieldNames);
+  }
+
+  @Test
+  public void recordValuePkModeWithFieldsRetainOriginalOrdering() {
+    final Schema valueSchema =
+            SchemaBuilder.struct()
+                    .field("field4", Schema.INT64_SCHEMA)
+                    .field("field2", Schema.INT64_SCHEMA)
+                    .field("field1", Schema.INT64_SCHEMA)
+                    .field("field3", Schema.INT64_SCHEMA)
+                    .build();
+
+    FieldsMetadata metadata = extract(
+            JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE,
+            Collections.singletonList("field4"),
+            new HashSet<>(Arrays.asList("field3", "field1", "field2")),
+            null,
+            valueSchema
+    );
+
+    assertEquals(Arrays.asList("field4", "field2", "field1", "field3"), new ArrayList<>(metadata.allFields.keySet()));
+
+    metadata = extract(
+            JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE,
+            Collections.singletonList("field1"),
+            new HashSet<>(Arrays.asList("field4", "field3")),
+            null,
+            valueSchema
+    );
+
+    assertEquals(Arrays.asList("field4", "field1", "field3"), new ArrayList<>(metadata.allFields.keySet()));
   }
 
   private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Schema keySchema, Schema valueSchema) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -289,6 +289,23 @@ public class FieldsMetadataTest {
     );
 
     assertEquals(Arrays.asList("field4", "field1", "field3"), new ArrayList<>(metadata.allFields.keySet()));
+
+    final Schema keySchema =
+            SchemaBuilder.struct()
+                    .field("field1", Schema.INT64_SCHEMA)
+                    .field("field3", Schema.INT64_SCHEMA)
+                    .field("field2", Schema.INT64_SCHEMA)
+                    .build();
+
+    metadata = extract(
+            JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+            Arrays.asList("field2", "field3", "field1"),
+            new HashSet<>(Arrays.asList("field3", "field1")),
+            keySchema,
+            null
+    );
+
+    assertEquals(Arrays.asList("field1", "field2", "field3"), new ArrayList<>(metadata.allFields.keySet()));
   }
 
   private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Schema keySchema, Schema valueSchema) {


### PR DESCRIPTION
Currently the use of a HashMap to store the columns loses the ordering of the columns from the schema.

When the create table is generated, the order of the columns is unpredictable.

This change creates a LinkedHashMap which preserves the original column order from the valueSchema and tests to check ordering is functioning correctly.
