### PR TITLE
CC-9567: Allow users to define extra connection properties individually rather than only through JDBC URI

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -328,8 +328,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     // Get the set of config keys that are known to the connector
     Set<String> configKeys = config.values().keySet();
     // Add any configuration property that begins with 'connection.` and that is not known
-    config.originalsWithPrefix("connection.").forEach((k,v) -> {
-      if (!configKeys.contains("connection." + k)) {
+    config.originalsWithPrefix(JdbcSourceConnectorConfig.CONNECTION_PREFIX).forEach((k,v) -> {
+      if (!configKeys.contains(JdbcSourceConnectorConfig.CONNECTION_PREFIX + k)) {
         properties.put(k, v);
       }
     });

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -51,7 +51,9 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceConnectorConfig.class);
 
-  public static final String CONNECTION_URL_CONFIG = "connection.url";
+  public static final String CONNECTION_PREFIX = "connection.";
+
+  public static final String CONNECTION_URL_CONFIG = CONNECTION_PREFIX + "url";
   private static final String CONNECTION_URL_DOC =
       "JDBC connection URL.\n"
           + "For example: ``jdbc:oracle:thin:@localhost:1521:orclpdb1``, "
@@ -60,22 +62,22 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "databaseName=db_name``";
   private static final String CONNECTION_URL_DISPLAY = "JDBC URL";
 
-  public static final String CONNECTION_USER_CONFIG = "connection.user";
+  public static final String CONNECTION_USER_CONFIG = CONNECTION_PREFIX + "user";
   private static final String CONNECTION_USER_DOC = "JDBC connection user.";
   private static final String CONNECTION_USER_DISPLAY = "JDBC User";
 
-  public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
+  public static final String CONNECTION_PASSWORD_CONFIG = CONNECTION_PREFIX + "password";
   private static final String CONNECTION_PASSWORD_DOC = "JDBC connection password.";
   private static final String CONNECTION_PASSWORD_DISPLAY = "JDBC Password";
 
-  public static final String CONNECTION_ATTEMPTS_CONFIG = "connection.attempts";
+  public static final String CONNECTION_ATTEMPTS_CONFIG = CONNECTION_PREFIX + "attempts";
   private static final String CONNECTION_ATTEMPTS_DOC
       = "Maximum number of attempts to retrieve a valid JDBC connection. "
           + "Must be a positive integer.";
   private static final String CONNECTION_ATTEMPTS_DISPLAY = "JDBC connection attempts";
   public static final int CONNECTION_ATTEMPTS_DEFAULT = 3;
 
-  public static final String CONNECTION_BACKOFF_CONFIG = "connection.backoff.ms";
+  public static final String CONNECTION_BACKOFF_CONFIG = CONNECTION_PREFIX + "backoff.ms";
   private static final String CONNECTION_BACKOFF_DOC
       = "Backoff time in milliseconds between connection attempts.";
   private static final String CONNECTION_BACKOFF_DISPLAY

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/MySQLOOMIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/MySQLOOMIT.java
@@ -26,10 +26,12 @@ public class MySQLOOMIT extends BaseOOMIntegrationTest {
   public void before() {
     props = new HashMap<>();
     props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG,
-        dbRule.getDBConfiguration().getURL("test") + "?useCursorFetch=true");
+        dbRule.getDBConfiguration().getURL("test"));
     props.put(JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG, "root");
     props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, "topic_");
+    // Use "extra" connection properties behavior
+    props.put("connection.useCursorFetch", "true");
   }
 
   protected String buildLargeQuery() {


### PR DESCRIPTION
Extra connection properties are those that are prefixed with `connection.` and that are not already predefined by the connector’s ConfigDef. These properties are added by default in the GenericDatabaseDialect, since the existing `addConnectionProperties(…)` method was not explicitly overridden by any known connector — and if any did but did not call `super. addConnectionProperties(…)`, they just wouldn’t get this feature by default.

Modified one of the MySQL integration tests to pass a connection property via the extra properties rather than via the JDBC URI.

This is to be merged/applied only in the `master` branch for inclusion in the upcoming 6.0.0 release.