### PR TITLE
Required DB2DatabaseDialect to support  `Insert or Ignore` Upsert style

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -187,6 +187,9 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     Map<String, String> connProps = new HashMap<>();
     connProps.putAll(propertiesFromPairs(propertyPairs));
     connProps.put(JdbcSinkConfig.CONNECTION_URL, url);
+    if (quoteIdentfiiers != null) {
+      connProps.put("quote.sql.identifiers", quoteIdentfiiers.toString());
+    }
     return new JdbcSinkConfig(connProps);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -67,6 +67,19 @@ public class JdbcSinkConfigTest {
   }
 
   @Test
+  public void shouldCreateConfigWithDefaultUpsertStyle() {
+    createConfig();
+    assertEquals(config.upsertStyle, JdbcSinkConfig.UpsertStyle.DEFAULT);
+  }
+
+  @Test
+  public void shouldCreateConfigWithGivenUpsertStyle() {
+    props.put("upsert.style", "insert_or_ignore");
+    createConfig();
+    assertEquals(config.upsertStyle, JdbcSinkConfig.UpsertStyle.INSERT_OR_IGNORE);
+  }
+
+  @Test
   public void shouldCreateConfigWithViewOnly() {
     props.put("table.types", "view");
     createConfig();


### PR DESCRIPTION
## Problem
We had a trigger that was processing on each inserted record and updates the record's status column to processed. While kafka-connect-jdbc retries with upsert it updates that status column back to pending;
DB2DatabaseDialect by default supports `INSERT OR UPDATE` but we required `INSERT OR IGNORE`

Fix for #874 

## Solution

1. Add UpsertStyle configuration in JdbcSinkConfig
2. Update Db2DatabaseDialect to read UpsertStyle config
3. Update Db2DatabaseDialect to build the merge statement based on the UpsertStyle

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ x] yes
- [ ] no

##### If yes, where?
1. This UpsertStyle configuration can be used by any other DatabaseDialect to provide support for `INSERT OR UPDATE` and `INSERT OR IGNORE` UpsertStyle

## Test Strategy

1. If UpsertStyle is not provided this will be taken as default which means as it was working before this configuration. So there is no impact on an existing application using `kafka-connect-jdbc`.

- Test config value if this configuration is not provided
- Test config value if this configuration is provided

2. DB2DatabaseDialect to generate the merge statement based on this style.
 
- Test merge sql statement for all type of upsert combination when `upsert.style=insert_or_ignore` 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan

We can merge it to master so that this functionality is available for everyone.  Going forward all other DatabseDialect can also be updated to respect this configuration is possible.
