### PR TITLE
Correction for paused Task with MySql (working with others JDBC connecteurs )

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -103,20 +103,20 @@ public class JdbcSourceTask extends SourceTask {
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
     if ((tables.isEmpty() && query.isEmpty()) || (!tables.isEmpty() && !query.isEmpty())) {
       throw new ConnectException("Invalid configuration: each JdbcSourceTask must have at "
-                                        + "least one table assigned to it or one query specified");
+              + "least one table assigned to it or one query specified");
     }
     TableQuerier.QueryMode queryMode = !query.isEmpty() ? TableQuerier.QueryMode.QUERY :
-                                       TableQuerier.QueryMode.TABLE;
+            TableQuerier.QueryMode.TABLE;
     List<String> tablesOrQuery = queryMode == TableQuerier.QueryMode.QUERY
-                                 ? Collections.singletonList(query) : tables;
+            ? Collections.singletonList(query) : tables;
 
     String mode = config.getString(JdbcSourceTaskConfig.MODE_CONFIG);
     //used only in table mode
     Map<String, List<Map<String, String>>> partitionsByTableFqn = new HashMap<>();
     Map<Map<String, String>, Map<String, Object>> offsets = null;
     if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)
-        || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)
-        || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
+            || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)
+            || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
       List<Map<String, String>> partitions = new ArrayList<>(tables.size());
       switch (queryMode) {
         case TABLE:
@@ -132,7 +132,7 @@ public class JdbcSourceTask extends SourceTask {
         case QUERY:
           log.trace("Starting in QUERY mode");
           partitions.add(Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-                                                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE));
+                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE));
           break;
         default:
           throw new ConnectException("Unknown query mode: " + queryMode);
@@ -142,13 +142,13 @@ public class JdbcSourceTask extends SourceTask {
     }
 
     String incrementingColumn
-        = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+            = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
     List<String> timestampColumns
-        = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+            = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
     Long timestampDelayInterval
-        = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
+            = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
-        = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+            = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
     TimeZone timeZone = config.timeZone();
     String suffix = config.getString(JdbcSourceTaskConfig.QUERY_SUFFIX_CONFIG).trim();
 
