### PR TITLE
CC-8651: Backport docs copy-edits to config docstrings.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -184,7 +184,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_GROUP = "Connection";
   private static final String WRITES_GROUP = "Writes";
   private static final String DATAMAPPING_GROUP = "Data Mapping";
-  private static final String DDL_GROUP = "SQL/DDL Support";
+  private static final String DDL_GROUP = "DDL Support";
   private static final String RETRIES_GROUP = "Retries";
 
   public static final String DIALECT_NAME_CONFIG = "dialect.name";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -108,15 +108,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "Precision (deprecated)";
 
   private static final String NUMERIC_MAPPING_DOC =
-      "Map NUMERIC values by precision and optionally scale to integral or decimal types. Use "
-      + "``none`` if all NUMERIC columns are to be represented by Connect's DECIMAL logical "
-      + "type. Use ``best_fit`` if NUMERIC columns should be cast to Connect's INT8, INT16, "
-      + "INT32, INT64, or FLOAT64 based upon the column's precision and scale. Or use "
-      + "``precision_only`` to map NUMERIC columns based only on the column's precision "
-      + "assuming that column's scale is 0. The ``none`` option is the default, but may lead "
-      + "to serialization issues with Avro since Connect's DECIMAL type is mapped to its "
-      + "binary representation, and ``best_fit`` will often be preferred since it maps to the"
-      + " most appropriate primitive type.";
+      "Map NUMERIC values by precision and optionally scale to integral or decimal types.\n"
+      + "  * Use ``none`` if all NUMERIC columns are to be represented by Connect's DECIMAL logical "
+      + "type.\n"
+      + "  * Use ``best_fit`` if NUMERIC columns should be cast to Connect's INT8, INT16, "
+      + "INT32, INT64, or FLOAT64 based upon the column's precision and scale.\n"
+      + "  * Use ``precision_only`` to map NUMERIC columns based only on the column's precision "
+      + "assuming that column's scale is 0.\n"
+      + "  * The ``none`` option is the default, but may lead to serialization issues with Avro "
+      + "since Connect's DECIMAL type is mapped to its binary representation, and ``best_fit`` "
+      + "will often be preferred since it maps to the most appropriate primitive type.";
 
   public static final String NUMERIC_MAPPING_DEFAULT = null;
   private static final String NUMERIC_MAPPING_DISPLAY = "Map Numeric Values, Integral "
@@ -138,14 +139,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String MODE_CONFIG = "mode";
   private static final String MODE_DOC =
       "The mode for updating a table each time it is polled. Options include:\n"
-      + "  * bulk - perform a bulk load of the entire table each time it is polled\n"
-      + "  * incrementing - use a strictly incrementing column on each table to "
+      + "  * bulk: perform a bulk load of the entire table each time it is polled\n"
+      + "  * incrementing: use a strictly incrementing column on each table to "
       + "detect only new rows. Note that this will not detect modifications or "
       + "deletions of existing rows.\n"
-      + "  * timestamp - use a timestamp (or timestamp-like) column to detect new and modified "
+      + "  * timestamp: use a timestamp (or timestamp-like) column to detect new and modified "
       + "rows. This assumes the column is updated with each write, and that values are "
       + "monotonically incrementing, but not necessarily unique.\n"
-      + "  * timestamp+incrementing - use two columns, a timestamp column that detects new and "
+      + "  * timestamp+incrementing: use two columns, a timestamp column that detects new and "
       + "modified rows and a strictly incrementing column which provides a globally unique ID for "
       + "updates so each row can be assigned a unique stream offset.";
   private static final String MODE_DISPLAY = "Table Loading Mode";
@@ -184,31 +185,35 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public static final String TABLE_WHITELIST_CONFIG = "table.whitelist";
   private static final String TABLE_WHITELIST_DOC =
-      "List of tables to include in copying. If specified, table.blacklist may not be set.";
+      "List of tables to include in copying. If specified, ``table.blacklist`` may not be set. "
+      + "Use a comma-separated list to specify multiple tables "
+      + "(for example, ``table.whitelist: \"User, Address, Email\"``).";
   public static final String TABLE_WHITELIST_DEFAULT = "";
   private static final String TABLE_WHITELIST_DISPLAY = "Table Whitelist";
 
   public static final String TABLE_BLACKLIST_CONFIG = "table.blacklist";
   private static final String TABLE_BLACKLIST_DOC =
-      "List of tables to exclude from copying. If specified, table.whitelist may not be set.";
+    "List of tables to exclude from copying. If specified, ``table.whitelist`` may not be set. "
+      + "Use a comma-separated list to specify multiple tables "
+      + "(for example, ``table.blacklist: \"User, Address, Email\"``).";
   public static final String TABLE_BLACKLIST_DEFAULT = "";
   private static final String TABLE_BLACKLIST_DISPLAY = "Table Blacklist";
 
   public static final String SCHEMA_PATTERN_CONFIG = "schema.pattern";
   private static final String SCHEMA_PATTERN_DOC =
