### PR TITLE
MINOR: Backport upgrade to postgres jdbc to 5.0.x

### DIFF
--- a/licenses/LICENSE-postgresql-42.2.10.txt
+++ b/licenses/LICENSE-postgresql-42.2.10.txt
@@ -1,0 +1,153 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" dir="ltr">
+<head>
+	<title>PostgreSQL JDBC License</title>
+	<meta http-equiv="Content-Type" content="text/xhtml; charset=utf-8" />
+	<meta name="description" content="The official site for the PostgreSQL JDBC Driver" />
+	<meta name="copyright" content="The PostgreSQL Global Development Group" />
+
+	<style type="text/css" media="screen" title="Normal Text">@import url("../media/css/base.css");</style>
+
+	<link rel="shortcut icon" href="../media/favicon.ico" />
+
+	<!--
+	<script type="text/javascript">
+		var _gaq = _gaq || [];
+		_gaq.push(['_setAccount', 'UA-1345454-1']);
+		_gaq.push(['_trackPageview']);
+		(function() {
+			var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+			})();
+	</script>
+	-->
+</head>
+
+<body>
+	<div id="pgContainerWrap">
+		<div id="pgContainer">
+
+			<span class="txtOffScreen"><a href="#pgContent" title="Skip site navigation" accesskey="1">Skip site navigation</a> (1)</span>
+			<span class="txtOffScreen"><a href="#pgContentWrap" title="Skip section navigation" accesskey="2">Skip section navigation</a> (2)</span>
+
+			<div id="pgHeaderContainer">
+
+				<div id="pgSearch">
+
+					<!-- Old pgjdbc form -->
+					<form action="https://www.google.com/search" method="get">
+						<input value="jdbc.postgresql.org" name="sitesearch" type="hidden" />
+						<input id="q" name="q" type="text" size="20" maxlength="255" onfocus="if( this.value==this.defaultValue ) this.value='';" value="Google Search" accesskey="s" />
+						<!-- <input onFocus="getBlank (this, 'Search the site with google');" size="25" name="q" id="query" type="text" value="Search the site with google">&nbsp; -->
+                    				<input name="Search" value="Search" type="submit" />
+					</form>
+
+					<!-- New PostgreSQL form
+					<form method="get" action="search/">
+					<div>
+						<h2 class="pgBlockHide"><label for="q">Search</label></h2>
+						<input id="q" name="q" type="text" size="20" maxlength="255" onfocus="if( this.value==this.defaultValue ) this.value='';" value="Search" accesskey="s" />
+						<input name="a" type="hidden" value="1"/>
+						<input id="submit" name="submit" type="submit" value="Search" />
+					</div>
+					</form>
+					-->
+
+				</div> <!-- pgSearch -->
+				<br />
+
+				<div id="pgHeader">
+					<div id="pgHeaderLogoLeft">
+						<img alt="PostgreSQL" height="80" width="390" src="../media/img/layout/hdr_left3.png" usemap="#maplinks" />
+						<map name="maplinks">
+							<area shape="rect" coords="0,0,231,80" alt="PostgreSQL" href="https://postgresql.org" />
+							<area shape="rect" coords="232,0,390,80" alt="PostgreSQL JDBC Driver" href="https://jdbc.postgresql.org" />
+						</map>
+					</div>
+					<div id="pgHeaderLogoRight">
+						<a href="https://postgresql.org">
+							<img width="210" height="80" alt="The world's most advanced open source database." src="../media/img/layout/hdr_right.png" />
+						</a>
+					</div>
+				</div> <!-- pgHeader -->
+
+				<div id="pgTopNav">
+					<div id="pgTopNavLeft">
+						<img width="7" style="height: 100%;" alt="" src="../media/img/layout/nav_lft.png" />
+					</div>
+					<div id="pgTopNavRight">
+						<img width="7" style="height: 100%;" alt="" src="../media/img/layout/nav_rgt.png" />
+					</div>
+					<ul id="pgTopNavList">
+						<li><a href="../index.html" title="Home">Home</a></li>
+						<li><a href="../about/about.html" title="About">About</a></li>
+						<li><a href="../download.html" title="Download">Download</a></li>
+						<li><a href="../documentation/documentation.html" title="Documentation">Documentation</a></li>
+						<li><a href="../community/community.html" title="Community">Community</a></li>
+						<li><a href="../development/development.html" title="Development">Development</a></li>
+					</ul>
+				</div> <!-- pgTopNav -->
+			</div> <!-- pgHeaderContainer -->
+
+			<div id="pgContent">
+				<div id="pgSideWrap">
+					<div id="pgSideNav">
+						<ul>
+							<li><a href="about.html">About</a></li>
+							<li><a href="license.html">License</a></li>
+							<li><a href="extras.html">Extras</a></li>
+						</ul>
+					</div> <!-- pgSideNam -->
+				</div> <!-- pgSideWrap -->
+
+				<div id="pgContentWrap">
+					<h1>BSD 2-clause "Simplified" License</h1>
+					<p>
+						The PostgreSQL JDBC Driver is distributed under the BSD-2-Clause License.
+						The simplest explanation of the licensing terms is that
+						you can do whatever you want with the product and source code as long
+						as you don't claim you wrote it or sue us.  You should give it a read
+						though, it's only half a page.
+					</p>
+					<hr />
+
+					<pre  style="font-family: monospace,'Courier'; background-color: #f9f9f9; padding: 1em; border: 1px solid #ddd">
+Copyright (c) 1997, PostgreSQL Global Development Group
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.</pre>
+				</div> <!-- pgContentWrap -->
+
+				<br class="pgClearBoth" />
+			</div> <!-- pgContent -->
+			<hr />
+
+			<div id="pgFooter">
+				<a class="navFooter" href="https://www.postgresql.org/about/privacypolicy">Privacy Policy</a> |
+				<a class="navFooter" href="https://www.postgresql.org/about/">About PostgreSQL</a><br/>
+				Copyright &copy; 1996-2019 The PostgreSQL Global Development Group
+			</div> <!-- pgFooter -->
+		</div> <!-- pgContainer -->
+	</div> <!-- pgContainerWrap -->
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
-        <postgresql.version>9.4.1212</postgresql.version>
+        <postgresql.version>42.2.10</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <licenses.name>Apache License 2.0</licenses.name>
         <licenses.version>${project.version}</licenses.version>


### PR DESCRIPTION
This upgrade is backported to earlier versions in order to fix https://nvd.nist.gov/vuln/detail/CVE-2018-10936 on the postgres-jdbc driver. 