### PR TITLE
Add the possibility for dialects to provide a SQL type for null values

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1535,7 +1535,12 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       Object value
   ) throws SQLException {
     if (value == null) {
-      statement.setObject(index, null);
+      Integer type = getSqlTypeForSchema(schema);
+      if (type != null) {
+        statement.setNull(index, type);
+      } else {
+        statement.setObject(index, null);
+      }
     } else {
       boolean bound = maybeBindLogical(statement, index, schema, value);
       if (!bound) {
@@ -1545,6 +1550,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         throw new ConnectException("Unsupported source data type: " + schema.type());
       }
     }
+  }
+
+  /**
+   * Dialects not supporting `setObject(index, null)` can override this method
+   * to provide a specific sqlType, as per the JDBC documentation
+   * https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html
+   */
+  protected Integer getSqlTypeForSchema(Schema schema) {
+    return null;
   }
 
   protected boolean maybeBindPrimitive(


### PR DESCRIPTION
## Problem

`statement.setObject(index, null);` is discouraged by JDBC, as per [`setObject` documentation](https://docs.oracle.com/javase/10/docs/api/java/sql/PreparedStatement.html#setObject(int,java.lang.Object)), as some dialects may not support it.

## Solution

A `getSqlTypeForSchema(Schema schema)` method is added. This method can be left alone for dialects that don't need it, or overridden when required. Nothing is affected unless a dialect overrides that method.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no
- [x] I don't understand the question

##### If yes, where?


## Test Strategy

This code has been tested together with a dialect that uses that method and provides SQL types for the different values of `schema`.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- Unit tests have been included in the dialect that use this particular method (not present in this library)
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
This can be included in any future release. If possible in both 6.x and 5.5.x.
