### PR TITLE
Override currentTimestampDatabaseQuery

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialect.java
@@ -65,6 +65,11 @@ public class SapHanaDatabaseDialect extends GenericDatabaseDialect {
   protected String checkConnectionQuery() {
     return "SELECT DATABASE_NAME FROM SYS.M_DATABASES";
   }
+  
+  @Override
+  protected String currentTimestampDatabaseQuery() {
+    return "SELECT CURRENT_TIMESTAMP FROM DUMMY";
+  }
 
   @Override
   protected String getSqlType(SinkRecordField field) {


### PR DESCRIPTION
Currently, kafka-JDBC-connect does not work for SAP Hana with timestamp. This changes will correct the error.