@@ -159,18 +159,18 @@ public class JdbcSourceTask extends SourceTask {
         case TABLE:
           if (validateNonNulls) {
             validateNonNullable(
-                mode,
-                tableOrQuery,
-                incrementingColumn,
-                timestampColumns
+                    mode,
+                    tableOrQuery,
+                    incrementingColumn,
+                    timestampColumns
             );
           }
           tablePartitionsToCheck = partitionsByTableFqn.get(tableOrQuery);
           break;
         case QUERY:
           partition = Collections.singletonMap(
-              JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-              JdbcSourceConnectorConstants.QUERY_NAME_VALUE
+                  JdbcSourceConnectorConstants.QUERY_NAME_KEY,
+                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE
           );
           tablePartitionsToCheck = Collections.singletonList(partition);
           break;
@@ -197,58 +197,58 @@ public class JdbcSourceTask extends SourceTask {
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(
-            new BulkTableQuerier(
-                dialect, 
-                queryMode, 
-                tableOrQuery, 
-                topicPrefix, 
-                suffix
-            )
+                new BulkTableQuerier(
+                        dialect,
+                        queryMode,
+                        tableOrQuery,
+                        topicPrefix,
+                        suffix
+                )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(
-            new TimestampIncrementingTableQuerier(
-                dialect,
-                queryMode,
-                tableOrQuery,
-                topicPrefix,
-                null,
-                incrementingColumn,
-                offset,
-                timestampDelayInterval,
-                timeZone,
-                suffix
-            )
+                new TimestampIncrementingTableQuerier(
+                        dialect,
+                        queryMode,
+                        tableOrQuery,
+                        topicPrefix,
+                        null,
+                        incrementingColumn,
+                        offset,
+                        timestampDelayInterval,
+                        timeZone,
+                        suffix
+                )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(
-            new TimestampIncrementingTableQuerier(
-                dialect,
-                queryMode,
-                tableOrQuery,
-                topicPrefix,
-                timestampColumns,
-                null,
-                offset,
-                timestampDelayInterval,
-                timeZone,
-                suffix
-            )
+                new TimestampIncrementingTableQuerier(
+                        dialect,
+                        queryMode,
+                        tableOrQuery,
+                        topicPrefix,
+                        timestampColumns,
+                        null,
+                        offset,
+                        timestampDelayInterval,
+                        timeZone,
+                        suffix
+                )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(
-            new TimestampIncrementingTableQuerier(
-                dialect,
-                queryMode,
-                tableOrQuery,
-                topicPrefix,
-                timestampColumns,
-                incrementingColumn,
-                offset,
-                timestampDelayInterval,
-                timeZone,
-                suffix
-            )
+                new TimestampIncrementingTableQuerier(
+                        dialect,
+                        queryMode,
+                        tableOrQuery,
+                        topicPrefix,
+                        timestampColumns,
+                        incrementingColumn,
+                        offset,
+                        timestampDelayInterval,
+                        timeZone,
+                        suffix
+                )
         );
       }
     }
@@ -272,8 +272,8 @@ public class JdbcSourceTask extends SourceTask {
   private List<Map<String, String>> possibleTablePartitions(String table) {
     TableId tableId = dialect.parseTableIdentifier(table);
     return Arrays.asList(
-        OffsetProtocols.sourcePartitionForProtocolV1(tableId),
-        OffsetProtocols.sourcePartitionForProtocolV0(tableId)
+            OffsetProtocols.sourcePartitionForProtocolV1(tableId),
+            OffsetProtocols.sourcePartitionForProtocolV0(tableId)
     );
   }
 
@@ -348,13 +348,18 @@ public class JdbcSourceTask extends SourceTask {
       if (!querier.querying()) {
         // If not in the middle of an update, wait for next update time
         final long nextUpdate = querier.getLastUpdate()
-            + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
+                + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
         final long now = time.milliseconds();
         final long sleepMs = Math.min(nextUpdate - now, 100);
         if (sleepMs > 0) {
           log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
-          time.sleep(sleepMs);
-          continue; // Re-check stop flag before continuing
+          if (running.get()) {
+            log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
+            time.sleep(sleepMs);
+            continue; // Re-check stop flag before continuing
+          } else {
+            break;
+          }
         }
       }
 
@@ -412,10 +417,10 @@ public class JdbcSourceTask extends SourceTask {
   }
 
   private void validateNonNullable(
-      String incrementalMode,
-      String table,
-      String incrementingColumn,
-      List<String> timestampColumns
+          String incrementalMode,
+          String table,
+          String incrementingColumn,
+          List<String> timestampColumns
   ) {
     try {
       Set<String> lowercaseTsColumns = new HashSet<>();
@@ -448,23 +453,23 @@ public class JdbcSourceTask extends SourceTask {
       // for table-based copying because custom query mode doesn't allow this to be looked up
       // without a query or parsing the query since we don't have a table name.
       if ((incrementalMode.equals(JdbcSourceConnectorConfig.MODE_INCREMENTING)
-           || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
-          && incrementingOptional) {
+              || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
+              && incrementingOptional) {
         throw new ConnectException("Cannot make incremental queries using incrementing column "
-                                   + incrementingColumn + " on " + table + " because this column "
-                                   + "is nullable.");
+                + incrementingColumn + " on " + table + " because this column "
+                + "is nullable.");
       }
       if ((incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP)
-           || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
-          && !atLeastOneTimestampNotOptional) {
+              || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
+              && !atLeastOneTimestampNotOptional) {
         throw new ConnectException("Cannot make incremental queries using timestamp columns "
-                                   + timestampColumns + " on " + table + " because all of these "
-                                   + "columns "
-                                   + "nullable.");
+                + timestampColumns + " on " + table + " because all of these "
+                + "columns "
+                + "nullable.");
       }
     } catch (SQLException e) {
       throw new ConnectException("Failed trying to validate that columns used for offsets are NOT"
-                                 + " NULL", e);
+              + " NULL", e);
     }
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -352,9 +352,9 @@ public class JdbcSourceTask extends SourceTask {
         final long now = time.milliseconds();
         final long sleepMs = Math.min(nextUpdate - now, 100);
         if (sleepMs > 0) {
+          log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
+          time.sleep(sleepMs);
           if (running.get()) {
-            log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
-            time.sleep(sleepMs);
             continue; // Re-check stop flag before continuing
           } else {
             break;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -354,10 +354,10 @@ public class JdbcSourceTask extends SourceTask {
         if (sleepMs > 0) {
           log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
           time.sleep(sleepMs); //Here the sleep don't get the Stop signal for the thread.
-          if (running.get()) { // Re-check stop flag before continuing
-            continue;  //If the task is still running no problem with it it can continue
+          if (running.get()) {
+            continue;  // Re-check stop flag before continuing
           } else {
-            break; //else before we were waiting the end of the poll (so they were some leak) now we exit if we need to stop before pull any data.
+            break;
           }
         }
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -103,20 +103,20 @@ public class JdbcSourceTask extends SourceTask {
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
     if ((tables.isEmpty() && query.isEmpty()) || (!tables.isEmpty() && !query.isEmpty())) {
       throw new ConnectException("Invalid configuration: each JdbcSourceTask must have at "
-              + "least one table assigned to it or one query specified");
+                                        + "least one table assigned to it or one query specified");
     }
     TableQuerier.QueryMode queryMode = !query.isEmpty() ? TableQuerier.QueryMode.QUERY :
-            TableQuerier.QueryMode.TABLE;
+                                       TableQuerier.QueryMode.TABLE;
     List<String> tablesOrQuery = queryMode == TableQuerier.QueryMode.QUERY
-            ? Collections.singletonList(query) : tables;
+                                 ? Collections.singletonList(query) : tables;
 
     String mode = config.getString(JdbcSourceTaskConfig.MODE_CONFIG);
     //used only in table mode
     Map<String, List<Map<String, String>>> partitionsByTableFqn = new HashMap<>();
     Map<Map<String, String>, Map<String, Object>> offsets = null;
     if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)
-            || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)
-            || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
+        || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)
+        || mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
       List<Map<String, String>> partitions = new ArrayList<>(tables.size());
       switch (queryMode) {
         case TABLE:
@@ -132,7 +132,7 @@ public class JdbcSourceTask extends SourceTask {
         case QUERY:
           log.trace("Starting in QUERY mode");
           partitions.add(Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE));
+                                                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE));
           break;
         default:
           throw new ConnectException("Unknown query mode: " + queryMode);
@@ -142,13 +142,13 @@ public class JdbcSourceTask extends SourceTask {
     }
 
     String incrementingColumn
-            = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+        = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
     List<String> timestampColumns
-            = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+        = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
     Long timestampDelayInterval
-            = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
+        = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
-            = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
+        = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
     TimeZone timeZone = config.timeZone();
     String suffix = config.getString(JdbcSourceTaskConfig.QUERY_SUFFIX_CONFIG).trim();
 
@@ -159,18 +159,18 @@ public class JdbcSourceTask extends SourceTask {
         case TABLE:
           if (validateNonNulls) {
             validateNonNullable(
-                    mode,
-                    tableOrQuery,
-                    incrementingColumn,
-                    timestampColumns
+                mode,
+                tableOrQuery,
+                incrementingColumn,
+                timestampColumns
             );
           }
           tablePartitionsToCheck = partitionsByTableFqn.get(tableOrQuery);
           break;
         case QUERY:
           partition = Collections.singletonMap(
-                  JdbcSourceConnectorConstants.QUERY_NAME_KEY,
-                  JdbcSourceConnectorConstants.QUERY_NAME_VALUE
+              JdbcSourceConnectorConstants.QUERY_NAME_KEY,
+              JdbcSourceConnectorConstants.QUERY_NAME_VALUE
           );
           tablePartitionsToCheck = Collections.singletonList(partition);
           break;
@@ -197,58 +197,58 @@ public class JdbcSourceTask extends SourceTask {
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(
-                new BulkTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        suffix
-                )
+            new BulkTableQuerier(
+                dialect,
+                queryMode,
+                tableOrQuery,
+                topicPrefix,
+                suffix
+            )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
         tableQueue.add(
-                new TimestampIncrementingTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        null,
-                        incrementingColumn,
-                        offset,
-                        timestampDelayInterval,
-                        timeZone,
-                        suffix
-                )
+            new TimestampIncrementingTableQuerier(
+                dialect,
+                queryMode,
+                tableOrQuery,
+                topicPrefix,
+                null,
+                incrementingColumn,
+                offset,
+                timestampDelayInterval,
+                timeZone,
+                suffix
+            )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(
-                new TimestampIncrementingTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        timestampColumns,
-                        null,
-                        offset,
-                        timestampDelayInterval,
-                        timeZone,
-                        suffix
-                )
+            new TimestampIncrementingTableQuerier(
+                dialect,
+                queryMode,
+                tableOrQuery,
+                topicPrefix,
+                timestampColumns,
+                null,
+                offset,
+                timestampDelayInterval,
+                timeZone,
+                suffix
+            )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
         tableQueue.add(
-                new TimestampIncrementingTableQuerier(
-                        dialect,
-                        queryMode,
-                        tableOrQuery,
-                        topicPrefix,
-                        timestampColumns,
-                        incrementingColumn,
-                        offset,
-                        timestampDelayInterval,
-                        timeZone,
-                        suffix
-                )
+            new TimestampIncrementingTableQuerier(
+                dialect,
+                queryMode,
+                tableOrQuery,
+                topicPrefix,
+                timestampColumns,
+                incrementingColumn,
+                offset,
+                timestampDelayInterval,
+                timeZone,
+                suffix
+            )
         );
       }
     }
@@ -272,8 +272,8 @@ public class JdbcSourceTask extends SourceTask {
   private List<Map<String, String>> possibleTablePartitions(String table) {
     TableId tableId = dialect.parseTableIdentifier(table);
     return Arrays.asList(
-            OffsetProtocols.sourcePartitionForProtocolV1(tableId),
-            OffsetProtocols.sourcePartitionForProtocolV0(tableId)
+        OffsetProtocols.sourcePartitionForProtocolV1(tableId),
+        OffsetProtocols.sourcePartitionForProtocolV0(tableId)
     );
   }
 
@@ -348,11 +348,10 @@ public class JdbcSourceTask extends SourceTask {
       if (!querier.querying()) {
         // If not in the middle of an update, wait for next update time
         final long nextUpdate = querier.getLastUpdate()
-                + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
+            + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
         final long now = time.milliseconds();
         final long sleepMs = Math.min(nextUpdate - now, 100);
         if (sleepMs > 0) {
-          log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
           if (running.get()) {
             log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
             time.sleep(sleepMs);
@@ -417,10 +416,10 @@ public class JdbcSourceTask extends SourceTask {
   }
 
   private void validateNonNullable(
-          String incrementalMode,
-          String table,
-          String incrementingColumn,
-          List<String> timestampColumns
+      String incrementalMode,
+      String table,
+      String incrementingColumn,
+      List<String> timestampColumns
   ) {
     try {
       Set<String> lowercaseTsColumns = new HashSet<>();
@@ -453,23 +452,23 @@ public class JdbcSourceTask extends SourceTask {
       // for table-based copying because custom query mode doesn't allow this to be looked up
       // without a query or parsing the query since we don't have a table name.
       if ((incrementalMode.equals(JdbcSourceConnectorConfig.MODE_INCREMENTING)
-              || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
-              && incrementingOptional) {
+           || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
+          && incrementingOptional) {
         throw new ConnectException("Cannot make incremental queries using incrementing column "
-                + incrementingColumn + " on " + table + " because this column "
-                + "is nullable.");
+                                   + incrementingColumn + " on " + table + " because this column "
+                                   + "is nullable.");
       }
       if ((incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP)
-              || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
-              && !atLeastOneTimestampNotOptional) {
+           || incrementalMode.equals(JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING))
+          && !atLeastOneTimestampNotOptional) {
         throw new ConnectException("Cannot make incremental queries using timestamp columns "
-                + timestampColumns + " on " + table + " because all of these "
-                + "columns "
-                + "nullable.");
+                                   + timestampColumns + " on " + table + " because all of these "
+                                   + "columns "
+                                   + "nullable.");
       }
     } catch (SQLException e) {
       throw new ConnectException("Failed trying to validate that columns used for offsets are NOT"
-              + " NULL", e);
+                                 + " NULL", e);
     }
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -353,11 +353,11 @@ public class JdbcSourceTask extends SourceTask {
         final long sleepMs = Math.min(nextUpdate - now, 100);
         if (sleepMs > 0) {
           log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
-          time.sleep(sleepMs);
-          if (running.get()) {
-            continue; // Re-check stop flag before continuing
+          time.sleep(sleepMs); //Here the sleep don't get the Stop signal for the thread.
+          if (running.get()) { // Re-check stop flag before continuing
+            continue;  //If the task is still running no problem with it it can continue
           } else {
-            break;
+            break; //else before we were waiting the end of the poll (so they were some leak) now we exit if we need to stop before pull any data.
           }
         }
       }


### PR DESCRIPTION
# Description

I had a check of stop flag before to pull any data (to avoid after a sleep method to poll data)

# Fixes 
Following this [problem](https://github.com/confluentinc/kafka-connect-jdbc/issues/374).
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
I launch a worker (in distributed mode ) with my modified version of JDBC connector 
I created a JDBC (mySql) connector : 
```bash
curl -X POST \
  http://localhost:8083/connectors \
  -H 'Content-Type: application/json' \
  -d '{ "name": "JDBC_My_SQL",
  "config": {
  "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
  "mode": "bulk",
  "incrementing.column.name": "id",
  "tasks.max": "2",
  "topic.prefix": "JDBC_",
  "topic": "testFinal",
  "connection.user":"Schmidt96u",
  "connection.password":"mdp123",
  "connection.url": "jdbc:mysql://127.0.0.1:3306/JDBCTEST",
  "table.whitelist": "test"
  }
}
'
```

I looked at his status : 

```JSON
{"name":"JDBC_My_SQL","config":{"connector.class":"io.confluent.connect.jdbc.JdbcSourceConnector","mode":"bulk","incrementing.column.name":"id","topic.prefix":"JDBC_","connection.password":"mdp123","tasks.max":"2","connection.user":"Schmidt96u","name":"JDBC_My_SQL","topic":"testFinal","connection.url":"jdbc:mysql://127.0.0.1:3306/JDBCTEST","table.whitelist":"test"},"tasks":[{"connector":"JDBC_My_SQL","task":0}],"type":"source"}{"name":"JDBC_My_SQL","connector":{"state":"RUNNING","worker_id":"localhost:8083"},"tasks":[{"id":0,"state":"RUNNING","worker_id":"localhost:8083"}],"type":"source"}
```
And next i just paused it : 

* Before : 
```JSON

{"name":"JDBC_My_SQL","config":{"connector.class":"io.confluent.connect.jdbc.JdbcSourceConnector","mode":"bulk","incrementing.column.name":"id","topic.prefix":"JDBC_","connection.password":"mdp123","tasks.max":"2","connection.user":"Schmidt96u","name":"JDBC_My_SQL","topic":"testFinal","connection.url":"jdbc:mysql://127.0.0.1:3306/JDBCTEST","table.whitelist":"test"},"tasks":[{"connector":"JDBC_My_SQL","task":0}],"type":"source"}{"name":"JDBC_My_SQL","connector":{"state":"PAUSED","worker_id":"localhost:8083"},"tasks":[{"id":0,"state":"RUNNING","worker_id":"localhost:8083"}],"type":"source"}

```

* After change : 

```JSON

{"name":"JDBC_My_SQL","config":{"connector.class":"io.confluent.connect.jdbc.JdbcSourceConnector","mode":"bulk","incrementing.column.name":"id","topic.prefix":"JDBC_","connection.password":"mdp123","tasks.max":"2","connection.user":"Schmidt96u","name":"JDBC_My_SQL","topic":"testFinal","connection.url":"jdbc:mysql://127.0.0.1:3306/JDBCTEST","table.whitelist":"test"},"tasks":[{"connector":"JDBC_My_SQL","task":0}],"type":"source"}{"name":"JDBC_My_SQL","connector":{"state":"PAUSED","worker_id":"localhost:8083"},"tasks":[{"id":0,"state":"PAUSED","worker_id":"localhost:8083"}],"type":"source"}

```
I Insert some value in mySql db, and they were not add if a pause was send (even if the task is seen as RUNNING" we are leaving the poll before any action [here](https://github.com/Schmidt96u/kafka-connect-jdbc/blob/4887aa3c41fabcfe0e12847f24c9549acfb43f6f/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java#L357)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules