### PR TITLE
Added support for arrays of primitives in Postgres dialect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <confluent.version>${project.version}</confluent.version>
         <derby.version>10.14.2.0</derby.version>
         <commons-io.version>2.4</commons-io.version>
+        <commons-lang.version>3.9</commons-lang.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>42.2.10</postgresql.version>
@@ -162,6 +163,12 @@
             <artifactId>mariadb-java-client</artifactId>
             <version>2.5.3</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -276,4 +276,22 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
+  @Override
+  protected boolean maybeBindPrimitive(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value
+  ) throws SQLException {
+
+    switch (schema.type()) {
+      case ARRAY:
+        statement.setObject(index, value, Types.ARRAY);
+        return true;
+      default:
+        break;
+    }
+    return super.maybeBindPrimitive(statement, index, schema, value);
+  }
+
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -317,6 +317,14 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     PreparedStatement statement = mock(PreparedStatement.class);
     int index = ThreadLocalRandom.current().nextInt();
 
-    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT8_SCHEMA), new int[] { 42 }).setObject(index, new int[] { 42 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT32_SCHEMA), new int[] { 42 }).setObject(index, new int[] { 42 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT8_SCHEMA), Arrays.asList( (byte) 42, (byte) 12)).setObject(index, new short[] { 42, 12 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT16_SCHEMA), Arrays.asList( (short) 42, (short) 12)).setObject(index, new short[] { 42, 12 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT32_SCHEMA), Arrays.asList(42, 16 )).setObject(index, new int[] { 42, 16 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT64_SCHEMA), Arrays.asList(42L, 16L )).setObject(index, new long[] { 42, 16 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.FLOAT32_SCHEMA), Arrays.asList(42.5F, 16.2F )).setObject(index, new float[] { 42.5F, 16.2F }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.FLOAT64_SCHEMA), Arrays.asList(42.5D, 16.2D )).setObject(index, new double[] { 42.5D, 16.2D }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.STRING_SCHEMA), Arrays.asList("42", "16" )).setObject(index, new String[] { "42", "16" }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.BOOLEAN_SCHEMA), Arrays.asList(true, false, true )).setObject(index, new boolean[] { true, false, true }, Types.ARRAY);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -15,21 +15,26 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Types;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
@@ -299,5 +304,19 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
         "jdbc:postgresql://localhost/test?user=fred&password=****&ssl=true"
     );
+  }
+
+  @Test
+  @Override
+  public void bindFieldArrayUnsupported() throws SQLException {
+      // Overridden simply to dummy out the test.
+  }
+
+  @Test
+  public void bindFieldPrimitiveValues() throws SQLException {
+    PreparedStatement statement = mock(PreparedStatement.class);
+    int index = ThreadLocalRandom.current().nextInt();
+
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT8_SCHEMA), new int[] { 42 }).setObject(index, new int[] { 42 }, Types.ARRAY);
   }
 }


### PR DESCRIPTION
While this won't help with arrays of complex types, it was fairly straightforward to piggyback on pgjdbc's setObject auto-casting to get at least some support for arrays of values in the sink connector. 