### PR TITLE
Allow 'connection.attempts' and 'connection.backoff.ms' to be configu…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -43,9 +43,16 @@ public class JdbcDbWriter {
     this.dbDialect = dbDialect;
     this.dbStructure = dbStructure;
 
-    this.cachedConnectionProvider = new CachedConnectionProvider(this.dbDialect) {
+    this.cachedConnectionProvider = connectionProvider(
+        config.connectionAttempts,
+        config.connectionBackoffMs
+    );
+  }
+
+  protected CachedConnectionProvider connectionProvider(int maxConnAttempts, long retryBackoff) {
+    return new CachedConnectionProvider(this.dbDialect, maxConnAttempts, retryBackoff) {
       @Override
-      protected void onConnect(Connection connection) throws SQLException {
+      protected void onConnect(final Connection connection) throws SQLException {
         log.info("JdbcDbWriter Connected");
         connection.setAutoCommit(false);
       }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -85,6 +85,22 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
+  public static final String CONNECTION_ATTEMPTS =
+          JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG;
+  private static final String CONNECTION_ATTEMPTS_DOC
+          = "Maximum number of attempts to retrieve a valid JDBC connection. "
+          + "Must be a positive integer.";
+  private static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
+  public static final int CONNECTION_ATTEMPTS_DEFAULT = 3;
+
+  public static final String CONNECTION_BACKOFF =
+          JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG;
+  private static final String CONNECTION_BACKOFF_DOC
+          = "Backoff time in milliseconds between connection attempts.";
+  private static final String CONNECTION_BACKOFF_DISPLAY
+          = "JDBC connection backoff in milliseconds";
+  public static final long CONNECTION_BACKOFF_DEFAULT = 10000L;
+
   public static final String TABLE_NAME_FORMAT = "table.name.format";
   private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
   private static final String TABLE_NAME_FORMAT_DOC =
@@ -290,6 +306,28 @@ public class JdbcSinkConfig extends AbstractConfig {
             DIALECT_NAME_DISPLAY,
             DatabaseDialectRecommender.INSTANCE
         )
+        .define(
+            CONNECTION_ATTEMPTS,
+            ConfigDef.Type.INT,
+            CONNECTION_ATTEMPTS_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            CONNECTION_ATTEMPTS_DOC,
+            CONNECTION_GROUP,
+            5,
+            ConfigDef.Width.SHORT,
+            CONNECTION_ATTEMPTS_DISPLAY
+        ).define(
+            CONNECTION_BACKOFF,
+            ConfigDef.Type.LONG,
+            CONNECTION_BACKOFF_DEFAULT,
+            ConfigDef.Importance.LOW,
+            CONNECTION_BACKOFF_DOC,
+            CONNECTION_GROUP,
+            6,
+            ConfigDef.Width.SHORT,
+            CONNECTION_BACKOFF_DISPLAY
+        )
         // Writes
         .define(
             INSERT_MODE,
@@ -456,6 +494,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionUrl;
   public final String connectionUser;
   public final String connectionPassword;
+  public final int connectionAttempts;
+  public final long connectionBackoffMs;
   public final String tableNameFormat;
   public final int batchSize;
   public final boolean deleteEnabled;
@@ -477,6 +517,8 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionUrl = getString(CONNECTION_URL);
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
+    connectionAttempts = getInt(CONNECTION_ATTEMPTS);
+    connectionBackoffMs = getLong(CONNECTION_BACKOFF);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
     deleteEnabled = getBoolean(DELETE_ENABLED);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -86,20 +86,22 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
   public static final String CONNECTION_ATTEMPTS =
-          JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG;
-  private static final String CONNECTION_ATTEMPTS_DOC
-          = "Maximum number of attempts to retrieve a valid JDBC connection. "
-          + "Must be a positive integer.";
-  private static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
-  public static final int CONNECTION_ATTEMPTS_DEFAULT = 3;
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_CONFIG;
+  private static final String CONNECTION_ATTEMPTS_DOC =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DOC;
+  private static final String CONNECTION_ATTEMPTS_DISPLAY =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DISPLAY;
+  public static final int CONNECTION_ATTEMPTS_DEFAULT =
+      JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT;
 
   public static final String CONNECTION_BACKOFF =
-          JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG;
-  private static final String CONNECTION_BACKOFF_DOC
-          = "Backoff time in milliseconds between connection attempts.";
-  private static final String CONNECTION_BACKOFF_DISPLAY
-          = "JDBC connection backoff in milliseconds";
-  public static final long CONNECTION_BACKOFF_DEFAULT = 10000L;
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_CONFIG;
+  private static final String CONNECTION_BACKOFF_DOC =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DOC;
+  private static final String CONNECTION_BACKOFF_DISPLAY =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DISPLAY;
+  public static final long CONNECTION_BACKOFF_DEFAULT =
+      JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT;
 
   public static final String TABLE_NAME_FORMAT = "table.name.format";
   private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -71,16 +71,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
   public static final String CONNECTION_ATTEMPTS_CONFIG = CONNECTION_PREFIX + "attempts";
-  private static final String CONNECTION_ATTEMPTS_DOC
+  public static final String CONNECTION_ATTEMPTS_DOC
       = "Maximum number of attempts to retrieve a valid JDBC connection. "
           + "Must be a positive integer.";
-  private static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
+  public static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
   public static final int CONNECTION_ATTEMPTS_DEFAULT = 3;
 
   public static final String CONNECTION_BACKOFF_CONFIG = CONNECTION_PREFIX + "backoff.ms";
-  private static final String CONNECTION_BACKOFF_DOC
+  public static final String CONNECTION_BACKOFF_DOC
       = "Backoff time in milliseconds between connection attempts.";
-  private static final String CONNECTION_BACKOFF_DISPLAY
+  public static final String CONNECTION_BACKOFF_DISPLAY
       = "JDBC connection backoff in milliseconds";
   public static final long CONNECTION_BACKOFF_DEFAULT = 10000L;
 

--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
-
 public class CachedConnectionProvider implements ConnectionProvider {
 
   private static final Logger log = LoggerFactory.getLogger(CachedConnectionProvider.class);
@@ -36,14 +34,6 @@ public class CachedConnectionProvider implements ConnectionProvider {
 
   private int count = 0;
   private Connection connection;
-
-  public CachedConnectionProvider(
-      ConnectionProvider provider
-  ) {
-    this(provider, JdbcSourceConnectorConfig.CONNECTION_ATTEMPTS_DEFAULT,
-         JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT
-    );
-  }
 
   public CachedConnectionProvider(
       ConnectionProvider provider,


### PR DESCRIPTION
…red for sink connectors

Currently it's hard coded to JdbcSourceConnectorConfig defaults.

I believe this resolves #515 and #648  