### PR TITLE
CC-8418: set default timezone for certain drivers

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -222,6 +222,10 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     // handshake, while still giving enough time to validate once in the follower worker,
     // and again in the leader worker and still be under 90s REST serving timeout
     DriverManager.setLoginTimeout(40);
+
+    // some drivers i.e oracle11g do not recognize timezones if this is not set
+    TimeZone.setDefault(timeZone);
+
     Connection connection = DriverManager.getConnection(jdbcUrl, properties);
     if (jdbcDriverInfo == null) {
       jdbcDriverInfo = createJdbcDriverInfo(connection);


### PR DESCRIPTION
this PR attempts to fix the `timezone region not found` issue for certain drivers such as oracle11g 
https://stackoverflow.com/questions/9156379/ora-01882-timezone-region-not-found

Signed-off-by: Lev Zemlyanov <lev@confluent.io>