### PR TITLE
Incrementing column delay 5.3.3 post

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -310,6 +310,21 @@ public interface DatabaseDialect extends ConnectionProvider {
    */
   void applyDdlStatements(Connection connection, List<String> statements) throws SQLException;
 
+
+  /**
+   * Build the SELECT prepared statement expression returning maximum id for the given table
+   * and the first column.
+   *
+   * @param table        the identifier of the table; may not be null
+   * @keyColumn          the identifier of the primary key columns; may not be null or empty
+   *
+   * @return the SELECT statement; may not be null
+   */
+  String buildSelectMaxStatement(
+      TableId table,
+      ColumnId keyColumn
+  );
+
   /**
    * Build the INSERT prepared statement expression for the given table and its columns.
    *

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -279,12 +279,14 @@ public interface DatabaseDialect extends ConnectionProvider {
    *
    * @param incrementingColumn the identifier of the incremented column; may be null if there is
    *                           none
+   * @param allowRelaxedIncrementing use upper bound  for incrementing column
    * @param timestampColumns   the identifiers of the timestamp column; may be null if there is
    *                           none
    * @return the {@link TimestampIncrementingCriteria} implementation; never null
    */
   TimestampIncrementingCriteria criteriaFor(
       ColumnId incrementingColumn,
+      boolean allowRelaxedIncrementing,
       List<ColumnId> timestampColumns
   );
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1381,9 +1381,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       ColumnId keyColumn
   ) {
     ExpressionBuilder builder = expressionBuilder();
-    builder.append("SELECT MAX(");
+    builder.append("SELECT COALESCE(MAX(");
     builder.appendColumnName(keyColumn.name());
-    builder.append(") as ");
+    builder.append("),-1) as ");
     builder.appendColumnName(keyColumn.name());
     builder.append(" FROM ");
     builder.appendTableName(table.tableName());

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1383,7 +1383,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     ExpressionBuilder builder = expressionBuilder();
     builder.append("SELECT MAX(");
     builder.appendColumnName(keyColumn.name());
-    builder.append(") FROM ");
+    builder.append(") as ");
+    builder.appendColumnName(keyColumn.name());
+    builder.append(" FROM ");
     builder.appendTableName(table.tableName());
     return builder.toString();
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -855,9 +855,11 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   @Override
   public TimestampIncrementingCriteria criteriaFor(
       ColumnId incrementingColumn,
+      boolean allowIncrementingRelax,
       List<ColumnId> timestampColumns
   ) {
-    return new TimestampIncrementingCriteria(incrementingColumn, timestampColumns, timeZone);
+    return new TimestampIncrementingCriteria(incrementingColumn,
+            allowIncrementingRelax, timestampColumns, timeZone);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1382,9 +1382,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   ) {
     ExpressionBuilder builder = expressionBuilder();
     builder.append("SELECT MAX(");
-    builder.append(keyColumn);
-    builder.append(") FROM");
-    builder.append(table);
+    builder.appendColumnName(keyColumn.name());
+    builder.append(") FROM ");
+    builder.appendTableName(table.tableName());
     return builder.toString();
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1376,6 +1376,19 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
+  public String buildSelectMaxStatement(
+      TableId table,
+      ColumnId keyColumn
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("SELECT MAX(");
+    builder.append(keyColumn);
+    builder.append(") FROM");
+    builder.append(table);
+    return builder.toString();
+  }
+
+  @Override
   public String buildInsertStatement(
       TableId table,
       Collection<ColumnId> keyColumns,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -163,6 +163,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String INCREMENTING_COLUMN_NAME_DEFAULT = "";
   private static final String INCREMENTING_COLUMN_NAME_DISPLAY = "Incrementing Column Name";
 
+  public static final String INCREMENTING_RELAXED_MONOTONIC_CONFIG = "incrementing.relaxed.monotonic";
+  private static final String INCREMENTING_RELAXED_MONOTONIC_DOC =
+          "Slightly relaxes monotonic requirement. Column specified or auto-detected as incrementing column "
+          + "allows values inserted in the last `poll.interval.ms` to be visible out-of-order. Values inserted "
+          + "before `poll.interval.ms` are required to be strictly monotonically increasing. "
+          + "This flag will introduce `poll.interval.ms` delay, but will allow transactions in the source database to be "
+          + "visible within this interval (usable e.g. when reading from read-only replicas).";
+  public static final boolean INCREMENTING_RELAXED_MONOTONIC_DEFAULT = false;
+  private static final String INCREMENTING_RELAXED_MONOTONIC_DISPLAY = "Enabled relaxed monotonic requirement";
+
   public static final String TIMESTAMP_COLUMN_NAME_CONFIG = "timestamp.column.name";
   private static final String TIMESTAMP_COLUMN_NAME_DOC =
       "Comma separated list of one or more timestamp columns to detect new or modified rows using "
@@ -454,6 +464,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         MODE_DISPLAY,
         Arrays.asList(
             INCREMENTING_COLUMN_NAME_CONFIG,
+            INCREMENTING_RELAXED_MONOTONIC_CONFIG,
             TIMESTAMP_COLUMN_NAME_CONFIG,
             VALIDATE_NON_NULL_CONFIG
         )
@@ -479,6 +490,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         Width.MEDIUM,
         TIMESTAMP_COLUMN_NAME_DISPLAY,
         MODE_DEPENDENTS_RECOMMENDER
+    ).define(
+            INCREMENTING_RELAXED_MONOTONIC_CONFIG,
+            Type.BOOLEAN,
+            INCREMENTING_RELAXED_MONOTONIC_DEFAULT,
+            Importance.LOW,
+            INCREMENTING_RELAXED_MONOTONIC_DOC,
+            MODE_GROUP,
+            ++orderInGroup,
+            Width.SHORT,
+            INCREMENTING_RELAXED_MONOTONIC_DISPLAY,
+            MODE_DEPENDENTS_RECOMMENDER
     ).define(
         VALIDATE_NON_NULL_CONFIG,
         Type.BOOLEAN,
@@ -709,10 +731,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_INCREMENTING:
           return name.equals(INCREMENTING_COLUMN_NAME_CONFIG)
-                 || name.equals(VALIDATE_NON_NULL_CONFIG);
+                 || name.equals(VALIDATE_NON_NULL_CONFIG)
+                 || name.equals(INCREMENTING_RELAXED_MONOTONIC_CONFIG);
         case MODE_TIMESTAMP_INCREMENTING:
           return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG)
                  || name.equals(INCREMENTING_COLUMN_NAME_CONFIG)
+                 || name.equals(INCREMENTING_RELAXED_MONOTONIC_CONFIG)
                  || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_UNSPECIFIED:
           throw new ConfigException("Query mode must be specified");

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -163,15 +163,18 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String INCREMENTING_COLUMN_NAME_DEFAULT = "";
   private static final String INCREMENTING_COLUMN_NAME_DISPLAY = "Incrementing Column Name";
 
-  public static final String INCREMENTING_RELAXED_MONOTONIC_CONFIG = "incrementing.relaxed.monotonic";
+  public static final String INCREMENTING_RELAXED_MONOTONIC_CONFIG =
+          "incrementing.relaxed.monotonic";
   private static final String INCREMENTING_RELAXED_MONOTONIC_DOC =
-          "Slightly relaxes monotonic requirement. Column specified or auto-detected as incrementing column "
-          + "allows values inserted in the last `poll.interval.ms` to be visible out-of-order. Values inserted "
-          + "before `poll.interval.ms` are required to be strictly monotonically increasing. "
-          + "This flag will introduce `poll.interval.ms` delay, but will allow transactions in the source database to be "
+          "Slightly relaxes monotonic requirement. Column specified or auto-detected "
+          + "as incrementing column allows values inserted in the last `poll.interval.ms` "
+          + "to be visible out-of-order. Values inserted before `poll.interval.ms` are "
+          + "required to be strictly monotonically increasing. This flag will introduce "
+          + "`poll.interval.ms` delay, but will allow transactions in the source database to be "
           + "visible within this interval (usable e.g. when reading from read-only replicas).";
   public static final boolean INCREMENTING_RELAXED_MONOTONIC_DEFAULT = false;
-  private static final String INCREMENTING_RELAXED_MONOTONIC_DISPLAY = "Enabled relaxed monotonic requirement";
+  private static final String INCREMENTING_RELAXED_MONOTONIC_DISPLAY =
+          "Enabled relaxed monotonic requirement";
 
   public static final String TIMESTAMP_COLUMN_NAME_CONFIG = "timestamp.column.name";
   private static final String TIMESTAMP_COLUMN_NAME_DOC =
@@ -724,20 +727,18 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     @Override
     public boolean visible(String name, Map<String, Object> config) {
       String mode = (String) config.get(MODE_CONFIG);
+      boolean isIncrementingCommon = name.equals(INCREMENTING_COLUMN_NAME_CONFIG)
+                      || name.equals(VALIDATE_NON_NULL_CONFIG)
+                      || name.equals(INCREMENTING_RELAXED_MONOTONIC_CONFIG);
       switch (mode) {
         case MODE_BULK:
           return false;
         case MODE_TIMESTAMP:
           return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG) || name.equals(VALIDATE_NON_NULL_CONFIG);
         case MODE_INCREMENTING:
-          return name.equals(INCREMENTING_COLUMN_NAME_CONFIG)
-                 || name.equals(VALIDATE_NON_NULL_CONFIG)
-                 || name.equals(INCREMENTING_RELAXED_MONOTONIC_CONFIG);
+          return isIncrementingCommon;
         case MODE_TIMESTAMP_INCREMENTING:
-          return name.equals(TIMESTAMP_COLUMN_NAME_CONFIG)
-                 || name.equals(INCREMENTING_COLUMN_NAME_CONFIG)
-                 || name.equals(INCREMENTING_RELAXED_MONOTONIC_CONFIG)
-                 || name.equals(VALIDATE_NON_NULL_CONFIG);
+          return isIncrementingCommon || name.equals(TIMESTAMP_COLUMN_NAME_CONFIG);
         case MODE_UNSPECIFIED:
           throw new ConfigException("Query mode must be specified");
         default:

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -142,6 +142,8 @@ public class JdbcSourceTask extends SourceTask {
 
     String incrementingColumn
         = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+    boolean incrementingRelaxed
+        = config.getBoolean(JdbcSourceTaskConfig.INCREMENTING_RELAXED_MONOTONIC_CONFIG);
     List<String> timestampColumns
         = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
     Long timestampDelayInterval
@@ -205,6 +207,7 @@ public class JdbcSourceTask extends SourceTask {
                 topicPrefix,
                 null,
                 incrementingColumn,
+                incrementingRelaxed,
                 offset,
                 timestampDelayInterval,
                 timeZone
@@ -219,6 +222,7 @@ public class JdbcSourceTask extends SourceTask {
                 topicPrefix,
                 timestampColumns,
                 null,
+                incrementingRelaxed,
                 offset,
                 timestampDelayInterval,
                 timeZone
@@ -233,6 +237,7 @@ public class JdbcSourceTask extends SourceTask {
                 topicPrefix,
                 timestampColumns,
                 incrementingColumn,
+                incrementingRelaxed,
                 offset,
                 timestampDelayInterval,
                 timeZone

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -231,6 +231,7 @@ public class TimestampIncrementingCriteria {
     return new TimestampIncrementingOffset(extractedTimestamp, extractedId, null);
   }
 
+
   /**
    * Extract the maximum offset value from the row
    *

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -67,6 +67,14 @@ public class TimestampIncrementingCriteria {
      * @throws SQLException if there is a problem accessing the value
      */
     Long lastIncrementedValue() throws SQLException;
+
+    /**
+     * Get the maximum detected value.
+     *
+     * @return maximum value seen in the table at the end of the last cycle
+     * @throws SQLException if there is a problem accessing the value
+     */
+    Long maximumSeenValue() throws SQLException;
   }
 
   protected static final BigDecimal LONG_MAX_VALUE_AS_BIGDEC = new BigDecimal(Long.MAX_VALUE);
@@ -80,12 +88,14 @@ public class TimestampIncrementingCriteria {
 
   public TimestampIncrementingCriteria(
       ColumnId incrementingColumn,
+      boolean incrementingRelaxed,
       List<ColumnId> timestampColumns,
       TimeZone timeZone
   ) {
     this.timestampColumns =
         timestampColumns != null ? timestampColumns : Collections.<ColumnId>emptyList();
     this.incrementingColumn = incrementingColumn;
+    this.incrementingRelaxed = incrementingRelaxed;
     this.timeZone = timeZone;
   }
 
@@ -95,6 +105,10 @@ public class TimestampIncrementingCriteria {
 
   protected boolean hasIncrementedColumn() {
     return incrementingColumn != null;
+  }
+
+  protected boolean isIncrementingRelaxed() {
+    return incrementingRelaxed;
   }
 
   /**
@@ -140,10 +154,16 @@ public class TimestampIncrementingCriteria {
     Timestamp beginTime = values.beginTimestampValue();
     Timestamp endTime = values.endTimestampValue();
     Long incOffset = values.lastIncrementedValue();
+    Long maxOffset = values.maximumSeenValue();
     stmt.setTimestamp(1, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setTimestamp(2, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setLong(3, incOffset);
-    stmt.setTimestamp(4, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    if (incrementingRelaxed) {
+      stmt.setLong(4, maxOffset);
+      stmt.setTimestamp(5, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    } else {
+      stmt.setTimestamp(4, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
+    }
     log.debug(
         "Executing prepared statement with start time value = {} end time = {} and incrementing"
         + " value = {}", DateTimeUtils.formatTimestamp(beginTime, timeZone),
@@ -156,8 +176,12 @@ public class TimestampIncrementingCriteria {
       CriteriaValues values
   ) throws SQLException {
     Long incOffset = values.lastIncrementedValue();
+    Long maxOffset = values.maximumSeenValue();
     stmt.setLong(1, incOffset);
-    log.debug("Executing prepared statement with incrementing value = {}", incOffset);
+    if (incrementingRelaxed) {
+      stmt.setLong(2, maxOffset);
+    }
+    log.debug("Executing prepared statement with incrementing value = {} and maximum value = {}", incOffset, maxOffset);
   }
 
   protected void setQueryParametersTimestamp(
@@ -310,6 +334,11 @@ public class TimestampIncrementingCriteria {
     builder.append(" = ? AND ");
     builder.append(incrementingColumn);
     builder.append(" > ?");
+    if (incrementingRelaxed) {
+      builder.append(" AND ");
+      builder.append(incrementingColumn);
+      builder.append(" <= ?");
+    }
     builder.append(") OR ");
     coalesceTimestampColumns(builder);
     builder.append(" > ?)");
@@ -324,6 +353,11 @@ public class TimestampIncrementingCriteria {
     builder.append(" WHERE ");
     builder.append(incrementingColumn);
     builder.append(" > ?");
+    if (incrementingRelaxed) {
+      builder.append(" AND ");
+      builder.append(incrementingColumn);
+      builder.append(" <= ?");
+    }
     builder.append(" ORDER BY ");
     builder.append(incrementingColumn);
     builder.append(" ASC");

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -181,7 +181,8 @@ public class TimestampIncrementingCriteria {
     if (incrementingRelaxed) {
       stmt.setLong(2, maxOffset);
     }
-    log.debug("Executing prepared statement with incrementing value = {} and maximum value = {}", incOffset, maxOffset);
+    log.debug("Executing prepared statement with incrementing value = {} and maximum value = {}",
+            incOffset, maxOffset);
   }
 
   protected void setQueryParametersTimestamp(
@@ -227,7 +228,28 @@ public class TimestampIncrementingCriteria {
       assert previousOffset == null || previousOffset.getIncrementingOffset() == -1L
              || extractedId > previousOffset.getIncrementingOffset() || hasTimestampColumns();
     }
-    return new TimestampIncrementingOffset(extractedTimestamp, extractedId);
+    return new TimestampIncrementingOffset(extractedTimestamp, extractedId, null);
+  }
+
+  /**
+   * Extract the maximum offset value from the row
+   *
+   * @param record the record's struct; never null
+   * @return updated offset
+   */
+  public TimestampIncrementingOffset extractMaximumSeenOffset(
+          Schema schema,
+          Struct record,
+          TimestampIncrementingOffset previousOffset
+  ) {
+    Long maximumId = null;
+    if (hasIncrementedColumn() && isIncrementingRelaxed()) {
+      maximumId = extractOffsetIncrementedId(schema, record);
+      assert previousOffset == null || previousOffset.getMaximumSeenOffset() == -1L
+             || maximumId >= previousOffset.getMaximumSeenOffset();
+    }
+    return new TimestampIncrementingOffset(previousOffset.getTimestampOffset(),
+            previousOffset.getIncrementingOffset(), maximumId);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -248,8 +248,12 @@ public class TimestampIncrementingCriteria {
       assert previousOffset == null || previousOffset.getMaximumSeenOffset() == -1L
              || maximumId >= previousOffset.getMaximumSeenOffset();
     }
-    return new TimestampIncrementingOffset(previousOffset.getTimestampOffset(),
-            previousOffset.getIncrementingOffset(), maximumId);
+    if (previousOffset == null) {
+      return new TimestampIncrementingOffset(null, null, maximumId);
+    } else {
+      return new TimestampIncrementingOffset(previousOffset.getTimestampOffset(),
+              previousOffset.getIncrementingOffset(), maximumId);
+    }
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -50,7 +50,7 @@ public class TimestampIncrementingCriteria {
      * @return the beginning timestamp; may be null
      * @throws SQLException if there is a problem accessing the value
      */
-    Timestamp beginTimetampValue() throws SQLException;
+    Timestamp beginTimestampValue() throws SQLException;
 
     /**
      * Get the end of the time period.
@@ -58,7 +58,7 @@ public class TimestampIncrementingCriteria {
      * @return the ending timestamp; never null
      * @throws SQLException if there is a problem accessing the value
      */
-    Timestamp endTimetampValue() throws SQLException;
+    Timestamp endTimestampValue() throws SQLException;
 
     /**
      * Get the last incremented value seen.
@@ -136,8 +136,8 @@ public class TimestampIncrementingCriteria {
       PreparedStatement stmt,
       CriteriaValues values
   ) throws SQLException {
-    Timestamp beginTime = values.beginTimetampValue();
-    Timestamp endTime = values.endTimetampValue();
+    Timestamp beginTime = values.beginTimestampValue();
+    Timestamp endTime = values.endTimestampValue();
     Long incOffset = values.lastIncrementedValue();
     stmt.setTimestamp(1, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setTimestamp(2, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
@@ -163,8 +163,8 @@ public class TimestampIncrementingCriteria {
       PreparedStatement stmt,
       CriteriaValues values
   ) throws SQLException {
-    Timestamp beginTime = values.beginTimetampValue();
-    Timestamp endTime = values.endTimetampValue();
+    Timestamp beginTime = values.beginTimestampValue();
+    Timestamp endTime = values.endTimestampValue();
     stmt.setTimestamp(1, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setTimestamp(2, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     log.debug("Executing prepared statement with timestamp value = {} end time = {}",

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -74,6 +74,7 @@ public class TimestampIncrementingCriteria {
   protected final Logger log = LoggerFactory.getLogger(getClass());
   protected final List<ColumnId> timestampColumns;
   protected final ColumnId incrementingColumn;
+  protected final boolean incrementingRelaxed;
   protected final TimeZone timeZone;
 
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
@@ -39,11 +39,13 @@ public class TimestampIncrementingOffset {
    *                        {@code new Timestamp(0)}.
    * @param incrementingOffset the incrementing offset.
    *                           If null, {@link #getIncrementingOffset()} will return -1.
-   *
    * @param maximumSeenOffset the maximum previously seen offset.
-   *                          If null {@link @getMaximumSeenOffset()} will return -1.
+   *                          If null {@link #getMaximumSeenOffset()} will return -1.
    */
-  public TimestampIncrementingOffset(Timestamp timestampOffset, Long incrementingOffset, Long maximumSeenOffset) {
+  public TimestampIncrementingOffset(
+          Timestamp timestampOffset,
+          Long incrementingOffset,
+          Long maximumSeenOffset) {
     this.timestampOffset = timestampOffset;
     this.incrementingOffset = incrementingOffset;
     this.maximumSeenOffset = maximumSeenOffset;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
@@ -30,6 +30,7 @@ public class TimestampIncrementingOffset {
   private static final String TIMESTAMP_NANOS_FIELD = "timestamp_nanos";
 
   private final Long incrementingOffset;
+  private final Long maximumSeenOffset;
   private final Timestamp timestampOffset;
 
   /**
@@ -38,19 +39,28 @@ public class TimestampIncrementingOffset {
    *                        {@code new Timestamp(0)}.
    * @param incrementingOffset the incrementing offset.
    *                           If null, {@link #getIncrementingOffset()} will return -1.
+   *
+   * @param maximumSeenOffset the maximum previously seen offset.
+   *                          If null {@link @getMaximumSeenOffset()} will return -1.
    */
-  public TimestampIncrementingOffset(Timestamp timestampOffset, Long incrementingOffset) {
+  public TimestampIncrementingOffset(Timestamp timestampOffset, Long incrementingOffset, Long maximumSeenOffset) {
     this.timestampOffset = timestampOffset;
     this.incrementingOffset = incrementingOffset;
+    this.maximumSeenOffset = maximumSeenOffset;
   }
 
   public long getIncrementingOffset() {
     return incrementingOffset == null ? -1 : incrementingOffset;
   }
 
+  public long getMaximumSeenOffset() {
+    return maximumSeenOffset == null ? -1 : maximumSeenOffset;
+  }
+
   public Timestamp getTimestampOffset() {
     return timestampOffset != null ? timestampOffset : new Timestamp(0L);
   }
+
 
   public Map<String, Object> toMap() {
     Map<String, Object> map = new HashMap<>(3);
@@ -66,7 +76,7 @@ public class TimestampIncrementingOffset {
 
   public static TimestampIncrementingOffset fromMap(Map<String, ?> map) {
     if (map == null || map.isEmpty()) {
-      return new TimestampIncrementingOffset(null, null);
+      return new TimestampIncrementingOffset(null, null, null);
     }
 
     Long incr = (Long) map.get(INCREMENTING_FIELD);
@@ -81,7 +91,7 @@ public class TimestampIncrementingOffset {
         ts.setNanos(nanos.intValue());
       }
     }
-    return new TimestampIncrementingOffset(ts, incr);
+    return new TimestampIncrementingOffset(ts, incr, null);
   }
 
   @Override
@@ -100,15 +110,20 @@ public class TimestampIncrementingOffset {
         : that.incrementingOffset != null) {
       return false;
     }
+    if (maximumSeenOffset != null
+            ? !maximumSeenOffset.equals(that.maximumSeenOffset)
+            : that.maximumSeenOffset != null) {
+      return false;
+    }
     return timestampOffset != null
            ? timestampOffset.equals(that.timestampOffset)
            : that.timestampOffset == null;
-
   }
 
   @Override
   public int hashCode() {
     int result = incrementingOffset != null ? incrementingOffset.hashCode() : 0;
+    result = 1001 * result + (maximumSeenOffset != null ? maximumSeenOffset.hashCode() : 0);
     result = 31 * result + (timestampOffset != null ? timestampOffset.hashCode() : 0);
     return result;
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -66,6 +66,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   private final List<String> timestampColumnNames;
   private final List<ColumnId> timestampColumns;
   private String incrementingColumnName;
+  private boolean incrementingRelaxed;
   private long timestampDelay;
   private TimestampIncrementingOffset offset;
   private TimestampIncrementingCriteria criteria;
@@ -77,11 +78,13 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                            String topicPrefix,
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
+                                           boolean incrementingRelaxed,
                                            Map<String, Object> offsetMap,
                                            Long timestampDelay,
                                            TimeZone timeZone) {
     super(dialect, mode, name, topicPrefix);
     this.incrementingColumnName = incrementingColumnName;
+    this.incrementingRelaxed = incrementingRelaxed;
     this.timestampColumnNames = timestampColumnNames != null
                                 ? timestampColumnNames : Collections.<String>emptyList();
     this.timestampDelay = timestampDelay;
@@ -142,6 +145,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     recordQuery(queryString);
     log.debug("{} prepared SQL query: {}", this, queryString);
     stmt = dialect.createPreparedStatement(db, queryString);
+  }
+
+  @Override
+  public void reset(long now) {
+    super.reset(now);
   }
 
   private void findDefaultAutoIncrementingColumn(Connection db) throws SQLException {

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -77,7 +77,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                            String topicPrefix,
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
-                                           Map<String, Object> offsetMap, Long timestampDelay,
+                                           Map<String, Object> offsetMap,
+                                           Long timestampDelay,
                                            TimeZone timeZone) {
     super(dialect, mode, name, topicPrefix);
     this.incrementingColumnName = incrementingColumnName;
@@ -198,12 +199,12 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   }
 
   @Override
-  public Timestamp beginTimetampValue() {
+  public Timestamp beginTimestampValue() {
     return offset.getTimestampOffset();
   }
 
   @Override
-  public Timestamp endTimetampValue()  throws SQLException {
+  public Timestamp endTimestampValue()  throws SQLException {
     final long currentDbTime = dialect.currentTimeOnDB(
         stmt.getConnection(),
         DateTimeUtils.getTimeZoneCalendar(timeZone)

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -151,7 +151,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   @Override
   public void reset(long now) {
     super.reset(now);
-    refreshMaximumSeenOffset();
+    if (this.incrementingRelaxed) {
+      refreshMaximumSeenOffset();
+    }
   }
 
   private void refreshMaximumSeenOffset() throws ConnectException {

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -226,6 +226,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   }
 
   @Override
+  public Long maximumSeenValue() {
+    return offset.getIncrementingOffset();
+  }
+
+  @Override
   public String toString() {
     return "TimestampIncrementingTableQuerier{"
            + "table=" + tableId

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -151,22 +151,26 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
 
   @Override
   public void reset(long now) {
-    super.reset(now);
     if (this.incrementingRelaxed
         && this.incrementingColumnName != null
         && this.incrementingColumnName.length() > 0) {
       updateMaximumSeenOffset();
     }
+    super.reset(now);
   }
 
   private void updateMaximumSeenOffset() throws ConnectException {
-    try (
-            PreparedStatement st = createSelectMaximumPreparedStatement(db);
-            ResultSet rs = executeMaxQuery(st)
-    ) {
-      this.offset = extractMaximumOffset(rs);
-    } catch (Throwable th) {
-      throw new ConnectException("Unable to fetch new maximum", th);
+    if (this.db != null) {
+      try (
+              PreparedStatement st = createSelectMaximumPreparedStatement(db);
+              ResultSet rs = executeMaxQuery(st)
+      ) {
+        this.offset = extractMaximumOffset(rs);
+      } catch (Throwable th) {
+        throw new ConnectException("Unable to fetch new maximum", th);
+      }
+    } else {
+      log.warn("Unable to update maximum seen offset. Database connection closed.");
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -258,13 +258,12 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
         SchemaMapping mapping = SchemaMapping.create(schemaName, resultSet.getMetaData(), dialect);
         assert !mapping.fieldSetters().isEmpty();
         FieldSetter se = mapping.fieldSetters().get(0);
-        log.info("Found field {} with schema", se.field().name(), se.field().schema());
         assert se.field().schema().name() == incrementingColumnName;
         Struct st = new Struct(mapping.schema());
         se.setField(st, rs);
         return criteria.extractMaximumSeenOffset(this.schemaMapping.schema(), st, this.offset);
       } else {
-        log.warn("No maximum found");
+        log.info("No maximum found. Skipping table.");
         return this.offset;
       }
     } catch (IOException e) {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -213,6 +213,15 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   }
 
   @Test
+  public void testMaxStatement() {
+    newDialectFor(TABLE_TYPES, null);
+    assertEquals(
+      "SELECT MAX(\"id1\") FROM \"myTable\"",
+      dialect.buildSelectMaxStatement(tableId, pkColumns.get(0))
+    );
+  }
+
+  @Test
   public void testBuildDeleteStatement() {
     newDialectFor(TABLE_TYPES, null);
     assertEquals(

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -216,7 +216,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   public void testMaxStatement() {
     newDialectFor(TABLE_TYPES, null);
     assertEquals(
-      "SELECT MAX(\"id1\") FROM \"myTable\"",
+      "SELECT MAX(\"id1\") as \"id1\" FROM \"myTable\"",
       dialect.buildSelectMaxStatement(tableId, pkColumns.get(0))
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -216,7 +216,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   public void testMaxStatement() {
     newDialectFor(TABLE_TYPES, null);
     assertEquals(
-      "SELECT MAX(\"id1\") as \"id1\" FROM \"myTable\"",
+      "SELECT COALESCE(MAX(\"id1\"),-1) as \"id1\" FROM \"myTable\"",
       dialect.buildSelectMaxStatement(tableId, pkColumns.get(0))
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -404,7 +404,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testManualIncrementingRestoreNoVersionOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L, null);
     testManualIncrementingRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
     );
@@ -412,7 +412,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testManualIncrementingRestoreVersionOneOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L, null);
     testManualIncrementingRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
     );
@@ -420,8 +420,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testManualIncrementingRestoreOffsetsWithMultipleProtocol() throws Exception {
-    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L, null);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L, null);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
@@ -453,7 +453,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testAutoincrementRestoreNoVersionOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L, null);
     testAutoincrementRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
     );
@@ -461,7 +461,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testAutoincrementRestoreVersionOneOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L, null);
     testAutoincrementRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
     );
@@ -469,8 +469,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testAutoincrementRestoreOffsetsWithMultipleProtocol() throws Exception {
-    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L);
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L);
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(null, 0L, null);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(null, 1L, null);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
@@ -507,13 +507,13 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampRestoreNoVersionOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null, null);
     testTimestampRestoreOffset(Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap()));
   }
 
   @Test
   public void testTimestampRestoreVersionOneOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null, null);
     testTimestampRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
     );
@@ -523,9 +523,10 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   public void testTimestampRestoreOffsetsWithMultipleProtocol() throws Exception {
     TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(
         new Timestamp(8L),
+        null,
         null
     );
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), null, null);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());
@@ -567,7 +568,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampAndIncrementingRestoreNoVersionOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L, null);
     testTimestampAndIncrementingRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION, offset.toMap())
     );
@@ -575,7 +576,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampAndIncrementingRestoreVersionOneOffset() throws Exception {
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L, null);
     testTimestampAndIncrementingRestoreOffset(
         Collections.singletonMap(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap())
     );
@@ -583,8 +584,8 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testTimestampAndIncrementingRestoreOffsetsWithMultipleProtocol() throws Exception {
-    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(new Timestamp(10L), 2L);
-    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L);
+    TimestampIncrementingOffset oldOffset = new TimestampIncrementingOffset(new Timestamp(10L), 2L, null);
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(new Timestamp(10L), 3L, null);
     Map<Map<String, String>, Map<String, Object>> offsets = new HashMap<>();
     offsets.put(SINGLE_TABLE_PARTITION_WITH_VERSION, offset.toMap());
     offsets.put(SINGLE_TABLE_PARTITION, oldOffset.toMap());

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -61,10 +61,10 @@ public class TimestampIncrementingCriteriaTest {
 
   @Before
   public void beforeEach() {
-    criteria = new TimestampIncrementingCriteria(null, null, utcTimeZone);
-    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, null, utcTimeZone);
-    criteriaTs = new TimestampIncrementingCriteria(null, TS_COLUMNS, utcTimeZone);
-    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, TS_COLUMNS, utcTimeZone);
+    criteria = new TimestampIncrementingCriteria(null, false, null, utcTimeZone);
+    criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, false, null, utcTimeZone);
+    criteriaTs = new TimestampIncrementingCriteria(null, false, TS_COLUMNS, utcTimeZone);
+    criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, false, TS_COLUMNS, utcTimeZone);
     identifierQuoting = null;
     rules = null;
     builder = null;

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -44,6 +44,7 @@ public class TimestampIncrementingCriteriaTest {
 
   private static final TableId TABLE_ID = new TableId(null, null,"myTable");
   private static final ColumnId INCREMENTING_COLUMN = new ColumnId(TABLE_ID, "id");
+  private static final ColumnId INCREMENTING_MAX_COLUMN = new ColumnId(TABLE_ID, "id_with_max");
   private static final ColumnId TS1_COLUMN = new ColumnId(TABLE_ID, "ts1");
   private static final ColumnId TS2_COLUMN = new ColumnId(TABLE_ID, "ts2");
   private static final List<ColumnId> TS_COLUMNS = Arrays.asList(TS1_COLUMN, TS2_COLUMN);
@@ -53,6 +54,7 @@ public class TimestampIncrementingCriteriaTest {
   private ExpressionBuilder builder;
   private TimestampIncrementingCriteria criteria;
   private TimestampIncrementingCriteria criteriaInc;
+  private TimestampIncrementingCriteria criteriaIncMax;
   private TimestampIncrementingCriteria criteriaTs;
   private TimestampIncrementingCriteria criteriaIncTs;
   private Schema schema;
@@ -63,6 +65,7 @@ public class TimestampIncrementingCriteriaTest {
   public void beforeEach() {
     criteria = new TimestampIncrementingCriteria(null, false, null, utcTimeZone);
     criteriaInc = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, false, null, utcTimeZone);
+    criteriaIncMax = new TimestampIncrementingCriteria(INCREMENTING_MAX_COLUMN, true, null, utcTimeZone);
     criteriaTs = new TimestampIncrementingCriteria(null, false, TS_COLUMNS, utcTimeZone);
     criteriaIncTs = new TimestampIncrementingCriteria(INCREMENTING_COLUMN, false, TS_COLUMNS, utcTimeZone);
     identifierQuoting = null;
@@ -134,6 +137,18 @@ public class TimestampIncrementingCriteriaTest {
                           .build();
     record = new Struct(schema).put("id", 42);
     assertExtractedOffset(42L, schema, record);
+  }
+
+  @Test
+  public void extractWithIncMax() throws SQLException {
+    schema = SchemaBuilder.struct()
+            .field("id_with_max", SchemaBuilder.INT32_SCHEMA)
+            .field(TS1_COLUMN.name(), Timestamp.SCHEMA)
+            .field(TS2_COLUMN.name(), Timestamp.SCHEMA)
+            .build();
+    record = new Struct(schema).put("id_with_max", 42);
+    TimestampIncrementingOffset offset = criteriaIncMax.extractMaximumSeenOffset(schema, record, null);
+    assertEquals(42, offset.getMaximumSeenOffset());
   }
 
   @Test(expected = DataException.class)

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
@@ -26,10 +26,14 @@ import static org.junit.Assert.assertNotNull;
 public class TimestampIncrementingOffsetTest {
   private final Timestamp ts = new Timestamp(100L);
   private final long id = 1000L;
-  private final TimestampIncrementingOffset unset = new TimestampIncrementingOffset(null, null);
-  private final TimestampIncrementingOffset tsOnly = new TimestampIncrementingOffset(ts, null);
-  private final TimestampIncrementingOffset incOnly = new TimestampIncrementingOffset(null, id);
-  private final TimestampIncrementingOffset tsInc = new TimestampIncrementingOffset(ts, id);
+  private final TimestampIncrementingOffset unset =
+          new TimestampIncrementingOffset(null, null, null);
+  private final TimestampIncrementingOffset tsOnly =
+          new TimestampIncrementingOffset(ts, null, null);
+  private final TimestampIncrementingOffset incOnly =
+          new TimestampIncrementingOffset(null, id, null);
+  private final TimestampIncrementingOffset tsInc =
+          new TimestampIncrementingOffset(ts, id, null);
   private Timestamp nanos;
   private TimestampIncrementingOffset nanosOffset;
 
@@ -39,7 +43,7 @@ public class TimestampIncrementingOffsetTest {
     nanos = new Timestamp(millis);
     nanos.setNanos((int)(millis % 1000) * 1000000 + 123456);
     assertEquals(millis, nanos.getTime());
-    nanosOffset = new TimestampIncrementingOffset(nanos, null);
+    nanosOffset = new TimestampIncrementingOffset(nanos, null, null);
   }
 
   @Test
@@ -91,19 +95,20 @@ public class TimestampIncrementingOffsetTest {
   @Test
   public void testEquals() {
     assertEquals(nanosOffset, nanosOffset);
-    assertEquals(new TimestampIncrementingOffset(null, null), new TimestampIncrementingOffset(null, null));
-    assertEquals(unset, new TimestampIncrementingOffset(null, null));
+    assertEquals(new TimestampIncrementingOffset(null, null, null),
+            new TimestampIncrementingOffset(null, null, null));
+    assertEquals(unset, new TimestampIncrementingOffset(null, null, null));
 
-    TimestampIncrementingOffset x = new TimestampIncrementingOffset(null, id);
+    TimestampIncrementingOffset x = new TimestampIncrementingOffset(null, id, null);
     assertEquals(x, incOnly);
 
-    x = new TimestampIncrementingOffset(ts, null);
+    x = new TimestampIncrementingOffset(ts, null, null);
     assertEquals(x, tsOnly);
 
-    x = new TimestampIncrementingOffset(ts, id);
+    x = new TimestampIncrementingOffset(ts, id, null);
     assertEquals(x, tsInc);
 
-    x = new TimestampIncrementingOffset(nanos, null);
+    x = new TimestampIncrementingOffset(nanos, null, null);
     assertEquals(x, nanosOffset);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 public class TimestampIncrementingOffsetTest {
   private final Timestamp ts = new Timestamp(100L);
   private final long id = 1000L;
+  private final long maxId = 2000L;
   private final TimestampIncrementingOffset unset =
           new TimestampIncrementingOffset(null, null, null);
   private final TimestampIncrementingOffset tsOnly =
@@ -34,6 +35,8 @@ public class TimestampIncrementingOffsetTest {
           new TimestampIncrementingOffset(null, id, null);
   private final TimestampIncrementingOffset tsInc =
           new TimestampIncrementingOffset(ts, id, null);
+  private final TimestampIncrementingOffset incOnlyMax =
+          new TimestampIncrementingOffset(null, id, maxId);
   private Timestamp nanos;
   private TimestampIncrementingOffset nanosOffset;
 
@@ -70,6 +73,11 @@ public class TimestampIncrementingOffsetTest {
     assertEquals(id, incOnly.getIncrementingOffset());
     assertEquals(id, tsInc.getIncrementingOffset());
     assertEquals(-1, nanosOffset.getIncrementingOffset());
+  }
+
+  @Test
+  public void testGetMax() {
+    assertEquals(maxId, incOnlyMax.getMaximumSeenOffset());
   }
 
   @Test
@@ -110,6 +118,9 @@ public class TimestampIncrementingOffsetTest {
 
     x = new TimestampIncrementingOffset(nanos, null, null);
     assertEquals(x, nanosOffset);
+
+    x = new TimestampIncrementingOffset(null, id, maxId);
+    assertEquals(x, incOnlyMax);
   }
 
 }


### PR DESCRIPTION
## Problem

Incrementing mode might fail to identify new rows even for columns that are eventually strictly monotonic. An example would be two transactions in MySQL inserting data with a primary column that is automatically incremented. 

First: `BEGIN; SELECT SLEEP(10); INSERT ....; COMMIT;`
Second: `BEGIN; INSERT ...; COMMIT;`

The first transactions will get assigned lower number, but as it's committed later the row won't be visible soon enough and it will be skipped. 

## Solution

Introduce an option to wait for `poll.interval.ms` before reading a row and committing the offset. This will give database and writer some time to commit the transaction and propagate it to the reader. If this interval is as long as maximum transaction time + maximum propagation time we will be always reading all rows inserted into the table.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy

- [x] Check if all existing unit tests still run fine
- [x] Add unit tests to cover new code
- [x] Verify by manual test that the new behavior with flag enabled actually detects all new rows
- [x] Verify that no rows are detected as new twice 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
