### PR TITLE
MINOR: Retain chain of SQLException exceptions

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -80,18 +80,20 @@ public class JdbcSinkTask extends SinkTask {
           remainingRetries,
           sqle
       );
-      String sqleAllMessages = "";
+      String sqleAllMessages = "Exception chain:" + System.lineSeparator();
       for (Throwable e : sqle) {
         sqleAllMessages += e + System.lineSeparator();
       }
+      SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
+      sqlAllMessagesException.setNextException(sqle);
       if (remainingRetries == 0) {
-        throw new ConnectException(new SQLException(sqleAllMessages));
+        throw new ConnectException(sqlAllMessagesException);
       } else {
         writer.closeQuietly();
         initWriter();
         remainingRetries--;
         context.timeout(config.retryBackoffMs);
-        throw new RetriableException(new SQLException(sqleAllMessages));
+        throw new RetriableException(sqlAllMessagesException);
       }
     }
     remainingRetries = config.maxRetries;

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
@@ -216,7 +218,10 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     SinkTaskContext ctx = createMock(SinkTaskContext.class);
 
     mockWriter.write(records);
-    expectLastCall().andThrow(new SQLException()).times(1 + maxRetries);
+    SQLException chainedException = new SQLException("cause 1");
+    chainedException.setNextException(new SQLException("cause 2"));
+    chainedException.setNextException(new SQLException("cause 3"));
+    expectLastCall().andThrow(chainedException).times(1 + maxRetries);
 
     ctx.timeout(retryBackoffMs);
     expectLastCall().times(maxRetries);
@@ -244,12 +249,28 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       task.put(records);
       fail();
     } catch (RetriableException expected) {
+      assertEquals(SQLException.class, expected.getCause().getClass());
+      int i = 0;
+      for (Throwable t : (SQLException) expected.getCause()) {
+        ++i;
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        System.out.println("Chained exception " + i + ": " + sw);
+      }
     }
 
     try {
       task.put(records);
       fail();
     } catch (RetriableException expected) {
+      assertEquals(SQLException.class, expected.getCause().getClass());
+      int i = 0;
+      for (Throwable t : (SQLException) expected.getCause()) {
+        ++i;
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        System.out.println("Chained exception " + i + ": " + sw);
+      }
     }
 
     try {
@@ -259,6 +280,13 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       fail("Non-retriable exception expected");
     } catch (ConnectException expected) {
       assertEquals(SQLException.class, expected.getCause().getClass());
+      int i = 0;
+      for (Throwable t : (SQLException) expected.getCause()) {
+        ++i;
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        System.out.println("Chained exception " + i + ": " + sw);
+      }
     }
 
     verifyAll();


### PR DESCRIPTION
Instead of just keeping the exception names when a series of SQLException exceptions is thrown, keep the exceptions themselves as well within the `ConnectException`. 