### PR TITLE
Explicitly set the PG type when binding a field during sink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>


### PR DESCRIPTION
In a project I am working on we're using the kafka-connect-jdbc connector to materialize an event stream into a PostgreSQL database.

We run into a problem where the incoming fields of type STRING cannot be written to PostgreSQL columns of type uuid, jsonb, etc. The problem manifests itself as:

```
Caused by: org.postgresql.util.PSQLException: ERROR: column "id" is of type uuid but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
  Position: 123
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2533)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2268)
        ... 19 more
```

A workaround we found was to configure implicit casts in the database.
```
CREATE CAST (varchar as uuid) WITH INOUT AS IMPLICIT;
```

The ugly part is that PostgreSQL does not support scoping such casts to a given table/schema but they are always global. As a result, the workaround for a sink connector limitation then affects the entire database.

Therefore, we instead chose to extended the PostgreSqlDatabaseDialect ourselves for it to set the PG type based on the record schema. For example, a message whose key schema is
```
{"type":"string","optional":false, "name": "io.confluent.connect.jdbc.dialect.PostgreSqlDatabaseDialect.pgtype=uuid"}
```

would be written to the database table column of type uuid just fine. The implementation uses org.postgresql.util.PGobject to achieve that.

The idea is that the event stream schema would not necessarily define these PostgreSQL-specific names but an SMT on the sink side would be used to alter the names so that the sink connector can then assign proper types when writing the record to the database

We're using the extended dialect as a workaround for
- https://github.com/confluentinc/kafka-connect-jdbc/issues/46
- https://github.com/confluentinc/kafka-connect-jdbc/issues/81


**This PR is not expected to be merged in its current form**. Instead I am submitting this PR to get feedback from maintainers about:
- is this approach reasonable? are there alternative/better approaches to deal with the current limitation?
- if so, what format should the schema name prefix have?
- what else needs to change for this to be considered for merging?

Thanks in advance