### PR TITLE
CC-8087: Remove plaintext logging of task configs

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -142,7 +142,7 @@ public class JdbcSourceConnector extends SourceConnector {
       Map<String, String> taskProps = new HashMap<>(configProperties);
       taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, "");
       taskConfigs = Collections.singletonList(taskProps);
-      log.trace("Task configs with no query");
+      log.trace("Producing task configs with custom query");
       return taskConfigs;
     } else {
       List<TableId> currentTables = tableMonitorThread.tables();
@@ -161,7 +161,7 @@ public class JdbcSourceConnector extends SourceConnector {
           taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, builder.toString());
           taskConfigs.add(taskProps);
         }
-        log.trace("Task configs with query: {}, tables: {}", taskConfigs, currentTables.toArray());
+        log.trace("Producing task configs with no custom query for tables: {}", currentTables.toArray());
       }
     }
     return taskConfigs;

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -161,7 +161,10 @@ public class JdbcSourceConnector extends SourceConnector {
           taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, builder.toString());
           taskConfigs.add(taskProps);
         }
-        log.trace("Producing task configs with no custom query for tables: {}", currentTables.toArray());
+        log.trace(
+            "Producing task configs with no custom query for tables: {}",
+            currentTables.toArray()
+        );
       }
     }
     return taskConfigs;


### PR DESCRIPTION
[JIRA](https://confluentinc.atlassian.net/browse/CC-8087)

These changes remove the logging of task configurations in plaintext, which should be done to avoid leaking database credentials and other secrets. Additionally, the log messages for whether a custom query has been specified by the user are flipped to correctly correspond to the actual presence of a custom query in the connector configuration.