### PR TITLE
CC-8898: Add better error messages when consumed records don’t match connector config

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -473,7 +473,7 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
-    connectorName = ConfigUtils.connectorName(this);
+    connectorName = ConfigUtils.connectorName(props);
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 
+import io.confluent.connect.jdbc.util.ConfigUtils;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.DeleteEnabledRecommender;
 import io.confluent.connect.jdbc.util.EnumRecommender;
@@ -451,6 +452,7 @@ public class JdbcSinkConfig extends AbstractConfig {
             RETRY_BACKOFF_MS_DISPLAY
         );
 
+  public final String connectorName;
   public final String connectionUrl;
   public final String connectionUser;
   public final String connectionPassword;
@@ -471,6 +473,7 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
+    connectorName = ConfigUtils.connectorName(this);
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
@@ -502,6 +505,10 @@ public class JdbcSinkConfig extends AbstractConfig {
       return password.value();
     }
     return null;
+  }
+
+  public String connectorName() {
+    return connectorName;
   }
 
   public EnumSet<TableType> tableTypes() {

--- a/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import io.confluent.connect.jdbc.util.StringUtils;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+@FunctionalInterface
+public interface RecordValidator {
+
+  RecordValidator NO_OP = (record) -> { };
+
+  void validate(SinkRecord record);
+
+  default RecordValidator and(RecordValidator other) {
+    if (other == null || other == NO_OP || other == this) {
+      return this;
+    }
+    if (this == NO_OP) {
+      return other;
+    }
+    RecordValidator thisValidator = this;
+    return (record) -> {
+      thisValidator.validate(record);
+      other.validate(record);
+    };
+  }
+
+  static RecordValidator create(JdbcSinkConfig config) {
+    RecordValidator requiresKey = requiresKey(config);
+    RecordValidator requiresValue = requiresValue(config);
+
+    RecordValidator keyValidator = NO_OP;
+    RecordValidator valueValidator = NO_OP;
+    switch (config.pkMode) {
+      case RECORD_KEY:
+        keyValidator = keyValidator.and(requiresKey);
+        break;
+      case RECORD_VALUE:
+      case NONE:
+        valueValidator = valueValidator.and(requiresValue);
+        break;
+      case KAFKA:
+      default:
+        // no primary key is required
+        break;
+    }
+
+    if (config.deleteEnabled) {
+      // When delete is enabled, we need a key
+      keyValidator = keyValidator.and(requiresKey);
+    }
+
+    // Compose the validator that may or may be NO_OP
+    return keyValidator.and(valueValidator);
+  }
+
+  static RecordValidator requiresValue(JdbcSinkConfig config) {
+    return record -> {
+      if (record.value() == null) {
+        throw new ConnectException(
+            String.format(
+                "The JDBC sink connector '%s' is configured with '%s=%s' and '%s=%s' "
+                + "and therefore requires non-null record values that are structs, "
+                + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+                + "with a %s value and %s value schema.",
+                config.connectorName(),
+                JdbcSinkConfig.DELETE_ENABLED,
+                config.deleteEnabled,
+                JdbcSinkConfig.PK_MODE,
+                config.pkMode.toString().toLowerCase(),
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset(),
+                record.timestamp(),
+                StringUtils.valueTypeOrNull(record.value()),
+                StringUtils.schemaTypeOrNull(record.valueSchema())
+            )
+        );
+      }
+      Schema valueSchema = record.valueSchema();
+      if (valueSchema == null) {
+        throw new ConnectException(
+            String.format(
+                "The JDBC sink connector '%s' is configured with '%s=%s' and '%s=%s' "
+                + "and therefore requires non-null record values that are structs, "
+                + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+                + "with a %s value and %s value schema.",
+                config.connectorName(),
+                JdbcSinkConfig.DELETE_ENABLED,
+                config.deleteEnabled,
+                JdbcSinkConfig.PK_MODE,
+                config.pkMode.toString().toLowerCase(),
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset(),
+                record.timestamp(),
+                StringUtils.valueTypeOrNull(record.value()),
+                StringUtils.schemaTypeOrNull(record.valueSchema())
+            )
+        );
+      }
+      if (valueSchema.type() != Schema.Type.STRUCT) {
+        throw new ConnectException(
+            String.format(
+                "The JDBC sink connector '%s' is configured with '%s=%s' and '%s=%s' "
+                + "and therefore requires record values to be structs, "
+                + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+                + "with a %s value and %s value schema.",
+                config.connectorName(),
+                JdbcSinkConfig.DELETE_ENABLED,
+                config.deleteEnabled,
+                JdbcSinkConfig.PK_MODE,
+                config.pkMode.toString().toLowerCase(),
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset(),
+                record.timestamp(),
+                StringUtils.valueTypeOrNull(record.value()),
+                StringUtils.schemaTypeOrNull(record.valueSchema())
+            )
+        );
+      }
+    };
+  }
+
+  static RecordValidator requiresKey(JdbcSinkConfig config) {
+    return record -> {
+      if (record.key() == null) {
+        throw new ConnectException(
+            String.format(
+                "The JDBC sink connector '%s' is configured with '%s=%s' and '%s=%s' "
+                + "and therefore requires non-null record keys, "
+                + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+                + "with a %s key and %s key schema.",
+                config.connectorName(),
+                JdbcSinkConfig.DELETE_ENABLED,
+                config.deleteEnabled,
+                JdbcSinkConfig.PK_MODE,
+                config.pkMode.toString().toLowerCase(),
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset(),
+                record.timestamp(),
+                StringUtils.valueTypeOrNull(record.key()),
+                StringUtils.schemaTypeOrNull(record.keySchema())
+            )
+        );
+      }
+      Schema keySchema = record.keySchema();
+      if (keySchema == null) {
+        throw new ConnectException(
+            String.format(
+                "The JDBC sink connector '%s' is configured with '%s=%s' and '%s=%s' "
+                + "and therefore requires non-null record keys with schemas, "
+                + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+                + "with a %s key and %s key schema.",
+                config.connectorName(),
+                JdbcSinkConfig.DELETE_ENABLED,
+                config.deleteEnabled,
+                JdbcSinkConfig.PK_MODE,
+                config.pkMode.toString().toLowerCase(),
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset(),
+                record.timestamp(),
+                StringUtils.valueTypeOrNull(record.key()),
+                StringUtils.schemaTypeOrNull(record.keySchema())
+            )
+        );
+      }
+      Schema.Type keySchemaType = keySchema.type();
+      if (keySchemaType != Schema.Type.STRUCT && !keySchemaType.isPrimitive()) {
+        throw new ConnectException(
+            String.format(
+                "The JDBC sink connector '%s' is configured with '%s=%s' and '%s=%s' "
+                + "and therefore requires non-null record keys that "
+                + "are either structs or a single primitive value, "
+                + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+                + "with a %s key and %s key schema.",
+                config.connectorName(),
+                JdbcSinkConfig.DELETE_ENABLED,
+                config.deleteEnabled,
+                JdbcSinkConfig.PK_MODE,
+                config.pkMode.toString().toLowerCase(),
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset(),
+                record.timestamp(),
+                StringUtils.valueTypeOrNull(record.key()),
+                StringUtils.schemaTypeOrNull(record.keySchema())
+            )
+        );
+      }
+    };
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/ConfigUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/ConfigUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.apache.kafka.common.config.AbstractConfig;
+
+/**
+ * Utilities for configuration properties.
+ */
+public class ConfigUtils {
+
+  /**
+   * Get the connector's name from the configuration.
+   *
+   * @param connectorConfig the connector configuration
+   * @return the concatenated string with delimiters
+   */
+  public static String connectorName(AbstractConfig connectorConfig) {
+    Object nameValue = connectorConfig.originals().get("name");
+    return nameValue != null ? nameValue.toString() : null;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/ConfigUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/ConfigUtils.java
@@ -15,7 +15,7 @@
 
 package io.confluent.connect.jdbc.util;
 
-import org.apache.kafka.common.config.AbstractConfig;
+import java.util.Map;
 
 /**
  * Utilities for configuration properties.
@@ -25,11 +25,11 @@ public class ConfigUtils {
   /**
    * Get the connector's name from the configuration.
    *
-   * @param connectorConfig the connector configuration
+   * @param connectorProps the connector properties
    * @return the concatenated string with delimiters
    */
-  public static String connectorName(AbstractConfig connectorConfig) {
-    Object nameValue = connectorConfig.originals().get("name");
+  public static String connectorName(Map<?, ?> connectorProps) {
+    Object nameValue = connectorProps.get("name");
     return nameValue != null ? nameValue.toString() : null;
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/StringUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/StringUtils.java
@@ -61,6 +61,14 @@ public class StringUtils {
    * @return the loggable string representation
    */
   public static String schemaTypeOrNull(Schema schema) {
-    return schema == null ? null : schema.type().toString();
+    if (schema == null) {
+      return null;
+    }
+    switch (schema.type()) {
+      case STRUCT:
+        return "Struct";
+      default:
+        return schema.type().getName();
+    }
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/StringUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/StringUtils.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.jdbc.util;
 
+import org.apache.kafka.connect.data.Schema;
+
 /**
  * General string utilities that are missing from the standard library and may commonly be
  * required by Connector or Task implementations.
@@ -40,5 +42,25 @@ public class StringUtils {
       result.append(elem);
     }
     return result.toString();
+  }
+
+  /**
+   * Get a string representation of the supplied value that can be included in a log message.
+   *
+   * @param value the value; may be null
+   * @return the loggable string representation
+   */
+  public static String valueTypeOrNull(Object value) {
+    return value == null ? null : value.getClass().getSimpleName();
+  }
+
+  /**
+   * Get a string representation of the supplied schema that can be included in a log message.
+   *
+   * @param schema the schema; may be null
+   * @return the loggable string representation
+   */
+  public static String schemaTypeOrNull(Schema schema) {
+    return schema == null ? null : schema.type().toString();
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -19,6 +19,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -34,6 +35,8 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
@@ -43,6 +46,7 @@ import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,9 +55,19 @@ public class BufferedRecordsTest {
 
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
 
+  private Map<Object, Object> props;
+
   @Before
   public void setUp() throws IOException, SQLException {
     sqliteHelper.setUp();
+    props = new HashMap<>();
+    props.put("name", "my-connector");
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
+    // We don't manually create the table, so let the connector do it
+    props.put("auto.create", true);
+    // We use various schemas, so let the connector add missing columns
+    props.put("auto.evolve", true);
   }
 
   @After
@@ -63,11 +77,6 @@ public class BufferedRecordsTest {
 
   @Test
   public void correctBatching() throws SQLException {
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
-    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
     final String url = sqliteHelper.sqliteUri();
@@ -109,10 +118,6 @@ public class BufferedRecordsTest {
 
   @Test(expected = ConfigException.class)
   public void configParsingFailsIfDeleteWithWrongPKMode() {
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
     props.put("delete.enabled", true);
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "kafka"); // wrong pk mode for deletes
@@ -121,14 +126,9 @@ public class BufferedRecordsTest {
 
   @Test
   public void insertThenDeleteInBatchNoFlush() throws SQLException {
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
     props.put("delete.enabled", true);
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "record_key");
-    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
     final String url = sqliteHelper.sqliteUri();
@@ -180,14 +180,9 @@ public class BufferedRecordsTest {
 
   @Test
   public void insertThenTwoDeletesWithSchemaInBatchNoFlush() throws SQLException {
-	    final HashMap<Object, Object> props = new HashMap<>();
-	    props.put("connection.url", sqliteHelper.sqliteUri());
-	    props.put("auto.create", true);
-	    props.put("auto.evolve", true);
 	    props.put("delete.enabled", true);
 	    props.put("insert.mode", "upsert");
 	    props.put("pk.mode", "record_key");
-	    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
 	    final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
 	    final String url = sqliteHelper.sqliteUri();
@@ -243,14 +238,9 @@ public class BufferedRecordsTest {
   
   @Test
   public void insertThenDeleteThenInsertInBatchFlush() throws SQLException {
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
     props.put("delete.enabled", true);
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "record_key");
-    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
     final String url = sqliteHelper.sqliteUri();
@@ -302,14 +292,9 @@ public class BufferedRecordsTest {
 
   @Test
   public void insertThenDeleteWithSchemaThenInsertInBatchFlush() throws SQLException {
-	    final HashMap<Object, Object> props = new HashMap<>();
-	    props.put("connection.url", sqliteHelper.sqliteUri());
-	    props.put("auto.create", true);
-	    props.put("auto.evolve", true);
 	    props.put("delete.enabled", true);
 	    props.put("insert.mode", "upsert");
 	    props.put("pk.mode", "record_key");
-	    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
 	    final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
 	    final String url = sqliteHelper.sqliteUri();
@@ -361,14 +346,9 @@ public class BufferedRecordsTest {
   
   @Test
   public void testMultipleDeletesBatchedTogether() throws SQLException {
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
     props.put("delete.enabled", true);
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "record_key");
-    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
     final String url = sqliteHelper.sqliteUri();
@@ -418,14 +398,9 @@ public class BufferedRecordsTest {
 
   @Test
   public void testMultipleDeletesWithSchemaBatchedTogether() throws SQLException {
-	    final HashMap<Object, Object> props = new HashMap<>();
-	    props.put("connection.url", sqliteHelper.sqliteUri());
-	    props.put("auto.create", true);
-	    props.put("auto.evolve", true);
 	    props.put("delete.enabled", true);
 	    props.put("insert.mode", "upsert");
 	    props.put("pk.mode", "record_key");
-	    props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
 	    final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
 	    final String url = sqliteHelper.sqliteUri();
@@ -478,11 +453,6 @@ public class BufferedRecordsTest {
   @Test
   public void testFlushSuccessNoInfo() throws SQLException {
     final String url = sqliteHelper.sqliteUri();
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", url);
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
-    props.put("batch.size", 1000);
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
@@ -525,11 +495,6 @@ public class BufferedRecordsTest {
   @Test
   public void testInsertModeUpdate() throws SQLException {
     final String url = sqliteHelper.sqliteUri();
-    final HashMap<Object, Object> props = new HashMap<>();
-    props.put("connection.url", url);
-    props.put("auto.create", true);
-    props.put("auto.evolve", true);
-    props.put("batch.size", 1000);
     props.put("insert.mode", "update");
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
@@ -559,5 +524,263 @@ public class BufferedRecordsTest {
         Mockito.times(1)
     ).prepareStatement(Matchers.eq("UPDATE \"dummy\" SET \"name\" = ?"));
 
+  }
+
+  @Test
+  public void testAddRecordDeleteNotEnabledAndNonePkMode() throws SQLException {
+    props.put("pk.mode", "none");
+
+    // Delete is not enabled, so therefore require non-null value and value schema,
+    // but any combination of key and key schema works
+    assertValidRecord(true, true, true, true);
+    assertValidRecord(false, true, true, true);
+    assertValidRecord(true, false, true, true);
+    assertValidRecord(false, false, true, true);
+
+    // Fail when null value
+    assertInvalidRecord(false, false, false, false, "with a null value and null value schema");
+    assertInvalidRecord(true, false, false, false, "with a null value and null value schema");
+    assertInvalidRecord(false, true, false, false, "with a null value and null value schema");
+    assertInvalidRecord(true, true, false, false, "with a null value and null value schema");
+    assertInvalidRecord(false, false, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(true, false, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(false, true, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(true, true, true, false, "with a null value and STRUCT value schema");
+
+    // Fail when null value schema but non-null value
+    assertInvalidRecord(false, false, false, true, "with a Struct value and null value schema");
+    assertInvalidRecord(true, false, false, true, "with a Struct value and null value schema");
+    assertInvalidRecord(false, true, false, true, "with a Struct value and null value schema");
+    assertInvalidRecord(true, true, false, true, "with a Struct value and null value schema");
+  }
+
+  @Test
+  public void testAddRecordDeleteNotEnabledAndRecordKeyPkMode() throws SQLException {
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+
+    // Delete is not enabled, so therefore require non-null key and key schema,
+    // but any combination of value and value schema works
+    assertValidRecord(true, true, true, true);
+    assertValidRecord(true, true, false, true);
+    assertValidRecord(true, true, true, false);
+    assertValidRecord(true, true, false, false);
+
+    // Fail when null key and null key schema
+    assertInvalidRecord(false, false, true, true, "with a null key and null key schema");
+    assertInvalidRecord(false, false, false, true, "with a null key and null key schema");
+    assertInvalidRecord(false, false, false, false, "with a null key and null key schema");
+
+    // Fail when null key and non-null key schema
+    assertInvalidRecord(true, false, true, true, "with a null key and STRUCT key schema");
+    assertInvalidRecord(true, false, false, true, "with a null key and STRUCT key schema");
+    assertInvalidRecord(true, false, false, false, "with a null key and STRUCT key schema");
+
+    // Fail when non-null key and null key schema
+    assertInvalidRecord(false, true, true, true, "with a Struct key and null key schema");
+    assertInvalidRecord(false, true, false, true, "with a Struct key and null key schema");
+    assertInvalidRecord(false, true, false, false, "with a Struct key and null key schema");
+  }
+
+  @Test
+  public void testAddRecordDeleteNotEnabledAndRecordValuePkMode() throws SQLException {
+    props.put("pk.mode", "record_value");
+    props.put("pk.fields", "name");
+
+    // Delete is not enabled, so therefore require non-null value and value schema,
+    // but any combination of key and key schema works
+    assertValidRecord(true, true, true, true);
+    assertValidRecord(false, true, true, true);
+    assertValidRecord(true, false, true, true);
+    assertValidRecord(false, false, true, true);
+
+    // Fail when null value and null value schema
+    assertInvalidRecord(true, true, false, false, "with a null value and null value schema");
+    assertInvalidRecord(true, false, false, false, "with a null value and null value schema");
+    assertInvalidRecord(false, true, false, false, "with a null value and null value schema");
+    assertInvalidRecord(false, false, false, false, "with a null value and null value schema");
+
+    // Fail when null value and non-null value schema
+    assertInvalidRecord(true, true, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(true, false, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(false, true, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(false, false, true, false, "with a null value and STRUCT value schema");
+
+    // Fail when non-null value and null value schema
+    assertInvalidRecord(true, true, false, true, "with a Struct value and null value schema");
+    assertInvalidRecord(true, false, false, true, "with a Struct value and null value schema");
+    assertInvalidRecord(false, true, false, true, "with a Struct value and null value schema");
+    assertInvalidRecord(false, false, false, true, "with a Struct value and null value schema");
+  }
+
+  @Test
+  public void testAddRecordDeleteNotEnabledAndKafkaPkMode() throws SQLException {
+    props.put("pk.mode", "kafka");
+
+    // Delete is not enabled, so therefore allow all combinations of
+    // null and non-null key, key schema, value, and value schema
+    assertValidRecord(true, true, true, true);
+    assertValidRecord(false, true, true, true);
+    assertValidRecord(true, false, true, true);
+    assertValidRecord(false, false, true, true);
+
+    assertValidRecord(true, true, true, false);
+    assertValidRecord(false, true, true, false);
+    assertValidRecord(true, false, true, false);
+    assertValidRecord(false, false, true, false);
+
+    assertValidRecord(true, true, false, true);
+    assertValidRecord(false, true, false, true);
+    assertValidRecord(true, false, false, true);
+    assertValidRecord(false, false, false, true);
+
+    assertValidRecord(true, true, false, false);
+    assertValidRecord(false, true, false, false);
+    assertValidRecord(true, false, false, false);
+    assertValidRecord(false, false, false, false);
+  }
+
+  @Test
+  public void testAddRecordDeleteEnabledAndNonePkMode() throws SQLException {
+    props.put("delete.enabled", true);
+    props.put("pk.mode", "none");
+    ConfigException e = assertThrows(ConfigException.class, () -> new JdbcSinkConfig(props));
+    assertEquals(
+        "Primary key mode must be 'record_key' when delete support is enabled",
+        e.getMessage()
+    );
+  }
+
+  @Test
+  public void testAddRecordDeleteEnabledAndRecordValuePkMode() throws SQLException {
+    props.put("delete.enabled", true);
+    props.put("pk.mode", "record_value");
+    props.put("pk.fields", "name");
+    ConfigException e = assertThrows(ConfigException.class, () -> new JdbcSinkConfig(props));
+    assertEquals(
+        "Primary key mode must be 'record_key' when delete support is enabled",
+        e.getMessage()
+    );
+  }
+
+  @Test
+  public void testAddRecordDeleteEnabledAndKafkaPkMode() throws SQLException {
+    props.put("delete.enabled", true);
+    props.put("pk.mode", "kafka");
+    ConfigException e = assertThrows(ConfigException.class, () -> new JdbcSinkConfig(props));
+    assertEquals(
+        "Primary key mode must be 'record_key' when delete support is enabled",
+        e.getMessage()
+    );
+  }
+
+  @Test
+  public void testAddRecordDeleteEnabledAndRecordKeyPkMode() throws SQLException {
+    // Enabling delete requires 'record_key' pk mode
+    props.put("delete.enabled", true);
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+
+    // Non-null key schema and key, but with various combinations of value schema and value
+    assertValidRecord(true, true, true, true);
+    assertValidRecord(true, true, true, true);
+    assertValidRecord(true, true, false, false);
+    assertValidRecord(true, true, false, false);
+
+    // Invalid when null key and null key schema
+    assertInvalidRecord(false, false, true, true, "with a null key");
+    assertInvalidRecord(false, false, false, true, "with a null key");
+    assertInvalidRecord(false, false, true, false, "with a null key");
+    assertInvalidRecord(false, false, false, false, "with a null key");
+
+    // Invalid when null key and non-null key schema
+    assertInvalidRecord(true, false, true, true, "with a null key");
+    assertInvalidRecord(true, false, false, true, "with a null key");
+    assertInvalidRecord(true, false, true, false, "with a null key");
+    assertInvalidRecord(true, false, false, false, "with a null key");
+
+    // Invalid when non-null key and null key schema
+    assertInvalidRecord(false, true, true, true, "with a Struct key and null key schema");
+    assertInvalidRecord(false, true, false, true, "with a Struct key and null key schema");
+    assertInvalidRecord(false, true, true, true, "with a Struct key and null key schema");
+    assertInvalidRecord(false, true, false, false, "with a Struct key and null key schema");
+  }
+
+  protected SinkRecord generateRecord(
+      boolean includeKeySchema,
+      boolean includeKey,
+      boolean includeValueSchema,
+      boolean includeValue
+  ) {
+    Schema keySchema = SchemaBuilder.struct()
+                                      .field("id", Schema.INT32_SCHEMA)
+                                      .build();
+    Schema valueSchema = SchemaBuilder.struct()
+                                      .field("name", Schema.STRING_SCHEMA)
+                                      .build();
+    Schema keySchemaForRecord = includeKeySchema ? keySchema : null;
+    Schema valueSchemaForRecord = includeValueSchema ? valueSchema : null;
+    final Object key = includeKey ? new Struct(keySchema).put("id", 100) : null;
+    final Object valueA = includeValue ? new Struct(valueSchema).put("name", "cuba") : null;
+    return new SinkRecord("dummy", 0, keySchemaForRecord, key, valueSchemaForRecord, valueA, 0);
+  }
+
+  protected void assertInvalidRecord(
+      boolean includeKeySchema,
+      boolean includeKey,
+      boolean includeValueSchema,
+      boolean includeValue,
+      String errorMessageFragment
+  ) {
+    assertInvalidRecord(
+        generateRecord(includeKeySchema, includeKey, includeValueSchema, includeValue),
+        errorMessageFragment
+    );
+  }
+
+  protected void assertInvalidRecord(SinkRecord record, String errorMessageFragment) {
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "dummy");
+    final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
+
+    ConnectException e = assertThrows(ConnectException.class, () -> {
+      buffer.add(record);
+      buffer.flush();
+    });
+    assertTrue(
+        "Unexpected message: " + e.getMessage(),
+        e.getMessage().contains(errorMessageFragment)
+    );
+  }
+
+  protected void assertValidRecord(
+      boolean includeKeySchema,
+      boolean includeKey,
+      boolean includeValueSchema,
+      boolean includeValue
+  ) throws SQLException {
+    assertValidRecord(
+        generateRecord(includeKeySchema, includeKey, includeValueSchema, includeValue)
+    );
+  }
+
+  protected void assertValidRecord(SinkRecord record) throws SQLException {
+    props.put("batch.size", 2);
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "dummy");
+    final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
+
+    List<SinkRecord> flushed = buffer.add(record);
+    assertEquals(Collections.emptyList(), flushed);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -542,10 +542,10 @@ public class BufferedRecordsTest {
     assertInvalidRecord(true, false, false, false, "with a null value and null value schema");
     assertInvalidRecord(false, true, false, false, "with a null value and null value schema");
     assertInvalidRecord(true, true, false, false, "with a null value and null value schema");
-    assertInvalidRecord(false, false, true, false, "with a null value and STRUCT value schema");
-    assertInvalidRecord(true, false, true, false, "with a null value and STRUCT value schema");
-    assertInvalidRecord(false, true, true, false, "with a null value and STRUCT value schema");
-    assertInvalidRecord(true, true, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(false, false, true, false, "with a null value and Struct value schema");
+    assertInvalidRecord(true, false, true, false, "with a null value and Struct value schema");
+    assertInvalidRecord(false, true, true, false, "with a null value and Struct value schema");
+    assertInvalidRecord(true, true, true, false, "with a null value and Struct value schema");
 
     // Fail when null value schema but non-null value
     assertInvalidRecord(false, false, false, true, "with a Struct value and null value schema");
@@ -572,9 +572,9 @@ public class BufferedRecordsTest {
     assertInvalidRecord(false, false, false, false, "with a null key and null key schema");
 
     // Fail when null key and non-null key schema
-    assertInvalidRecord(true, false, true, true, "with a null key and STRUCT key schema");
-    assertInvalidRecord(true, false, false, true, "with a null key and STRUCT key schema");
-    assertInvalidRecord(true, false, false, false, "with a null key and STRUCT key schema");
+    assertInvalidRecord(true, false, true, true, "with a null key and Struct key schema");
+    assertInvalidRecord(true, false, false, true, "with a null key and Struct key schema");
+    assertInvalidRecord(true, false, false, false, "with a null key and Struct key schema");
 
     // Fail when non-null key and null key schema
     assertInvalidRecord(false, true, true, true, "with a Struct key and null key schema");
@@ -601,10 +601,10 @@ public class BufferedRecordsTest {
     assertInvalidRecord(false, false, false, false, "with a null value and null value schema");
 
     // Fail when null value and non-null value schema
-    assertInvalidRecord(true, true, true, false, "with a null value and STRUCT value schema");
-    assertInvalidRecord(true, false, true, false, "with a null value and STRUCT value schema");
-    assertInvalidRecord(false, true, true, false, "with a null value and STRUCT value schema");
-    assertInvalidRecord(false, false, true, false, "with a null value and STRUCT value schema");
+    assertInvalidRecord(true, true, true, false, "with a null value and Struct value schema");
+    assertInvalidRecord(true, false, true, false, "with a null value and Struct value schema");
+    assertInvalidRecord(false, true, true, false, "with a null value and Struct value schema");
+    assertInvalidRecord(false, false, true, false, "with a null value and Struct value schema");
 
     // Fail when non-null value and null value schema
     assertInvalidRecord(true, true, false, true, "with a Struct value and null value schema");


### PR DESCRIPTION
Added record validation that checks records key, key schema, value, and value schema to ensure that they match with the `delete.enabled` and `pk.mode` connector configuration properties.

Added unit tests that check all permutations of records with combinations of these configuration properties. Importantly, all of these unit tests were developed initially to identify the current behavior without the new validation, and thus asserted each permutation was either successfully written to a database or failed with one of the following:

* ConnectException (e.g., “PK mode for table 'dummy' is RECORD_KEY, but record key schema is missing”);
* NPEs; or
* SQLExceptions (e.g., “Values not bound to statement”)

The `ConnectException` instances are okay, and even had a relatively useful error message. But there still is a lot more info that could be added.

Then when validation was added, the tests' assertions remained the same, except that the exceptions thrown in the failure cases are always ConnectException with much more useful error messages; NPEs and the aforementioned SQLException no longer occur.

The more useful error messages include information that is essential for the user to understand and correct the problem:
1. the connector name;
1. the related connector configs and what they require of records in terms of key, key schema, value, and value schemas;
1. what about the record did not satisfy the requirements; and 
1. the coordinates (topic, partition, offset) of the problematic record.

For example:

> The JDBC sink connector 'my-connector' is configured with 'delete.enabled=true' and 'pk.mode=record_key' and therefore requires non-null record keys, but found record at (topic='dummy',partition=0,offset=1001,timestamp=null) with a null key and STRUCT key schema.

**This is targeted at `5.4.x` and later branches.**

Fixes #789 