### PR TITLE
Provide Avro Decimal schema connect.decimal.precision parameter

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/data/ConnectDecimal.java
+++ b/src/main/java/io/confluent/connect/jdbc/data/ConnectDecimal.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.data;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+
+/**
+ * Wrapper around Kafka {@link Decimal} to include the additional precision parameter required by
+ * the Connect Avro Decimal schema.
+ */
+public class ConnectDecimal extends Decimal {
+  /**
+   * Used by AvroData serializer for creating an Avro schema with the correct precision.
+   * @see "io.confluent.connect.avro.AvroData.CONNECT_AVRO_DECIMAL_PRECISION_PROP"
+   */
+  public static final String CONNECT_AVRO_PRECISION_FIELD = "connect.decimal.precision";
+
+  /**
+   * Returns a {@link SchemaBuilder} for a Decimal number with a given precision and scale factor.
+   */
+  public static SchemaBuilder builder(int precision, int scale) {
+    return Decimal.builder(scale)
+        .parameter(CONNECT_AVRO_PRECISION_FIELD, String.valueOf(precision));
+  }
+
+  public static Schema schema(int precision, int scale) {
+    return builder(precision, scale).build();
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -88,6 +88,7 @@ import io.confluent.connect.jdbc.util.JdbcDriverInfo;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.data.ConnectDecimal;
 
 /**
  * A {@link DatabaseDialect} implementation that provides functionality based upon JDBC and SQL.
@@ -1013,7 +1014,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       case Types.DECIMAL: {
         log.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
-        SchemaBuilder fieldBuilder = Decimal.builder(scale);
+        SchemaBuilder fieldBuilder = ConnectDecimal.builder(precision, scale);
         if (optional) {
           fieldBuilder.optional();
         }

--- a/src/test/java/io/confluent/connect/jdbc/data/ConnectDecimalTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/data/ConnectDecimalTest.java
@@ -1,0 +1,19 @@
+package io.confluent.connect.jdbc.data;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConnectDecimalTest {
+  private static final String CONNECT_AVRO_PRECISION_FIELD = "connect.decimal.precision";
+
+  /**
+   * Regression test for https://github.com/confluentinc/kafka-connect-jdbc/issues/788
+   */
+  @Test
+  public void testConnectDecimalPrecisionParameter() {
+    Schema schema = ConnectDecimal.builder(5, 2).build();
+    assertEquals(schema.parameters().get(CONNECT_AVRO_PRECISION_FIELD), "5");
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -41,6 +41,7 @@ import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import io.confluent.connect.jdbc.data.ConnectDecimal;
 
 // Tests conversion of data types and schemas. These use the types supported by Derby, which
 // might not cover everything in the SQL standards and definitely doesn't cover any non-standard
@@ -221,16 +222,16 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   public void testDecimal() throws Exception {
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-                   Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
+                   ConnectDecimal.schema(5, 2), new BigDecimal(new BigInteger("12345"), 2));
   }
 
   @Test
   public void testNullableDecimal() throws Exception {
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-                   Decimal.builder(2).optional().build(),
+                   ConnectDecimal.builder(5, 2).optional().parameter("connect.decimal.precision", "5").build(),
                    new BigDecimal(new BigInteger("12345"), 2));
-    typeConversion("DECIMAL(5,2)", true, null, Decimal.builder(2).optional().build(),
+    typeConversion("DECIMAL(5,2)", true, null, ConnectDecimal.builder(5,2).optional().build(),
                    null);
   }
 


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-jdbc/issues/788

Schema Registry `AvroData` converter uses a connect.decimal.precision
parameter https://github.com/confluentinc/schema-registry/blob/master/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java#L252
when performing serde for logical Decimal schema. This is also required by KSQL for the same reason https://github.com/confluentinc/ksql/issues/4602#issuecomment-591369585 .

This adds a new
`ConnectDecimal` class to provide this and replace uses of org.apache.kafka.connect.data.Decimal
where appropriate.

I have tested this using the [example repo](https://github.com/SteadBytes/ksql-numeric-types-issue) from the original issue (loading the new jar into the `connect` docker container) - the schema is generated correctly and the KSQL queries no longer produce errors. I have not run integration tests with databases other than PostgreSQL in the example repo as I this change should be independent of database type - please correct me if I'm wrong! :smiley: 

I wasn't sure on the licence comment other than that the maven style check failed without it - please let me know if that needs changing :+1: 