### PR TITLE
MINOR: Upgrade to Derby 10.12.1.1 on versions prior to CP 5.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <junit.version>4.12</junit.version>
         <easymock.version>3.0</easymock.version>
         <powermock.version>1.6.2</powermock.version>
-        <derby.version>10.11.1.1</derby.version>
+        <derby.version>10.12.1.1</derby.version>
         <commons-io.version>2.4</commons-io.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>


### PR DESCRIPTION
Upgrades the derby to a CVE free version