### PR TITLE
CC-9435: Implement DLQ Support in JDBC Sink

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -87,6 +87,7 @@ public class JdbcSinkTask extends SinkTask {
         for (SinkRecord record : records) {
           retryAndSendDLQ(Collections.singletonList(record));
         }
+        return;
       }
       log.warn(
           "Write of {} records failed, remainingRetries={}",

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -51,7 +51,7 @@ public class JdbcSinkTask extends SinkTask {
     remainingRetries = config.maxRetries;
     try {
       reporter = context.errantRecordReporter(); // may be null if DLQ not enabled
-    } catch (NoClassDefFoundError e) {
+    } catch (NoSuchMethodError | NoClassDefFoundError e) {
       // Will occur in Connect runtimes earlier than 2.6
       reporter = null;
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -116,7 +116,7 @@ public class JdbcSinkTask extends SinkTask {
   private void retryAndSendDLQ(Collection<SinkRecord> records) {
     try {
       writer.write(records);
-  } catch (SQLException e) {
+    } catch (SQLException e) {
       reporter.report(records.iterator().next(), e);
     }
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -324,7 +324,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     task.initialize(ctx);
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
-    expect(reporter.report(anyObject(), anyObject())).andReturn(createMock(Future.class));
+    expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null));
     replayAll();
 
     Map<String, String> props = new HashMap<>();
@@ -378,7 +378,6 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
     task.start(props);
 
-
     task.put(records);
 
     verifyAll();
@@ -424,7 +423,6 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
     task.start(props);
-
 
     task.put(records);
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -241,7 +241,6 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put(JdbcSinkConfig.CONNECTION_URL, "stub");
     props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
-    expect()
     task.start(props);
 
     replayAll();

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -240,6 +241,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put(JdbcSinkConfig.CONNECTION_URL, "stub");
     props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
+    expect()
     task.start(props);
 
     replayAll();

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -34,11 +34,13 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 /**
  * Integration tests for writing to Postgres with UUID columns.
@@ -135,6 +138,7 @@ public class PostgresDatatypeIT {
 
   private void startTask() {
     task = new JdbcSinkTask();
+    task.initialize(mock(SinkTaskContext.class));
     task.start(props);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -19,6 +19,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
@@ -169,7 +170,7 @@ public class PostgresViewIT {
 
   private void startTask() {
     task = new JdbcSinkTask();
-    task.initialize(Mockito.mock(SinkTaskContext.class));
+    task.initialize(mock(SinkTaskContext.class));
     task.start(props);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -37,11 +37,13 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,6 +169,7 @@ public class PostgresViewIT {
 
   private void startTask() {
     task = new JdbcSinkTask();
+    task.initialize(Mockito.mock(SinkTaskContext.class));
     task.start(props);
   }
 


### PR DESCRIPTION
Signed-off-by: Aakash Shah <ashah@confluent.io>

## Problem
Certain errors encountered in the JDBC Sink Connector can be deferred to the DLQ for later access, e.g, a failure to bind a SinkRecord to the statement.

## Solution
When encountering these errors, send the record and its corresponding error to the DLQ.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
TBD