### PR TITLE
CC-8823: Add support for the JDBC sink to write to views in addition to tables

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -32,6 +32,7 @@ import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableDefinitions;
 import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.TableType;
 
 public class DbStructure {
   private static final Logger log = LoggerFactory.getLogger(DbStructure.class);
@@ -42,6 +43,11 @@ public class DbStructure {
   public DbStructure(DatabaseDialect dbDialect) {
     this.dbDialect = dbDialect;
     this.tableDefns = new TableDefinitions(dbDialect);
+  }
+
+  public DbStructure(TableDefinitions tableDefinitions) {
+    this.dbDialect = tableDefinitions.dialect();
+    this.tableDefns = tableDefinitions;
   }
 
   /**
@@ -127,18 +133,41 @@ public class DbStructure {
       return false;
     }
 
+    // At this point there are missing fields
+    TableType type = tableDefn.type();
+    switch (type) {
+      case TABLE:
+        // Rather than embed the logic and change lots of lines, just break out
+        break;
+      case VIEW:
+      default:
+        throw new ConnectException(
+            String.format(
+                "%s %s is missing fields (%s) and ALTER %s is unsupported",
+                type.capitalized(),
+                tableId,
+                missingFields,
+                type.jdbcName()
+            )
+        );
+    }
+
     for (SinkRecordField missingField: missingFields) {
       if (!missingField.isOptional() && missingField.defaultValue() == null) {
-        throw new ConnectException(
-            "Cannot ALTER to add missing field " + missingField
-            + ", as it is not optional and does not have a default value"
-        );
+        throw new ConnectException(String.format(
+            "Cannot ALTER %s %s to add missing field %s, as the field is not optional and does "
+            + "not have a default value",
+            type.jdbcName(),
+            tableId,
+            missingField
+        ));
       }
     }
 
     if (!config.autoEvolve) {
       throw new ConnectException(String.format(
-          "Table %s is missing fields (%s) and auto-evolution is disabled",
+          "%s %s is missing fields (%s) and auto-evolution is disabled",
+          type.capitalized(),
           tableId,
           missingFields
       ));
@@ -146,7 +175,8 @@ public class DbStructure {
 
     final List<String> amendTableQueries = dbDialect.buildAlterTable(tableId, missingFields);
     log.info(
-        "Amending table to add missing fields:{} maxRetries:{} with SQL: {}",
+        "Amending %s to add missing fields:{} maxRetries:{} with SQL: {}",
+        type,
         missingFields,
         maxRetries,
         amendTableQueries
@@ -157,7 +187,8 @@ public class DbStructure {
       if (maxRetries <= 0) {
         throw new ConnectException(
             String.format(
-                "Failed to amend table '%s' to add missing fields: %s",
+                "Failed to amend %s '%s' to add missing fields: %s",
+                type,
                 tableId,
                 missingFields
             ),

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
+import io.confluent.connect.jdbc.util.TableDefinitions;
 
 public class JdbcSinkTask extends SinkTask {
   private static final Logger log = LoggerFactory.getLogger(JdbcSinkTask.class);
@@ -52,7 +53,8 @@ public class JdbcSinkTask extends SinkTask {
     } else {
       dialect = DatabaseDialects.findBestFor(config.connectionUrl, config);
     }
-    final DbStructure dbStructure = new DbStructure(dialect);
+    TableDefinitions tableDefns = new TableDefinitions(dialect, config.tableTypes);
+    final DbStructure dbStructure = new DbStructure(tableDefns);
     log.info("Initializing writer using SQL dialect: {}", dialect.getClass().getSimpleName());
     writer = new JdbcDbWriter(config, dialect, dbStructure);
   }

--- a/src/main/java/io/confluent/connect/jdbc/util/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/EnumRecommender.java
@@ -49,6 +49,21 @@ public class EnumRecommender implements ConfigDef.Validator, ConfigDef.Recommend
 
   @Override
   public void ensureValid(String key, Object value) {
+    if (value instanceof List) {
+      List<?> values = (List<?>) value;
+      for (Object v : values) {
+        if (v == null) {
+          validate(key, null);
+        } else {
+          validate(key, v);
+        }
+      }
+    } else {
+      validate(key, value);
+    }
+  }
+
+  protected void validate(String key, Object value) {
     // calling toString on itself because IDE complains if the Object is passed.
     if (value != null && !validValues.contains(value.toString())) {
       throw new ConfigException(key, value, "Invalid enumerator");

--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinition.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinition.java
@@ -26,12 +26,23 @@ public class TableDefinition {
   private final TableId id;
   private final Map<String, ColumnDefinition> columnsByName = new LinkedHashMap<>();
   private final Map<String, String> pkColumnNames = new LinkedHashMap<>();
+  private final TableType type;
+
 
   public TableDefinition(
       TableId id,
       Iterable<ColumnDefinition> columns
   ) {
+    this(id, columns, TableType.TABLE);
+  }
+
+  public TableDefinition(
+      TableId id,
+      Iterable<ColumnDefinition> columns,
+      TableType type
+  ) {
     this.id = id;
+    this.type = type;
     for (ColumnDefinition defn : columns) {
       String columnName = defn.id().name();
       columnsByName.put(
@@ -49,6 +60,10 @@ public class TableDefinition {
 
   public TableId id() {
     return id;
+  }
+
+  public TableType type() {
+    return type;
   }
 
   public int columnCount() {

--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ public class TableDefinitions {
 
   private final Map<TableId, TableDefinition> cache = new HashMap<>();
   private final DatabaseDialect dialect;
+  private final EnumSet<TableType> allowedTypes;
 
   /**
    * Create an instance that uses the specified database dialect.
@@ -40,7 +42,22 @@ public class TableDefinitions {
    * @param dialect the database dialect; may not be null
    */
   public TableDefinitions(DatabaseDialect dialect) {
+    this(dialect, EnumSet.of(TableType.TABLE));
+  }
+
+  /**
+   * Create an instance that uses the specified database dialect.
+   *
+   * @param dialect      the database dialect; may not be null
+   * @param allowedTypes the allowed table types to discover; may not be null or empty
+   */
+  public TableDefinitions(DatabaseDialect dialect, EnumSet<TableType> allowedTypes) {
     this.dialect = dialect;
+    this.allowedTypes = allowedTypes;
+  }
+
+  public DatabaseDialect dialect() {
+    return dialect;
   }
 
   /**
@@ -58,7 +75,7 @@ public class TableDefinitions {
     TableDefinition dbTable = cache.get(tableId);
     if (dbTable == null) {
       if (dialect.tableExists(connection, tableId)) {
-        dbTable = dialect.describeTable(connection, tableId);
+        dbTable = dialect.describeTable(connection, tableId, allowedTypes);
         if (dbTable != null) {
           log.info("Setting metadata for table {} to {}", tableId, dbTable);
           cache.put(tableId, dbTable);

--- a/src/main/java/io/confluent/connect/jdbc/util/TableType.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableType.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum TableType {
+
+  TABLE("table", "Table"), VIEW("view", "View");
+
+  private final String lowercase;
+  private final String capitalCase;
+  private final String jdbcCase;
+
+  TableType(String value, String capitalCase) {
+    this.lowercase = value.toLowerCase();
+    this.jdbcCase = value.toUpperCase();
+    this.capitalCase = capitalCase;
+  }
+
+  public String capitalized() {
+    return capitalCase;
+  }
+
+  public String jdbcName() {
+    return jdbcCase;
+  }
+
+  @Override
+  public String toString() {
+    return lowercase;
+  }
+
+  public static TableType get(String name) {
+    if (name != null) {
+      name = name.trim();
+    }
+    for (TableType method : values()) {
+      if (method.toString().equalsIgnoreCase(name)) {
+        return method;
+      }
+    }
+    throw new IllegalArgumentException("No matching QuoteMethod found for '" + name + "'");
+  }
+
+  public static EnumSet<TableType> parse(Collection<String> values) {
+    Set<TableType> types = values.stream().map(TableType::get).collect(Collectors.toSet());
+    return EnumSet.copyOf(types);
+  }
+
+  public static String asJdbcTableTypeNames(EnumSet<TableType> types, String delim) {
+    return types.stream()
+                .map(TableType::jdbcName)
+                .sorted()
+                .collect(Collectors.joining(delim));
+  }
+
+  public static String[] asJdbcTableTypeArray(EnumSet<TableType> types) {
+    return types.stream()
+                .map(TableType::jdbcName)
+                .sorted()
+                .collect(Collectors.toList())
+                .toArray(new String[types.size()]);
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 
 import static org.junit.Assert.assertEquals;
@@ -17,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 public class DbStructureTest {
 
-  DbStructure structure = new DbStructure(null);
+  DbStructure structure = new DbStructure((DatabaseDialect) null);
 
   @Test
   public void testNoMissingFields() {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.util.TableType;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdbcSinkConfigTest {
+
+  private Map<String, String> props = new HashMap<>();
+  private JdbcSinkConfig config;
+
+  @Before
+  public void beforeEach() {
+    // add the minimum settings only
+    props.put("connection.url", "jdbc:mysql://something"); // we won't connect
+  }
+
+  @After
+  public void afterEach() {
+    props.clear();
+    config = null;
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldFailToCreateConfigWithoutConnectionUrl() {
+    props.remove(JdbcSinkConfig.CONNECTION_URL);
+    createConfig();
+  }
+
+  @Test
+  public void shouldCreateConfigWithMinimalConfigs() {
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldCreateConfigWithAdditionalConfigs() {
+    props.put("auto.create", "true");
+    props.put("pk.mode", "kafka");
+    props.put("pk.fields", "kafka_topic,kafka_partition,kafka_offset");
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldCreateConfigWithViewOnly() {
+    props.put("table.types", "view");
+    createConfig();
+    assertTableTypes(TableType.VIEW);
+  }
+
+  @Test
+  public void shouldCreateConfigWithTableOnly() {
+    props.put("table.types", "table");
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldCreateConfigWithViewAndTable() {
+    props.put("table.types", "view,table");
+    createConfig();
+    assertTableTypes(TableType.TABLE, TableType.VIEW);
+    props.put("table.types", "table,view");
+    createConfig();
+    assertTableTypes(TableType.TABLE, TableType.VIEW);
+    props.put("table.types", "table , view");
+    createConfig();
+    assertTableTypes(TableType.TABLE, TableType.VIEW);
+  }
+
+  @Test
+  public void shouldCreateConfigWithLeadingWhitespaceInTableTypes() {
+    props.put("table.types", " \t\n  view");
+    createConfig();
+    assertTableTypes(TableType.VIEW);
+  }
+
+  @Test
+  public void shouldCreateConfigWithTrailingWhitespaceInTableTypes() {
+    props.put("table.types", "table \t \n");
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  protected void createConfig() {
+    config = new JdbcSinkConfig(props);
+  }
+
+  protected void assertTableTypes(TableType...types) {
+    EnumSet<TableType> expected = EnumSet.copyOf(Arrays.asList(types));
+    EnumSet<TableType> tableTypes = config.tableTypes;
+    assertEquals(expected, tableTypes);
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TableTypeTest {
+
+  private static EnumSet<TableType> TABLE_ONLY = types(TableType.TABLE);
+  private static EnumSet<TableType> VIEW_ONLY = types(TableType.VIEW);
+  private static EnumSet<TableType> TABLE_AND_VIEW = types(TableType.TABLE, TableType.VIEW);
+
+  @Test
+  public void shouldParseLowercaseTypes() {
+    assertEquals(TableType.TABLE, TableType.get("table"));
+    assertEquals(TableType.VIEW, TableType.get("view"));
+  }
+
+  @Test
+  public void shouldParseUppercaseTypes() {
+    assertEquals(TableType.TABLE, TableType.get("TABLE"));
+    assertEquals(TableType.VIEW, TableType.get("VIEW"));
+  }
+
+  @Test
+  public void shouldParseMixedcaseTypes() {
+    assertEquals(TableType.TABLE, TableType.get("Table"));
+    assertEquals(TableType.VIEW, TableType.get("vIeW"));
+  }
+
+  @Test
+  public void shouldParseTypeStringWithWhitespace() {
+    assertEquals(TableType.TABLE, TableType.get(" table \t"));
+    assertEquals(TableType.VIEW, TableType.get("VIEW \t\n "));
+  }
+
+  @Test
+  public void shouldComputeJdbcTypeArray() {
+    assertArrayEquals(array("TABLE"), TableType.asJdbcTableTypeArray(TABLE_ONLY));
+    assertArrayEquals(array("VIEW"), TableType.asJdbcTableTypeArray(VIEW_ONLY));
+    assertArrayEquals(array("TABLE", "VIEW"), TableType.asJdbcTableTypeArray(TABLE_AND_VIEW));
+  }
+
+  @Test
+  public void shouldComputeJdbcTypeNames() {
+    assertEquals("TABLE", TableType.asJdbcTableTypeNames(TABLE_ONLY, "/"));
+    assertEquals("VIEW", TableType.asJdbcTableTypeNames(VIEW_ONLY, "/"));
+    assertEquals("TABLE/VIEW", TableType.asJdbcTableTypeNames(TABLE_AND_VIEW, "/"));
+  }
+
+  protected static EnumSet<TableType> types(TableType...types) {
+    return EnumSet.copyOf(Arrays.asList(types));
+  }
+
+  protected static String[] array(String...strs) {
+    return strs;
+  }
+
+}


### PR DESCRIPTION
This change allows the JDBC sink to optionally write to tables (by default), views, or a combination.
A new low-importance `table.types` configuration property has been added to the JDBC sink config, with `table` and/or `view` as allowed values, with `table` being the default to maintain backward compatibility when people upgrade. Note that the JDBC sink connector does not attempt to alter a view that does not match the sink records' schemas, and in such cases the sink connector always fails.

The changes are backward compatible (mostly through avoiding changes to signatures), so any connector that reused the JDBC sink classes should automatically work with these changes. Any connector that extends the generic dialect and should get all of the functionality for free.