### PR TITLE
CC-11507: Always parse Date in UTC

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1246,12 +1246,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
       // Date is day + month + year
       case Types.DATE: {
-        return rs -> rs.getDate(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
+        return rs -> rs.getDate(col,
+            DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC)));
       }
 
       // Time is a time of day -- hour, minute, seconds, nanoseconds
       case Types.TIME: {
-        return rs -> rs.getTime(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
+        return rs -> rs.getTime(col,
+            DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC)));
       }
 
       // Timestamp is a date + time

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1252,8 +1252,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
       // Time is a time of day -- hour, minute, seconds, nanoseconds
       case Types.TIME: {
-        return rs -> rs.getTime(col,
-            DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC)));
+        return rs -> rs.getTime(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
       }
 
       // Timestamp is a date + time

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -269,7 +269,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTime() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1970, Calendar.JANUARY, 1, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIME", false, "23:03:20",
                    Time.builder().build(),
                    expected.getTime());
@@ -278,7 +278,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testNullableTime() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1970, Calendar.JANUARY, 1, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIME", true, "23:03:20",
                    Time.builder().optional().build(),
                    expected.getTime());

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -35,7 +35,9 @@ import javax.sql.rowset.serial.SerialBlob;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.TimeZone;
@@ -49,18 +51,26 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
-  @Parameterized.Parameters
-  public static Object[] mapping() {
-    return new Object[] { false, true };
+  @Parameterized.Parameters(name="extendedMapping: {0}, timezone: {1}")
+  public static Collection<Object[]> mapping() {
+    return Arrays.asList(new Object[][] {
+        {false, TimeZone.getTimeZone("UTC")},
+        {true, TimeZone.getTimeZone("UTC")},
+        {false, TimeZone.getTimeZone("America/Los_Angeles")},
+        {true, TimeZone.getTimeZone("Asia/Kolkata")}
+    });
   }
 
-  @Parameterized.Parameter
+  @Parameterized.Parameter(0)
   public boolean extendedMapping;
+
+  @Parameterized.Parameter(1)
+  public TimeZone timezone;
 
   @Before
   public void setup() throws Exception {
     super.setup();
-    task.start(singleTableConfig(extendedMapping));
+    task.start(singleTableWithTimezoneConfig(extendedMapping, timezone));
   }
 
   @After
@@ -280,7 +290,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testTimestamp() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1977, Calendar.FEBRUARY, 13, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIMESTAMP", false, "1977-02-13 23:03:20",
                    Timestamp.builder().build(),
                    expected.getTime());
@@ -289,7 +299,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testNullableTimestamp() throws Exception {
     GregorianCalendar expected = new GregorianCalendar(1977, Calendar.FEBRUARY, 13, 23, 3, 20);
-    expected.setTimeZone(TimeZone.getTimeZone("UTC"));
+    expected.setTimeZone(timezone);
     typeConversion("TIMESTAMP", true, "1977-02-13 23:03:20",
                    Timestamp.builder().optional().build(),
                    expected.getTime());

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -28,6 +28,7 @@ import org.powermock.api.easymock.annotation.Mock;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.NumericMapping;
 
@@ -101,6 +102,14 @@ public class JdbcSourceTaskTestBase {
     } else {
       props.put(JdbcSourceTaskConfig.NUMERIC_PRECISION_MAPPING_CONFIG, "true");
     }
+    return props;
+  }
+
+  protected Map<String, String> singleTableWithTimezoneConfig(
+      boolean completeMapping,
+      TimeZone tz) {
+    Map<String, String> props = singleTableConfig(completeMapping);
+    props.put(JdbcSourceTaskConfig.DB_TIMEZONE_CONFIG, tz.getID());
     return props;
   }
 


### PR DESCRIPTION
## Problem
AK Date logical type expects the native Date object to be in UTC time. It complains loudly if it receives native Date from another timezone: https://github.com/apache/kafka/blob/trunk/connect/api/src/main/java/org/apache/kafka/connect/data/Date.java#L62

## Solution
Parse Date in UTC timezone, ignoring the `db.timezone` specified.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Updated unittests. Verified end-to-end against postgres and mysql using IT in `connet-ksql-integration`

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Targeting `5.0.x` as the timezone fix was backported very far back. Will merge the fix forward to other branches. Fix will be released with next bugfix release on perspective branches.