-      "Schema pattern to fetch table metadata from the database:\n"
-      + "  * \"\" retrieves those without a schema,"
-      + "  * null (default) means that the schema name should not be used to narrow the search,"
-      + " so that all table metadata would be fetched, regardless of their schema.";
+      "Schema pattern to fetch table metadata from the database.\n"
+      + "  * ``\"\"`` retrieves those without a schema.\n"
+      + "  * null (default) indicates that the schema name is not used to narrow the search and "
+      + "that all table metadata is fetched, regardless of the schema.";
   private static final String SCHEMA_PATTERN_DISPLAY = "Schema pattern";
   public static final String SCHEMA_PATTERN_DEFAULT = null;
 
   public static final String CATALOG_PATTERN_CONFIG = "catalog.pattern";
   private static final String CATALOG_PATTERN_DOC =
-      "Catalog pattern to fetch table metadata from the database:\n"
-      + "  * \"\" retrieves those without a catalog,"
-      + "  * null (default) means that the catalog name should not be used to narrow the search"
-      + " so that all table metadata would be fetched, regardless of their catalog.";
+      "Catalog pattern to fetch table metadata from the database.\n"
+      + "  * ``\"\"`` retrieves those without a catalog \n"
+      + "  * null (default) indicates that the schema name is not used to narrow the search and "
+        + "that all table metadata is fetched, regardless of the catalog.";
   private static final String CATALOG_PATTERN_DISPLAY = "Schema pattern";
   public static final String CATALOG_PATTERN_DEFAULT = null;
 
@@ -251,7 +256,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String DB_TIMEZONE_CONFIG = "db.timezone";
   public static final String DB_TIMEZONE_DEFAULT = "UTC";
   private static final String DB_TIMEZONE_CONFIG_DOC =
-      "Name of the JDBC timezone that should be used in the connector when "
+      "Name of the JDBC timezone used in the connector when "
           + "querying with time-based criteria. Defaults to UTC.";
   private static final String DB_TIMEZONE_CONFIG_DISPLAY = "DB time zone";
 
@@ -259,7 +264,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String QUOTE_SQL_IDENTIFIERS_DEFAULT = QuoteMethod.ALWAYS.name().toString();
   public static final String QUOTE_SQL_IDENTIFIERS_DOC =
       "When to quote table names, column names, and other identifiers in SQL statements. "
-      + "For backward compatibility, the default is 'always'.";
+      + "For backward compatibility, the default is ``always``.";
   public static final String QUOTE_SQL_IDENTIFIERS_DISPLAY = "Quote Identifiers";
 
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
@@ -285,14 +290,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       "By default, the JDBC connector will only detect tables with type TABLE from the source "
       + "Database. This config allows a command separated list of table types to extract. Options"
       + " include:\n"
-      + "* TABLE\n"
-      + "* VIEW\n"
-      + "* SYSTEM TABLE\n"
-      + "* GLOBAL TEMPORARY\n"
-      + "* LOCAL TEMPORARY\n"
-      + "* ALIAS\n"
-      + "* SYNONYM\n"
-      + "In most cases it only makes sense to have either TABLE or VIEW.";
+      + "  * TABLE\n"
+      + "  * VIEW\n"
+      + "  * SYSTEM TABLE\n"
+      + "  * GLOBAL TEMPORARY\n"
+      + "  * LOCAL TEMPORARY\n"
+      + "  * ALIAS\n"
+      + "  * SYNONYM\n"
+      + "  In most cases it only makes sense to have either TABLE or VIEW.";
   private static final String TABLE_TYPE_DISPLAY = "Table Types";
 
   public static ConfigDef baseConfigDef() {
@@ -392,7 +397,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         SCHEMA_PATTERN_CONFIG,
         Type.STRING,
         SCHEMA_PATTERN_DEFAULT,
-        Importance.MEDIUM,
+        Importance.HIGH,
         SCHEMA_PATTERN_DOC,
         DATABASE_GROUP,
         ++orderInGroup,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -109,8 +109,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   private static final String NUMERIC_MAPPING_DOC =
       "Map NUMERIC values by precision and optionally scale to integral or decimal types.\n"
-      + "  * Use ``none`` if all NUMERIC columns are to be represented by Connect's DECIMAL logical "
-      + "type.\n"
+      + "  * Use ``none`` if all NUMERIC columns are to be represented by Connect's DECIMAL "
+      + "logical type.\n"
       + "  * Use ``best_fit`` if NUMERIC columns should be cast to Connect's INT8, INT16, "
       + "INT32, INT64, or FLOAT64 based upon the column's precision and scale.\n"
       + "  * Use ``precision_only`` to map NUMERIC columns based only on the column's precision "
@@ -193,7 +193,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public static final String TABLE_BLACKLIST_CONFIG = "table.blacklist";
   private static final String TABLE_BLACKLIST_DOC =
-    "List of tables to exclude from copying. If specified, ``table.whitelist`` may not be set. "
+      "List of tables to exclude from copying. If specified, ``table.whitelist`` may not be set. "
       + "Use a comma-separated list to specify multiple tables "
       + "(for example, ``table.blacklist: \"User, Address, Email\"``).";
   public static final String TABLE_BLACKLIST_DEFAULT = "";


### PR DESCRIPTION
The configuration RST generated by this connector has diverged significantly from docs.
This PR makes them more similar, but not the same. Several changes were left in the docs themselves.

Signed-off-by: Greg Harris <gregh@confluent.io>