### PR TITLE
CC-8823: Add support for the JDBC sink to write to views in addition to tables

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -550,7 +550,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         tableId.catalogName(),
         tableId.schemaName(),
         tableId.tableName(),
-        new String[]{"TABLE"}
+        tableTypes
     )) {
       final boolean exists = rs.next();
       log.info(

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -33,6 +33,7 @@ import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableDefinitions;
 import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.TableType;
 
 public class DbStructure {
   private static final Logger log = LoggerFactory.getLogger(DbStructure.class);
@@ -128,20 +129,41 @@ public class DbStructure {
       return false;
     }
 
-    for (SinkRecordField missingField: missingFields) {
-      if (!missingField.isOptional() && missingField.defaultValue() == null) {
+    // At this point there are missing fields
+    TableType type = tableDefn.type();
+    switch (type) {
+      case TABLE:
+        // Rather than embed the logic and change lots of lines, just break out
+        break;
+      case VIEW:
+      default:
         throw new ConnectException(
             String.format(
-                "Cannot ALTER %s to add missing field %s, as it is not optional and "
-                    + "does not have a default value",
-                tableId, missingField)
+                "%s %s is missing fields (%s) and ALTER %s is unsupported",
+                type.capitalized(),
+                tableId,
+                missingFields,
+                type.jdbcName()
+            )
         );
+    }
+
+    for (SinkRecordField missingField: missingFields) {
+      if (!missingField.isOptional() && missingField.defaultValue() == null) {
+        throw new ConnectException(String.format(
+            "Cannot ALTER %s %s to add missing field %s, as the field is not optional and does "
+            + "not have a default value",
+            type.jdbcName(),
+            tableId,
+            missingField
+        ));
       }
     }
 
     if (!config.autoEvolve) {
       throw new ConnectException(String.format(
-          "Table %s is missing fields (%s) and auto-evolution is disabled",
+          "%s %s is missing fields (%s) and auto-evolution is disabled",
+          type.capitalized(),
           tableId,
           missingFields
       ));
@@ -149,7 +171,8 @@ public class DbStructure {
 
     final List<String> amendTableQueries = dbDialect.buildAlterTable(tableId, missingFields);
     log.info(
-        "Amending table to add missing fields:{} maxRetries:{} with SQL: {}",
+        "Amending %s to add missing fields:{} maxRetries:{} with SQL: {}",
+        type,
         missingFields,
         maxRetries,
         amendTableQueries
@@ -160,7 +183,8 @@ public class DbStructure {
       if (maxRetries <= 0) {
         throw new ConnectException(
             String.format(
-                "Failed to amend table '%s' to add missing fields: %s",
+                "Failed to amend %s '%s' to add missing fields: %s",
+                type,
                 tableId,
                 missingFields
             ),

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -171,7 +171,7 @@ public class DbStructure {
 
     final List<String> amendTableQueries = dbDialect.buildAlterTable(tableId, missingFields);
     log.info(
-        "Amending %s to add missing fields:{} maxRetries:{} with SQL: {}",
+        "Amending {} to add missing fields:{} maxRetries:{} with SQL: {}",
         type,
         missingFields,
         maxRetries,

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -230,9 +230,10 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String TABLE_TYPES_DOC =
       "The comma-separated types of database tables to which the sink connector can write. "
       + "By default this is ``" + TableType.TABLE + "``, but any combination of ``"
-      + TableType.TABLE + "`` and ``" + TableType.VIEW + "`` is allowed. Note that when "
-      + "views are included, the sink connector will fail if the view definition does not match "
-      + "the records' schemas.";
+      + TableType.TABLE + "`` and ``" + TableType.VIEW + "`` is allowed. Not all databases "
+      + "support writing to views, and when they do the the sink connector will fail if the "
+      + "view definition does not match the records' schemas (regardless of ``"
+      + AUTO_EVOLVE + "``).";
 
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 
@@ -500,6 +501,14 @@ public class JdbcSinkConfig extends AbstractConfig {
       return password.value();
     }
     return null;
+  }
+
+  public EnumSet<TableType> tableTypes() {
+    return tableTypes;
+  }
+
+  public Set<String> tableTypeNames() {
+    return tableTypes().stream().map(TableType::toString).collect(Collectors.toSet());
   }
 
   private static class EnumValidator implements ConfigDef.Validator {

--- a/src/main/java/io/confluent/connect/jdbc/util/EnumRecommender.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/EnumRecommender.java
@@ -48,6 +48,21 @@ public class EnumRecommender implements ConfigDef.Validator, ConfigDef.Recommend
 
   @Override
   public void ensureValid(String key, Object value) {
+    if (value instanceof List) {
+      List<?> values = (List<?>) value;
+      for (Object v : values) {
+        if (v == null) {
+          validate(key, null);
+        } else {
+          validate(key, v);
+        }
+      }
+    } else {
+      validate(key, value);
+    }
+  }
+
+  protected void validate(String key, Object value) {
     // calling toString on itself because IDE complains if the Object is passed.
     if (value != null && !validValues.contains(value.toString())) {
       throw new ConfigException(key, value, "Invalid enumerator");

--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinition.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinition.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc.util;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -27,12 +28,22 @@ public class TableDefinition {
   private final TableId id;
   private final Map<String, ColumnDefinition> columnsByName = new LinkedHashMap<>();
   private final Map<String, String> pkColumnNames = new LinkedHashMap<>();
+  private final TableType type;
 
   public TableDefinition(
       TableId id,
       Iterable<ColumnDefinition> columns
   ) {
+    this(id, columns, TableType.TABLE);
+  }
+
+  public TableDefinition(
+      TableId id,
+      Iterable<ColumnDefinition> columns,
+      TableType type
+  ) {
     this.id = id;
+    this.type = Objects.requireNonNull(type);
     for (ColumnDefinition defn : columns) {
       String columnName = defn.id().name();
       columnsByName.put(
@@ -50,6 +61,10 @@ public class TableDefinition {
 
   public TableId id() {
     return id;
+  }
+
+  public TableType type() {
+    return type;
   }
 
   public int columnCount() {
@@ -84,14 +99,20 @@ public class TableDefinition {
     }
     if (obj instanceof TableDefinition) {
       TableDefinition that = (TableDefinition) obj;
-      return this.id.equals(that.id()) && this.definitionsForColumns()
-                                              .equals(that.definitionsForColumns());
+      return Objects.equals(this.id(), that.id())
+             && Objects.equals(this.type(), that.type())
+             && Objects.equals(this.definitionsForColumns(), that.definitionsForColumns());
     }
     return false;
   }
 
   @Override
   public String toString() {
-    return "Table{" + "name='" + id + '\'' + ", columns=" + definitionsForColumns() + '}';
+    return String.format(
+        "Table{name='%s', type=%s columns=%s}",
+        id,
+        type,
+        definitionsForColumns()
+    );
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/TableType.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableType.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum TableType {
+
+  TABLE("TABLE", "Table"), VIEW("VIEW", "View");
+
+  private final String value;
+  private final String capitalCase;
+  private final String jdbcCase;
+
+  TableType(String value, String capitalCase) {
+    this.value = value.toLowerCase();
+    this.jdbcCase = value.toUpperCase();
+    this.capitalCase = capitalCase;
+  }
+
+  public String capitalized() {
+    return capitalCase;
+  }
+
+  public String jdbcName() {
+    return jdbcCase;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+
+  public static TableType get(String name) {
+    if (name != null) {
+      name = name.trim();
+    }
+    for (TableType method : values()) {
+      if (method.toString().equalsIgnoreCase(name)) {
+        return method;
+      }
+    }
+    throw new IllegalArgumentException("No matching QuoteMethod found for '" + name + "'");
+  }
+
+  public static EnumSet<TableType> parse(Collection<String> values) {
+    Set<TableType> types = values.stream().map(TableType::get).collect(Collectors.toSet());
+    return EnumSet.copyOf(types);
+  }
+
+  public static String asJdbcTableTypeNames(EnumSet<TableType> types, String delim) {
+    return types.stream()
+                .map(TableType::jdbcName)
+                .sorted()
+                .collect(Collectors.joining(delim));
+  }
+
+  public static String[] asJdbcTableTypeArray(EnumSet<TableType> types) {
+    return types.stream()
+                .map(TableType::jdbcName)
+                .sorted()
+                .collect(Collectors.toList())
+                .toArray(new String[types.size()]);
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/TableType.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableType.java
@@ -25,11 +25,9 @@ public enum TableType {
 
   private final String value;
   private final String capitalCase;
-  private final String jdbcCase;
 
   TableType(String value, String capitalCase) {
-    this.value = value.toLowerCase();
-    this.jdbcCase = value.toUpperCase();
+    this.value = value.toUpperCase();
     this.capitalCase = capitalCase;
   }
 
@@ -38,7 +36,7 @@ public enum TableType {
   }
 
   public String jdbcName() {
-    return jdbcCase;
+    return value;
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -57,6 +57,7 @@ import io.confluent.connect.jdbc.util.TableType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -127,11 +128,9 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
 
   protected GenericDatabaseDialect newSinkDialectFor(Set<String> tableTypes) {
-    if (tableTypes != null) {
-      connProps.put(JdbcSinkConfig.TABLE_TYPES_CONFIG, StringUtils.join(tableTypes, ","));
-    } else {
-      connProps.remove(JdbcSinkConfig.TABLE_TYPES_CONFIG);
-    }
+    assertNotNull(tableTypes);
+    assertFalse(tableTypes.isEmpty());
+    connProps.put(JdbcSinkConfig.TABLE_TYPES_CONFIG, StringUtils.join(tableTypes, ","));
     sinkConfig = new JdbcSinkConfig(connProps);
     dialect = createDialect(sinkConfig);
     assertTrue(dialect.tableTypes.containsAll(tableTypes));

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.util.TableType;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdbcSinkConfigTest {
+
+  private Map<String, String> props = new HashMap<>();
+  private JdbcSinkConfig config;
+
+  @Before
+  public void beforeEach() {
+    // add the minimum settings only
+    props.put("connection.url", "jdbc:mysql://something"); // we won't connect
+  }
+
+  @After
+  public void afterEach() {
+    props.clear();
+    config = null;
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldFailToCreateConfigWithoutConnectionUrl() {
+    props.remove(JdbcSinkConfig.CONNECTION_URL);
+    createConfig();
+  }
+
+  @Test
+  public void shouldCreateConfigWithMinimalConfigs() {
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldCreateConfigWithAdditionalConfigs() {
+    props.put("auto.create", "true");
+    props.put("pk.mode", "kafka");
+    props.put("pk.fields", "kafka_topic,kafka_partition,kafka_offset");
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldCreateConfigWithViewOnly() {
+    props.put("table.types", "view");
+    createConfig();
+    assertTableTypes(TableType.VIEW);
+  }
+
+  @Test
+  public void shouldCreateConfigWithTableOnly() {
+    props.put("table.types", "table");
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldCreateConfigWithViewAndTable() {
+    props.put("table.types", "view,table");
+    createConfig();
+    assertTableTypes(TableType.TABLE, TableType.VIEW);
+    props.put("table.types", "table,view");
+    createConfig();
+    assertTableTypes(TableType.TABLE, TableType.VIEW);
+    props.put("table.types", "table , view");
+    createConfig();
+    assertTableTypes(TableType.TABLE, TableType.VIEW);
+  }
+
+  @Test
+  public void shouldCreateConfigWithLeadingWhitespaceInTableTypes() {
+    props.put("table.types", " \t\n  view");
+    createConfig();
+    assertTableTypes(TableType.VIEW);
+  }
+
+  @Test
+  public void shouldCreateConfigWithTrailingWhitespaceInTableTypes() {
+    props.put("table.types", "table \t \n");
+    createConfig();
+    assertTableTypes(TableType.TABLE);
+  }
+
+  protected void createConfig() {
+    config = new JdbcSinkConfig(props);
+  }
+
+  protected void assertTableTypes(TableType...types) {
+    EnumSet<TableType> expected = EnumSet.copyOf(Arrays.asList(types));
+    EnumSet<TableType> tableTypes = config.tableTypes;
+    assertEquals(expected, tableTypes);
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.integration;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.JdbcSinkTask;
+import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
+import io.zonky.test.db.postgres.junit.SingleInstancePostgresRule;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration tests for writing to Postgres views.
+ */
+@Category(IntegrationTest.class)
+public class PostgresViewIT {
+
+  private static Logger log = LoggerFactory.getLogger(PostgresViewIT.class);
+
+  @Rule
+  public SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
+
+  private Map<String, String> props;
+  private String tableName;
+  private String topic;
+  private JdbcSinkTask task;
+
+  @Before
+  public void before() {
+    tableName = "test";
+    topic = tableName + "_view";
+    props = new HashMap<>();
+    String jdbcURL = String
+        .format("jdbc:postgresql://localhost:%s/postgres", pg.getEmbeddedPostgres().getPort());
+    props.put(JdbcSinkConfig.CONNECTION_URL, jdbcURL);
+    props.put(JdbcSinkConfig.CONNECTION_USER, "postgres");
+    props.put(JdbcSinkConfig.TABLE_TYPES_CONFIG, "VIEW");
+    props.put("pk.mode", "none");
+    props.put("topics", topic);
+  }
+
+  @After
+  public void after() throws SQLException {
+    stopTask();
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        s.execute("DROP VIEW " + topic);
+        s.execute("DROP TABLE " + tableName);
+      }
+    }
+    log.info("Dropped table");
+  }
+
+  @Test
+  public void testRecordSchemaDoesNotMatchView() throws SQLException {
+    createTestTableAndView();
+    startTask();
+    final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstname", Schema.STRING_SCHEMA)
+        .field("lastname", Schema.STRING_SCHEMA)
+        .field("age", Schema.INT32_SCHEMA)
+        .build();
+    final Struct struct = new Struct(schema)
+        .put("firstname", "Christina")
+        .put("lastname", "Brams")
+        .put("age", 20);
+    try {
+      task.put(Collections.singleton(new SinkRecord(topic, 1, null, null, schema, struct, 1)));
+      fail();
+    } catch (ConnectException e) {
+      assertTrue(e.getMessage().contains("View \"" + topic + "\" is missing fields"));
+    }
+  }
+
+  @Test
+  public void testWriteToView() throws SQLException {
+    createTestTableAndView();
+    startTask();
+    final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstname", Schema.STRING_SCHEMA)
+        .field("lastname", Schema.STRING_SCHEMA)
+        .build();
+    final Struct struct = new Struct(schema)
+        .put("firstname", "Christina")
+        .put("lastname", "Brams");
+    task.put(Collections.singleton(new SinkRecord(topic, 1, null, null, schema, struct, 1)));
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(struct.getString("lastname"), rs.getString("lastname"));
+        }
+      }
+    }
+  }
+
+  private void createTestTableAndView() throws SQLException {
+    log.info("Creating test table");
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        s.execute("CREATE TABLE " + tableName + "(firstName TEXT, lastName TEXT, age INTEGER)");
+        s.execute("CREATE VIEW " + topic + " AS SELECT firstName, lastName FROM " + tableName);
+      }
+    }
+    log.info("Created table");
+  }
+
+  private void startTask() {
+    task = new JdbcSinkTask();
+    task.start(props);
+  }
+
+  public void stopTask() {
+    if (task != null) {
+      task.stop();
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.util.BytesUtil;
-import io.confluent.connect.jdbc.util.TableType;
 
 /**
  * Embedded Derby server useful for testing against a real JDBC database.
@@ -148,8 +147,8 @@ public class EmbeddedDerby {
 
   /**
    * Shorthand for creating a view over a different table
-   * @param name      name of the table
-   * @param tableName the name of the table over which the view should select
+   * @param name        name of the table
+   * @param tableName   the name of the table over which the view should select
    * @param columnNames the names of the columns in the table that should be included in the view
    */
   public void createView(String name, String tableName, String... columnNames) throws SQLException {
@@ -171,15 +170,6 @@ public class EmbeddedDerby {
     String statementStr = statement.toString();
     log.debug("Creating view {} in {} with statement {}", name, this.name, statementStr);
     stmt.execute(statementStr);
-  }
-
-  /**
-   * Drop a view.
-   * @param name
-   */
-  public void dropView(String name) throws SQLException {
-    Statement stmt = conn.createStatement();
-    stmt.execute("DROP VIEW \"" + name + "\"");
   }
 
   public void close() throws SQLException {

--- a/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
@@ -27,8 +27,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.util.BytesUtil;
+import io.confluent.connect.jdbc.util.TableType;
 
 /**
  * Embedded Derby server useful for testing against a real JDBC database.
@@ -141,6 +144,42 @@ public class EmbeddedDerby {
   public void dropTable(String name) throws SQLException {
     Statement stmt = conn.createStatement();
     stmt.execute("DROP TABLE \"" + name + "\"");
+  }
+
+  /**
+   * Shorthand for creating a view over a different table
+   * @param name      name of the table
+   * @param tableName the name of the table over which the view should select
+   * @param columnNames the names of the columns in the table that should be included in the view
+   */
+  public void createView(String name, String tableName, String... columnNames) throws SQLException {
+    if (columnNames.length == 0) {
+      throw new IllegalArgumentException("Must specify at least one column when creating a view");
+    }
+
+    StringBuilder statement = new StringBuilder();
+    statement.append("CREATE VIEW ");
+    statement.append(quoteCaseSensitive(name));
+    statement.append(" (");
+    statement.append(Arrays.stream(columnNames).collect(Collectors.joining("\", \"", "\"", "\"")));
+    statement.append(") AS SELECT ");
+    statement.append(Arrays.stream(columnNames).collect(Collectors.joining("\", \"", "\"", "\"")));
+    statement.append(" FROM ");
+    statement.append(quoteCaseSensitive(tableName));
+
+    Statement stmt = conn.createStatement();
+    String statementStr = statement.toString();
+    log.debug("Creating view {} in {} with statement {}", name, this.name, statementStr);
+    stmt.execute(statementStr);
+  }
+
+  /**
+   * Drop a view.
+   * @param name
+   */
+  public void dropView(String name) throws SQLException {
+    Statement stmt = conn.createStatement();
+    stmt.execute("DROP VIEW \"" + name + "\"");
   }
 
   public void close() throws SQLException {

--- a/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
@@ -65,6 +65,12 @@ public class TableTypeTest {
     assertEquals("TABLE/VIEW", TableType.asJdbcTableTypeNames(TABLE_AND_VIEW, "/"));
   }
 
+  @Test
+  public void shouldHaveUpperCaseToString() {
+    assertEquals("TABLE", TableType.TABLE.toString());
+    assertEquals("VIEW", TableType.VIEW.toString());
+  }
+
   protected static EnumSet<TableType> types(TableType...types) {
     return EnumSet.copyOf(Arrays.asList(types));
   }

--- a/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TableTypeTest {
+
+  private static EnumSet<TableType> TABLE_ONLY = types(TableType.TABLE);
+  private static EnumSet<TableType> VIEW_ONLY = types(TableType.VIEW);
+  private static EnumSet<TableType> TABLE_AND_VIEW = types(TableType.TABLE, TableType.VIEW);
+
+  @Test
+  public void shouldParseLowercaseTypes() {
+    assertEquals(TableType.TABLE, TableType.get("table"));
+    assertEquals(TableType.VIEW, TableType.get("view"));
+  }
+
+  @Test
+  public void shouldParseUppercaseTypes() {
+    assertEquals(TableType.TABLE, TableType.get("TABLE"));
+    assertEquals(TableType.VIEW, TableType.get("VIEW"));
+  }
+
+  @Test
+  public void shouldParseMixedcaseTypes() {
+    assertEquals(TableType.TABLE, TableType.get("Table"));
+    assertEquals(TableType.VIEW, TableType.get("vIeW"));
+  }
+
+  @Test
+  public void shouldParseTypeStringWithWhitespace() {
+    assertEquals(TableType.TABLE, TableType.get(" table \t"));
+    assertEquals(TableType.VIEW, TableType.get("VIEW \t\n "));
+  }
+
+  @Test
+  public void shouldComputeJdbcTypeArray() {
+    assertArrayEquals(array("TABLE"), TableType.asJdbcTableTypeArray(TABLE_ONLY));
+    assertArrayEquals(array("VIEW"), TableType.asJdbcTableTypeArray(VIEW_ONLY));
+    assertArrayEquals(array("TABLE", "VIEW"), TableType.asJdbcTableTypeArray(TABLE_AND_VIEW));
+  }
+
+  @Test
+  public void shouldComputeJdbcTypeNames() {
+    assertEquals("TABLE", TableType.asJdbcTableTypeNames(TABLE_ONLY, "/"));
+    assertEquals("VIEW", TableType.asJdbcTableTypeNames(VIEW_ONLY, "/"));
+    assertEquals("TABLE/VIEW", TableType.asJdbcTableTypeNames(TABLE_AND_VIEW, "/"));
+  }
+
+  protected static EnumSet<TableType> types(TableType...types) {
+    return EnumSet.copyOf(Arrays.asList(types));
+  }
+
+  protected static String[] array(String...strs) {
+    return strs;
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
@@ -19,7 +19,8 @@ import java.util.EnumSet;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 public class TableTypeTest {
 


### PR DESCRIPTION
This change allows the JDBC sink to optionally write to tables (by default), views, or a combination. A new low-importance `table.types` configuration property has been added to the JDBC sink config, with `table` and/or `view` as allowed values, with `table` being the default to maintain backward compatibility when people upgrade. Note that the JDBC sink connector does not attempt to alter a view that does not match the sink records' schemas, and in such cases the sink connector always fails.

The changes are backward compatible (mostly through avoiding changes to signatures), so any connector that reused the JDBC sink classes should automatically work with these changes. Any connector that extends the generic dialect and should get all of the functionality for free.