### PR TITLE
CC-8794: MS SQL Server datetime give repeated messages due to rounding error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <connect.utils.version>0.1.11</connect.utils.version>
+        <confluent.licensing.version>0.5.2</confluent.licensing.version>
     </properties>
 
     <repositories>
@@ -82,7 +84,12 @@
             <artifactId>connect-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
          <!-- JDBC drivers, only included in runtime so they get packaged -->
         <dependency>
             <groupId>org.xerial</groupId>
@@ -163,6 +170,59 @@
             <version>2.5.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>8.4.1.jre11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>connect-licensing-extensions</artifactId>
+            <version>${confluent.licensing.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kafka.version}</version>
+            <type>test-jar</type>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <type>test-jar</type>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>connect-utils</artifactId>
+            <version>${connect.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.12.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -174,7 +234,6 @@
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
+                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -442,6 +442,19 @@ public interface DatabaseDialect extends ConnectionProvider {
   ) throws SQLException;
 
   /**
+   * Validate if dialect specific column types are compatible with connector.
+   * Sometimes JDBC treats some column types in a SQL database the same
+   * (eg, MSSQL Server's DATETIME and DATETIME2 are considered {@link java.sql.Time}).
+   * This function is used to handle these specifc column types.
+   *
+   * @param rsMetadata          the result set metadata; may not be null
+   * @param timestampColumns    the timestamp columns configured; may not be null
+   * @throws ConnectException   if column type not compatible with connector
+   *                            or if there is an error accessing the result set metadata
+   */
+  void validateSpecificColumnsTypes(ResultSetMetaData rsMetadata, List<ColumnId> timestampColumns) throws ConnectException;
+
+  /**
    * A function to bind the values from a sink record into a prepared statement.
    */
   @FunctionalInterface

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -442,17 +442,16 @@ public interface DatabaseDialect extends ConnectionProvider {
   ) throws SQLException;
 
   /**
-   * Validate if dialect specific column types are compatible with connector.
-   * Sometimes JDBC treats some column types in a SQL database the same
-   * (eg, MSSQL Server's DATETIME and DATETIME2 are considered {@link java.sql.Time}).
-   * This function is used to handle these specifc column types.
+   * Validate that columns used for timestamp mode are compatible with connector.
+   * For example MSSQL Server's DATETIME columns are not supported as
+   * columns in timestamp mode.
    *
    * @param rsMetadata          the result set metadata; may not be null
    * @param timestampColumns    the timestamp columns configured; may not be null
    * @throws ConnectException   if column type not compatible with connector
    *                            or if there is an error accessing the result set metadata
    */
-  void validateSpecificColumnsTypes(
+  void validateTimestampColumns(
           ResultSetMetaData rsMetadata,
           List<ColumnId> timestampColumns
   ) throws ConnectException;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -442,18 +442,19 @@ public interface DatabaseDialect extends ConnectionProvider {
   ) throws SQLException;
 
   /**
-   * Validate that columns used for timestamp mode are compatible with connector.
-   * For example MSSQL Server's DATETIME columns are not supported as
-   * columns in timestamp mode.
+   * Validate if dialect specific column types are compatible with connector.
+   * Sometimes JDBC treats some column types in a SQL database the same
+   * (eg, MSSQL Server's DATETIME and DATETIME2 are considered {@link java.sql.Time}).
+   * This function is used to handle these specifc column types.
    *
    * @param rsMetadata          the result set metadata; may not be null
-   * @param timestampColumns    the timestamp columns configured; may not be null
+   * @param columns             columns to check; may not be null
    * @throws ConnectException   if column type not compatible with connector
    *                            or if there is an error accessing the result set metadata
    */
-  void validateTimestampColumns(
+  void validateSpecificColumnTypes(
           ResultSetMetaData rsMetadata,
-          List<ColumnId> timestampColumns
+          List<ColumnId> columns
   ) throws ConnectException;
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -452,7 +452,10 @@ public interface DatabaseDialect extends ConnectionProvider {
    * @throws ConnectException   if column type not compatible with connector
    *                            or if there is an error accessing the result set metadata
    */
-  void validateSpecificColumnsTypes(ResultSetMetaData rsMetadata, List<ColumnId> timestampColumns) throws ConnectException;
+  void validateSpecificColumnsTypes(
+          ResultSetMetaData rsMetadata,
+          List<ColumnId> timestampColumns
+  ) throws ConnectException;
 
   /**
    * A function to bind the values from a sink record into a prepared statement.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1641,7 +1641,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
-  public void validateSpecificColumnsTypes(
+  public void validateTimestampColumns(
           ResultSetMetaData rsMetadata,
           List<ColumnId> timestampColumns
   ) throws ConnectException { }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1641,9 +1641,9 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
-  public void validateTimestampColumns(
+  public void validateSpecificColumnTypes(
           ResultSetMetaData rsMetadata,
-          List<ColumnId> timestampColumns
+          List<ColumnId> columns
   ) throws ConnectException { }
 
   protected List<String> extractPrimaryKeyFieldNames(Collection<SinkRecordField> fields) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1640,6 +1640,12 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return Collections.singletonList(builder.toString());
   }
 
+  @Override
+  public void validateSpecificColumnsTypes(
+          ResultSetMetaData rsMetadata,
+          List<ColumnId> timestampColumns
+  ) throws ConnectException { }
+
   protected List<String> extractPrimaryKeyFieldNames(Collection<SinkRecordField> fields) {
     final List<String> pks = new ArrayList<>();
     for (SinkRecordField f : fields) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -366,10 +366,10 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
 
     if (versionWithBreakingDatetimeChange()) {
       try {
-        for (int i = 1; i < rsMetadata.getColumnCount(); i++) {
-          if (rsMetadata.getColumnTypeName(i).equals(DATETIME)) {
+        for (int i = 0; i < rsMetadata.getColumnCount(); i++) {
+          if (rsMetadata.getColumnTypeName(i + 1).equals(DATETIME)) {
             for (ColumnId id: timestampColumns) {
-              if (id.name().equals(rsMetadata.getColumnName(i))) {
+              if (id.name().equals(rsMetadata.getColumnName(i + 1))) {
                 throw new ConnectException(
                         "A DATETIME column is configured for " + TIMESTAMP_COLUMN_NAME_CONFIG
                         + " with Sql Server. DATETIME is not supported. Use DATETIME2 instead.");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -64,6 +64,9 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
   private static final DateTimeFormatter DATE_TIME_FORMATTER =
       DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
 
+  private static final int MSSQL_2016_VERSION = 13;
+  private static final int PRE_MSSQL_2016_VERSION = 12;
+
   /**
    * The provider for {@link SqlServerDatabaseDialect}.
    */
@@ -89,6 +92,21 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
   public SqlServerDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "[", "]"));
     jtdsDriver = jdbcUrlInfo == null ? false : jdbcUrlInfo.subprotocol().matches("jtds");
+  }
+
+  public boolean sqlServer2016OrLater() {
+    //DATETIME columns are handled different post MSSQL SERVER 2016
+    String jdbcDatabaseMajorVersion = jdbcDriverInfo().productVersion().split("\\.")[0];
+    int jdbcDatabaseMajorVersionValue = PRE_MSSQL_2016_VERSION;
+    try {
+      jdbcDatabaseMajorVersionValue = Integer.parseInt(jdbcDatabaseMajorVersion);
+    } catch (NumberFormatException e) {
+      log.warn("Could not retrieve MSSQL Database version from JDBC."
+              + "Version is used to verify timestamp mode compatibility with "
+              + "Sql Server Datetime columns. Defaulting to pre 2016 version."
+              + "Error:" + e.toString());
+    }
+    return (jdbcDatabaseMajorVersionValue >= MSSQL_2016_VERSION);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -356,7 +356,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
    *                            or if there is an error accessing the result set metadata
    */
   @Override
-  public void validateSpecificColumnsTypes(
+  public void validateTimestampColumns(
           ResultSetMetaData rsMetadata,
           List<ColumnId> timestampColumns
   ) throws ConnectException {
@@ -367,6 +367,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     if (versionWithBreakingDatetimeChange()) {
       try {
         for (int i = 0; i < rsMetadata.getColumnCount(); i++) {
+          // columns in the meta data is indexed starting at 1 (not 0).
           if (rsMetadata.getColumnTypeName(i + 1).equals(DATETIME)) {
             for (ColumnId id: timestampColumns) {
               if (id.name().equals(rsMetadata.getColumnName(i + 1))) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -351,15 +351,16 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
    * References: http://www.dbdelta.com/sql-server-2016-and-azure-sql-database-v12-breaking-change/
    *
    * @param rsMetadata          the result set metadata; may not be null
-   * @param timestampColumns    the timestamp columns configured; may not be null
+   * @param columns             the timestamp columns configured; may not be null
    * @throws ConnectException   if column type not compatible with connector
    *                            or if there is an error accessing the result set metadata
    */
   @Override
-  public void validateTimestampColumns(
+  public void validateSpecificColumnTypes(
           ResultSetMetaData rsMetadata,
-          List<ColumnId> timestampColumns
+          List<ColumnId> columns
   ) throws ConnectException {
+    List<ColumnId> timestampColumns = columns;
     if (verifiedSqlServerTimestamp) {
       return;
     }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.ZonedDateTime;
@@ -44,6 +45,9 @@ import io.confluent.connect.jdbc.util.IdentifierRules;
 import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.ColumnDefinition.Mutability;
 import io.confluent.connect.jdbc.util.ColumnDefinition.Nullability;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG;
 
 /**
  * A {@link DatabaseDialect} for SQL Server.
@@ -63,9 +67,15 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
   private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSSS ZZZZZ";
   private static final DateTimeFormatter DATE_TIME_FORMATTER =
       DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
-
   private static final int MSSQL_2016_VERSION = 13;
   private static final int PRE_MSSQL_2016_VERSION = 12;
+
+  /**
+   * JDBC TypeName constant for SQL Server's DATETIME columns.
+   */
+  private static String DATETIME = "datetime";
+
+  private boolean verifiedSqlServerTimestamp = false;
 
   /**
    * The provider for {@link SqlServerDatabaseDialect}.
@@ -94,8 +104,13 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     jtdsDriver = jdbcUrlInfo == null ? false : jdbcUrlInfo.subprotocol().matches("jtds");
   }
 
-  public boolean sqlServer2016OrLater() {
-    //DATETIME columns are handled different post MSSQL SERVER 2016
+  /**
+   * Check if the mssql server instance, the connector is configured, to is an mssql version with
+   * the breaking Datetime change (MSSQL Server version 2016 or newer). If unable to get version
+   * assume non breaking datetime version
+   * @return if mssql server instance connected to, is version with breaking datetime or not
+   */
+  public boolean versionWithBreakingDatetimeChange() {
     String jdbcDatabaseMajorVersion = jdbcDriverInfo().productVersion().split("\\.")[0];
     int jdbcDatabaseMajorVersionValue = PRE_MSSQL_2016_VERSION;
     try {
@@ -321,6 +336,53 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
            .of(nonKeyColumns, keyColumns);
     builder.append(");");
     return builder.toString();
+  }
+
+  /**
+   * If Sql Server is 2016 or newer, and time stamp mode configured against a datetime column
+   * kill task.
+   * Datetime as a Timestamp column is not supported for these versions because a Datetime casting
+   * error causes our connector to loop on the most recent record. The error arises because JDBC
+   * handles all timestamp columns as {@link java.sql.Time} and by extension to a greater precision
+   * than supported by Datetime. Since Datetime is only accurate to 3.33 MS it casts itself
+   * a higher precision recursively (3.333333 MS). However JDBC casts to higher precision
+   * non recursively (3.330000 MS). This disparity causes looping.
+   * Older MSSQL Server instances do not have this problem because it casts non-recursively.
+   * References: http://www.dbdelta.com/sql-server-2016-and-azure-sql-database-v12-breaking-change/
+   *
+   * @param rsMetadata          the result set metadata; may not be null
+   * @param timestampColumns    the timestamp columns configured; may not be null
+   * @throws ConnectException   if column type not compatible with connector
+   *                            or if there is an error accessing the result set metadata
+   */
+  @Override
+  public void validateSpecificColumnsTypes(
+          ResultSetMetaData rsMetadata,
+          List<ColumnId> timestampColumns
+  ) throws ConnectException {
+    if (verifiedSqlServerTimestamp) {
+      return;
+    }
+
+    if (versionWithBreakingDatetimeChange()) {
+      try {
+        for (int i = 1; i < rsMetadata.getColumnCount(); i++) {
+          if (rsMetadata.getColumnTypeName(i).equals(DATETIME)) {
+            for (ColumnId id: timestampColumns) {
+              if (id.name().equals(rsMetadata.getColumnName(i))) {
+                throw new ConnectException(
+                        "A DATETIME column is configured for " + TIMESTAMP_COLUMN_NAME_CONFIG
+                        + " with Sql Server. DATETIME is not supported. Use DATETIME2 instead.");
+              }
+            }
+          }
+        }
+      } catch (SQLException sqlException) {
+        throw new ConnectException("Failed to get table meta data"
+                + "while verifying Timestamp column type:", sqlException);
+      }
+    }
+    verifiedSqlServerTimestamp = true;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -157,7 +157,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       resultSet = executeQuery();
       String schemaName = tableId != null ? tableId.tableName() : null; // backwards compatible
       ResultSetMetaData metadata = resultSet.getMetaData();
-      dialect.validateTimestampColumns(metadata, timestampColumns);
+      dialect.validateSpecificColumnTypes(metadata, timestampColumns);
       schemaMapping = SchemaMapping.create(schemaName, metadata, dialect);
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -157,7 +157,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       resultSet = executeQuery();
       String schemaName = tableId != null ? tableId.tableName() : null; // backwards compatible
       ResultSetMetaData metadata = resultSet.getMetaData();
-      dialect.validateSpecificColumnsTypes(metadata, timestampColumns);
+      dialect.validateTimestampColumns(metadata, timestampColumns);
       schemaMapping = SchemaMapping.create(schemaName, metadata, dialect);
     }
   }

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -57,6 +57,21 @@ public class JdbcSourceConnectorTest {
   private EmbeddedDerby db;
   private Map<String, String> connProps;
 
+  public static class MockJdbcSourceConnector extends JdbcSourceConnector {
+    CachedConnectionProvider provider;
+    public MockJdbcSourceConnector() {}
+    public MockJdbcSourceConnector(CachedConnectionProvider provider) {
+      this.provider = provider;
+    }
+    @Override
+    protected CachedConnectionProvider connectionProvider(
+            int maxConnAttempts,
+            long retryBackoff
+    ) {
+      return provider;
+    }
+  }
+
   @Mock
   private DatabaseDialect dialect;
 
@@ -104,15 +119,7 @@ public class JdbcSourceConnectorTest {
   @Test
   public void testStartStop() throws Exception {
     CachedConnectionProvider mockCachedConnectionProvider = PowerMock.createMock(CachedConnectionProvider.class);
-    connector = new JdbcSourceConnector() {
-        @Override
-        protected CachedConnectionProvider connectionProvider(
-            int maxConnAttempts,
-            long retryBackoff
-        ) {
-            return mockCachedConnectionProvider;
-        }
-    };
+    connector  = new MockJdbcSourceConnector(mockCachedConnectionProvider);
     // Should request a connection, then should close it on stop(). The background thread may also
     // request connections any time it performs updates.
     Connection conn = PowerMock.createMock(Connection.class);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -358,7 +358,7 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     Mockito.doReturn(timeStampColumnName).when(spyRsMetadata).getColumnName(1);
     Mockito.doReturn("datetime").when(spyRsMetadata).getColumnTypeName(1);
 
-    dialect.validateSpecificColumnsTypes(spyRsMetadata, timestampColumns);
+    dialect.validateTimestampColumns(spyRsMetadata, timestampColumns);
   }
 
   @Test
@@ -377,7 +377,7 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     Mockito.doReturn(timeStampColumnName).when(spyRsMetadata).getColumnName(2);
     Mockito.doReturn("datetime2").when(spyRsMetadata).getColumnTypeName(2);
 
-    dialect.validateSpecificColumnsTypes(spyRsMetadata, timestampColumns);
+    dialect.validateTimestampColumns(spyRsMetadata, timestampColumns);
   }
 
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -358,7 +358,7 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     Mockito.doReturn(timeStampColumnName).when(spyRsMetadata).getColumnName(1);
     Mockito.doReturn("datetime").when(spyRsMetadata).getColumnTypeName(1);
 
-    dialect.validateTimestampColumns(spyRsMetadata, timestampColumns);
+    dialect.validateSpecificColumnTypes(spyRsMetadata, timestampColumns);
   }
 
   @Test
@@ -377,7 +377,7 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     Mockito.doReturn(timeStampColumnName).when(spyRsMetadata).getColumnName(2);
     Mockito.doReturn("datetime2").when(spyRsMetadata).getColumnTypeName(2);
 
-    dialect.validateTimestampColumns(spyRsMetadata, timestampColumns);
+    dialect.validateSpecificColumnTypes(spyRsMetadata, timestampColumns);
   }
 
 

--- a/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.integration;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category(IntegrationTest.class)
+public abstract class BaseConnectorIT {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseConnectorIT.class);
+
+    protected static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+
+    protected EmbeddedConnectCluster connect;
+
+    protected void startConnect() {
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("jdbc-connect-cluster")
+                .build();
+
+        // start the clusters
+        connect.start();
+    }
+
+    protected void stopConnect() {
+        // stop all Connect, Kafka and Zk threads.
+        if (connect != null) {
+            connect.stop();
+        }
+    }
+
+    /**
+     * Wait up to {@link #CONNECTOR_STARTUP_DURATION_MS maximum time limit} for the connector with the given
+     * name to start the specified number of tasks.
+     *
+     * @param name the name of the connector
+     * @param numTasks the minimum number of tasks that are expected
+     * @return the time this method discovered the connector has started, in milliseconds past epoch
+     * @throws InterruptedException if this was interrupted
+     */
+    protected long waitForConnectorToStart(String name, int numTasks) throws InterruptedException {
+        TestUtils.waitForCondition(
+                () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
+                CONNECTOR_STARTUP_DURATION_MS,
+                "Connector tasks did not start in time."
+        );
+        return System.currentTimeMillis();
+    }
+
+    /**
+     * Confirm that a connector with an exact number of tasks is running.
+     *
+     * @param connectorName the connector
+     * @param numTasks the minimum number of tasks
+     * @return true if the connector and tasks are in RUNNING state; false otherwise
+     */
+    protected Optional<Boolean> assertConnectorAndTasksRunning(String connectorName, int numTasks) {
+        try {
+            ConnectorStateInfo info = connect.connectorStatus(connectorName);
+            boolean result = info != null
+                    && info.tasks().size() >= numTasks
+                    && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
+                    && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
+            return Optional.of(result);
+        } catch (Exception e) {
+            log.warn("Could not check connector state info.");
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
@@ -234,14 +234,16 @@ public class MSSQLDateTimeIT extends BaseConnectorIT {
         insertStmt.setTimestamp(2, t);
         executeSQL(insertStmt);
 
-
+        // Wait long enough for connector to query table for new records
+        // if works as expected regardless of how long we wait, only one record would be found
+        // verifies that there is no looping on the most recent record for datetime2 in MSSQL Server
         Thread.sleep(Duration.ofSeconds(30).toMillis());
         for (String topic: KAFKA_TOPICS) {
             ConsumerRecords<byte[], byte[]> records = connect.kafka().consume(
                     NUM_RECORDS_PRODUCED,
                     CONSUME_MAX_DURATION_MS,
                     topic);
-            //Assert that records in topic == NUM_RECORDS_PRODUCED
+            // Assert that records in topic == NUM_RECORDS_PRODUCED
             assertEquals(NUM_RECORDS_PRODUCED, records.count());
         }
     }

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright [2017 - 2019] Confluent Inc.
+ */
+
+package io.confluent.connect.jdbc.source.integration;
+
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.storage.StringConverter;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+
+import org.apache.kafka.test.IntegrationTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.sql.Connection;
+import java.sql.Timestamp;
+import java.sql.PreparedStatement;
+import java.time.Duration;
+
+import io.confluent.connect.jdbc.integration.BaseConnectorIT;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import java.lang.StringBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECTION_PASSWORD_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.MODE_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.MODE_TIMESTAMP;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG;
+
+import static io.confluent.connect.utils.licensing.LicenseConfigUtil.CONFLUENT_TOPIC_BOOTSTRAP_SERVERS_CONFIG;
+import static io.confluent.connect.utils.licensing.LicenseConfigUtil.CONFLUENT_TOPIC_REPLICATION_FACTOR_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+
+@Category(IntegrationTest.class)
+public class MSSQLDateTimeIT extends BaseConnectorIT {
+
+    private static final Logger log = LoggerFactory.getLogger(MSSQLDateTimeIT.class);
+    private static final String CONNECTOR_NAME = "JdbcSourceConnector";
+    private static final int NUM_RECORDS_PRODUCED = 1;
+    private static final long CONSUME_MAX_DURATION_MS = TimeUnit.MINUTES.toMillis(2);
+    private static final int TASKS_MAX = 3;
+    private static final String MSSQL_URL = "jdbc:sqlserver://0.0.0.0:1433";
+    private static final String MSSQL_Table = "TestTable";
+    private static final String TOPIC_PREFIX = "test-";
+    private static final List<String> KAFKA_TOPICS = Collections.singletonList(TOPIC_PREFIX + MSSQL_Table );
+
+    private Map<String, String> props;
+
+    private static final String USER = "sa"; // test creds
+    private static final String PASS = "reallyStrongPwd123"; // test creds
+
+    private Connection connection;
+
+    @ClassRule
+    public static final FixedHostPortGenericContainer mssqlServer =
+            new FixedHostPortGenericContainer<>("microsoft/mssql-server-linux:latest")
+                .withEnv("ACCEPT_EULA","Y")
+                .withEnv("SA_PASSWORD","reallyStrongPwd123")
+                .withFixedExposedPort(1433, 1433);
+
+    @Before
+    public void setup() throws Exception {
+        //Create table
+        Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        connection = DriverManager.getConnection(MSSQL_URL, USER, PASS);
+        startConnect();
+
+    }
+
+    @After
+    public void close() throws SQLException {
+        connect.deleteConnector(CONNECTOR_NAME);
+        connection.close();
+        // Stop all Connect, Kafka and Zk threads.
+        stopConnect();
+    }
+
+    /**
+     * Verify that after a number of poll intervals the number of records in topic
+     * still equal to the number of records written to the MSSQL Server instance.
+     *
+     * This test is for a datetime to datetime2 comparison error in MSSQL Server (2016 and after).
+     * Datetime is converted recursively to a higher precision (eg- 3.33 MS would be 3.33333 ),
+     * while java.sql.Timestamp converts by tacking on 0s (3.33000).
+     */
+    // Verify connect error thrown
+    @Test
+    public void verifyDateTimeTSModeKillsTasks() throws Exception {
+        // Setup up props for the source connector
+        props = configProperties(true);
+        createDateTimeTable("DATETIME", "VARCHAR(255)", true);
+        ZoneId utc = ZoneId.of("UTC");
+        // Create topic in Kafka
+        KAFKA_TOPICS.forEach(topic -> connect.kafka().createTopic(topic, 1));
+
+        // Configure source connector
+        configureAndWaitForConnector();
+
+        java.sql.Timestamp t = java.sql.Timestamp.from(
+                ZonedDateTime.of(2016, 12, 8, 19, 34, 56, 2000000, utc).toInstant()
+        );
+
+        writeSingleRowWithTimestamp(t, true, true);
+
+        connect.assertions().assertConnectorIsRunningAndTasksHaveFailed(
+                CONNECTOR_NAME,
+                Math.min(KAFKA_TOPICS.size(), TASKS_MAX),
+                "failed to verify that tasks have failed"
+        );
+
+        deleteTable();
+    }
+
+
+    @Test
+    public void verifyDateTimeTSAndIncrModeKillsTasks() throws Exception {
+        // Setup up props for the source connector
+        props = configProperties(false);
+        createDateTimeTable("DATETIME", "VARCHAR(255)", false);
+        ZoneId utc = ZoneId.of("UTC");
+        // Create topic in Kafka
+        KAFKA_TOPICS.forEach(topic -> connect.kafka().createTopic(topic, 1));
+
+        // Configure source connector
+        configureAndWaitForConnector();
+
+        java.sql.Timestamp t = java.sql.Timestamp.from(
+                ZonedDateTime.of(2016, 12, 8, 19, 34, 56, 2000000, utc).toInstant()
+        );
+
+        writeSingleRowWithTimestamp(t, true, false);
+
+        connect.assertions().assertConnectorIsRunningAndTasksHaveFailed(
+                CONNECTOR_NAME,
+                Math.min(KAFKA_TOPICS.size(), TASKS_MAX),
+                "failed to verify that tasks have failed"
+        );
+
+        deleteTable();
+    }
+
+
+    /**
+     * Verify that after a number of poll intervals the number of records in topic
+     * still equal to the number of records written to the MSSQL Server instance.
+     *
+     * This test is for a datetime to datetime2 comparison error in MSSQL Server (2016 and after).
+     * Datetime is converted recursively to a higer precision (eg- 3.33 MS would be 3.33333 ),
+     * while java.sql.Timestamp converts by tacking on 0s (3.33000).
+     */
+
+    @Test
+    public void verifyDATETIME2DoesNotKillTask() throws Exception {
+        props = configProperties(true);
+        // And verify that datetime in a non-timestamp column does not kill task.
+        createDateTimeTable("DATETIME2", "DATETIME", true);
+        ZoneId utc = ZoneId.of("UTC");
+        // Create topic in Kafka
+        KAFKA_TOPICS.forEach(topic -> connect.kafka().createTopic(topic, 1));
+
+        // Configure source connector
+        configureAndWaitForConnector();
+
+        java.sql.Timestamp t = java.sql.Timestamp.from(
+                ZonedDateTime.of(2016, 12, 8, 19, 34, 56, 2000000, utc).toInstant()
+        );
+
+        writeSingleRowWithTimestamp(t, false, true);
+
+        Thread.sleep(Duration.ofSeconds(30).toMillis());
+        for (String topic: KAFKA_TOPICS) {
+            ConsumerRecords<byte[], byte[]> records = connect.kafka().consume(
+                    NUM_RECORDS_PRODUCED,
+                    CONSUME_MAX_DURATION_MS,
+                    topic);
+            //Assert that records in topic == NUM_RECORDS_PRODUCED
+            assertEquals(NUM_RECORDS_PRODUCED, records.count());
+
+        }
+        // clean up table
+        deleteTable();
+    }
+
+    private Map<String, String> configProperties(boolean timestampModeOnly) {
+        // Create a hashmap to setup source connector config properties
+        Map<String, String> props = new HashMap<>();
+        props.put(CONNECTOR_CLASS_CONFIG, "JdbcSourceConnector");
+        props.put(CONNECTION_URL_CONFIG, MSSQL_URL);
+        props.put(CONNECTION_USER_CONFIG, "sa");
+        props.put(CONNECTION_PASSWORD_CONFIG, "reallyStrongPwd123");
+        props.put(TABLE_WHITELIST_CONFIG, MSSQL_Table);
+
+        if (timestampModeOnly) {
+            props.put(MODE_CONFIG, MODE_TIMESTAMP);
+        } else {
+            props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+            props.put(INCREMENTING_COLUMN_NAME_CONFIG, "ict");
+        }
+
+        props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "start_time");
+        props.put(TOPIC_PREFIX_CONFIG, "test-");
+        props.put(POLL_INTERVAL_MS_CONFIG, "30");
+        props.put(TASKS_MAX_CONFIG, Integer.toString(TASKS_MAX));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(CONFLUENT_TOPIC_BOOTSTRAP_SERVERS_CONFIG, connect.kafka().bootstrapServers());
+        props.put(CONFLUENT_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+
+        return props;
+    }
+
+    private void createDateTimeTable(
+            String timestampColType,
+            String regularColType,
+            boolean timestampModeOnly
+    ) throws Exception {
+        try {
+            Statement stmt = connection.createStatement();
+            StringBuilder builder = new StringBuilder();
+            builder.append("CREATE TABLE " + MSSQL_Table )
+                    .append("(start_time " + timestampColType +  " not NULL, " );
+            if (!timestampModeOnly) builder.append(" ict  int not NULL, ");
+            builder.append(" record " + regularColType +  " )");
+
+            String sql = builder.toString();
+
+            stmt.executeUpdate(sql);
+            log.info("Successfully created table");
+        } catch (Exception ex) {
+            log.error("Could not create table");
+            throw ex;
+        }
+    }
+
+    private void writeSingleRowWithTimestamp(
+            Timestamp t,
+            boolean stringRecord,
+            boolean timestampModeOnly
+    ) throws Exception {
+        try {
+            StringBuilder builder = new StringBuilder();
+            builder.append("INSERT INTO " + MSSQL_Table )
+                    .append("(start_time, record" );
+            if (!timestampModeOnly) builder.append(", ict");
+            builder.append(") values (?, ?");
+            if (!timestampModeOnly) builder.append(", ?");
+            builder.append(")");
+            String sql = builder.toString();
+            PreparedStatement stmt = connection.prepareStatement(sql);
+
+
+            stmt.setTimestamp(1, t);
+            if (stringRecord) {
+                stmt.setString(2, "example record value");
+            } else {
+                stmt.setTimestamp(2, t);
+            }
+            if (!timestampModeOnly) stmt.setInt(3, 1);
+
+            stmt.executeUpdate();
+        } catch (Exception ex) {
+            log.error("Could not write row to MSSQL table");
+            throw ex;
+        }
+    }
+
+    private void deleteTable() throws Exception {
+        try {
+            PreparedStatement stmt = connection.prepareStatement(
+                    "DROP TABLE " + MSSQL_Table
+            );
+            stmt.executeUpdate();
+        } catch (Exception ex) {
+            log.error("Could delete all rows in the MSSQL table");
+            throw ex;
+        }
+    }
+
+    private void configureAndWaitForConnector() throws Exception {
+        // start a source connector
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        // wait for tasks to spin up
+        int minimumNumTasks = Math.min(KAFKA_TOPICS.size(), TASKS_MAX);
+        waitForConnectorToStart(CONNECTOR_NAME, minimumNumTasks);
+    }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -21,3 +21,8 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.io.confluent.connect=ERROR
+
+#IT test log levels
+log4j.logger.kafka=WARN
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.reflections.Reflections=ERROR


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

## Problem
Ms Sql Server datetime columns have a precision error that causes our connector to loop on the most recent record. This error cannot be fixed by increasing precision because precision is set at a driver level.

### References
http://www.dbdelta.com/sql-server-2016-and-azure-sql-database-v12-breaking-change/

## Solution
 We've decided to forbid the use of `datetime` for MSSQL Server (post 2016) and this pr includes a runtime validation for it

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ x] no

##### If yes, where?


## Test Strategy
Tested this using IT tests and different MS SQL Drivers locally

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
