### PR TITLE
Basic master branch build/test CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+
+jdk: openjdk8
+
+before_install:
+  # https://github.com/confluentinc/kafka-connect-jdbc/wiki/FAQ
+  - git clone https://github.com/confluentinc/kafka.git && pushd kafka && ./gradlew installAll && popd
+  - git clone https://github.com/confluentinc/common && pushd common && mvn install && popd
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.m2


### PR DESCRIPTION
Confluent uses a long lived branch development workflow, where Confluent
Platform versions are major branches e.g. 5.4.x. Release branches/tags have
fully pinned dependencies (e.g. in pom.xml), whereas development
branches often use SNAPSHOT dependencies (e.g. Kafka 6.0.0-SNAPSHOT). As
such, master is always the latest development branch using SNAPSHOT
versions of dependencies. This commit introduces a simple build/test
workflow for Travis CI to ensure our master branch is up to date with
upstream.

Further PRs will follow for building Docker images for pinned version branches that we make patches for.