### PR TITLE
CC-8090: Validate connection.attempts property in config class

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -67,7 +67,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public static final String CONNECTION_ATTEMPTS_CONFIG = "connection.attempts";
   private static final String CONNECTION_ATTEMPTS_DOC
-      = "Maximum number of attempts to retrieve a valid JDBC connection.";
+      = "Maximum number of attempts to retrieve a valid JDBC connection. "
+          + "Must be a positive integer.";
   private static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
   public static final int CONNECTION_ATTEMPTS_DEFAULT = 3;
 
@@ -296,6 +297,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         CONNECTION_ATTEMPTS_CONFIG,
         Type.INT,
         CONNECTION_ATTEMPTS_DEFAULT,
+        ConfigDef.Range.atLeast(1),
         Importance.LOW,
         CONNECTION_ATTEMPTS_DOC,
         DATABASE_GROUP,

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -69,6 +71,17 @@ public class JdbcSourceConnectorConfigTest {
   public void cleanup() throws Exception {
     db.close();
     db.dropDatabase();
+  }
+
+  @Test
+  public void testConnectionAttemptsAtLeastOne() {
+    props.put(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG, "0");
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    ConfigValue connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertFalse(connectionAttemptsConfig.errorMessages().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-8090)

This adds a quick check to the `JdbcSourceConnectorConfig` class that ensures that the `connection.attempts` property has a value of at least one. The docs for that config property are updated accordingly, and a small unit test is added to prevent regression.