### PR TITLE
CC-10823: Require non-tombstone records when deletes are disabled

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -65,6 +65,9 @@ public interface RecordValidator {
     if (config.deleteEnabled) {
       // When delete is enabled, we need a key
       keyValidator = keyValidator.and(requiresKey);
+    } else {
+      // When delete is disabled, we need non-tombstone values
+      valueValidator = valueValidator.and(requiresValue);
     }
 
     // Compose the validator that may or may be NO_OP

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -559,12 +559,12 @@ public class BufferedRecordsTest {
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "id");
 
-    // Delete is not enabled, so therefore require non-null key and key schema,
-    // but any combination of value and value schema works
+    // Delete is not enabled, so therefore require non-null key and values with schemas
     assertValidRecord(true, true, true, true);
-    assertValidRecord(true, true, false, true);
-    assertValidRecord(true, true, true, false);
-    assertValidRecord(true, true, false, false);
+    // Fail when ingesting tombstones
+    assertInvalidRecord(true, true, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, false, false, "with a non-null Struct value and non-null Struct schema");
 
     // Fail when null key and null key schema
     assertInvalidRecord(false, false, true, true, "with a null key and null key schema");
@@ -624,20 +624,20 @@ public class BufferedRecordsTest {
     assertValidRecord(true, false, true, true);
     assertValidRecord(false, false, true, true);
 
-    assertValidRecord(true, true, true, false);
-    assertValidRecord(false, true, true, false);
-    assertValidRecord(true, false, true, false);
-    assertValidRecord(false, false, true, false);
+    assertInvalidRecord(true, true, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, true, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, false, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, false, true, false, "with a non-null Struct value and non-null Struct schema");
 
-    assertValidRecord(true, true, false, true);
-    assertValidRecord(false, true, false, true);
-    assertValidRecord(true, false, false, true);
-    assertValidRecord(false, false, false, true);
+    assertInvalidRecord(true, true, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, true, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, false, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, false, false, true, "with a non-null Struct value and non-null Struct schema");
 
-    assertValidRecord(true, true, false, false);
-    assertValidRecord(false, true, false, false);
-    assertValidRecord(true, false, false, false);
-    assertValidRecord(false, false, false, false);
+    assertInvalidRecord(true, true, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, true, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, false, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(false, false, false, false, "with a non-null Struct value and non-null Struct schema");
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Greg Harris <gregh@confluent.io>

## Problem

Vertica does not validate that fields are bound before completing a batch. This causes tombstones to be incorrectly inserted into the destination database with every column being `null`, instead of the task failing.

## Solution

Use the RecordValidator framework to require a value (non-tombstone) whenever deletes are disabled.
This will throw an exception at the beginning of the write, rather than leaving this validation up to the database driver.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 

Because this behavior technically works for Vertica right now, it's not safe to release this behavior as a patch version. It must only be released in 6.0.0.
This is safe to roll back, as the validation will just begin passing again, and the connector will not fail.
