### PR TITLE
CC-8750: Changed the dialects to sanitize all URL properties that case-insensitively contain “password”

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1742,12 +1742,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   /**
    * Return the sanitized form of the supplied JDBC URL, which masks any secrets or credentials.
    *
+   * <p>This implementation replaces the value of all properties that contain {@code password}.
+   *
    * @param url the JDBC URL; may not be null
    * @return the sanitized URL; never null
    */
   protected String sanitizedUrl(String url) {
     // Only replace standard URL-type properties ...
-    return url.replaceAll("(?i)([?&]([^=&]*)password([^=]*)=)[^&]*", "$1****");
+    return url.replaceAll("(?i)([?&]([^=&]*)password([^=&]*)=)[^&]*", "$1****");
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1747,7 +1747,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    */
   protected String sanitizedUrl(String url) {
     // Only replace standard URL-type properties ...
-    return url.replaceAll("(?i)([?&]password=)[^&]*", "$1****");
+    return url.replaceAll("(?i)([?&]([^=&]*)password([^=]*)=)[^&]*", "$1****");
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -404,4 +404,34 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
         + "user=smith&password=****&other=value"
     );
   }
+
+  @Test
+  public void shouldSanitizeUrlWithManyPasswordVariationsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:acme:db/foo:100?"
+        + "javax.net.ssl.keyStorePassword=secret2&"
+        + "password=secret&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=value3&"
+        + "javax.net.ssl.trustStorePassword=superSecret&"
+        + "user=smith&"
+        + "Password=secret&"
+        + "other=value",
+        "jdbc:acme:db/foo:100?"
+        + "javax.net.ssl.keyStorePassword=****&"
+        + "password=****&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=****&"
+        + "javax.net.ssl.trustStorePassword=****&"
+        + "user=smith&"
+        + "Password=****&"
+        + "other=value"
+    );
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -411,6 +411,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
         "jdbc:acme:db/foo:100?"
         + "javax.net.ssl.keyStorePassword=secret2&"
         + "password=secret&"
+        + "password&" // incorrect parameter before a non-secret
         + "key1=value1&"
         + "key2=value2&"
         + "key3=value3&"
@@ -423,6 +424,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
         "jdbc:acme:db/foo:100?"
         + "javax.net.ssl.keyStorePassword=****&"
         + "password=****&"
+        + "password&"
         + "key1=value1&"
         + "key2=value2&"
         + "key3=value3&"

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -239,4 +239,42 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
         + "key2=value2&key3=value3&user=smith&password=****&other=value"
     );
   }
+
+  @Test
+  public void shouldSanitizeUrlWithKerberosCredentialsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:oracle:thin:@myhost:1111/db?"
+        + "password=secret&"
+        + "javax.net.ssl.keyStorePassword=secret2&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "user=smith&"
+        + "password=secret&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=value3&"
+        + "javax.net.ssl.trustStorePassword=superSecret&"
+        + "OCINewPassword=secret2&"
+        + "oracle.net.wallet_password=secret3&"
+        + "proxy_password=secret4&"
+        + "PROXY_USER_PASSWORD=secret5&"
+        + "other=value",
+        "jdbc:oracle:thin:@myhost:1111/db?"
+        + "password=****&"
+        + "javax.net.ssl.keyStorePassword=****&"
+        + "key1=value1&"
+        + "key2=value2&"
+        + "key3=value3&"
+        + "user=smith&"
+        + "password=****&"
+        + "passworNotSanitized=not-secret&"
+        + "passwordShouldBeSanitized=****&"
+        + "javax.net.ssl.trustStorePassword=****&"
+        + "OCINewPassword=****&"
+        + "oracle.net.wallet_password=****&"
+        + "proxy_password=****&"
+        + "PROXY_USER_PASSWORD=****&"
+        + "other=value"
+    );
+  }
 }


### PR DESCRIPTION
Now sanitizing any URL property that case-insensitively contains (and not just equal to) `password`. Also added a few dialect-specific tests to ensure that different dialects are sanitizing DBMS-specific properties.

Applying to 5.0.x and newer.