### PR TITLE
MINOR: Upgrade to Derby 10.14.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
     <properties>
         <confluent.version>${project.version}</confluent.version>
-        <derby.version>10.12.1.1</derby.version>
+        <derby.version>10.14.2.0</derby.version>
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>


### PR DESCRIPTION
Upgrades the derby to a CVE free version for release supporting Java 8 and newer