### PR TITLE
MINOR: Fix exception when failing to read tables

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -530,7 +531,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       try (Connection db = DriverManager.getConnection(dbUrl, dbUser, dbPasswordStr)) {
         return new LinkedList<Object>(JdbcUtils.getTables(db, schemaPattern, tableTypes));
       } catch (SQLException e) {
-        throw new ConfigException("Couldn't open connection to " + dbUrl, e);
+        throw new ConnectException("Couldn't open connection to " + dbUrl, e);
       }
     }
 


### PR DESCRIPTION
The `ConfigException` class doesn't have a constructor that accepts a child exception, but it does have a constructor that appears to, which accepts [a `String` and an `Object`](https://github.com/apache/kafka/blob/149897976214a769a35cf87eecf9c02221f8d597/clients/src/main/java/org/apache/kafka/common/config/ConfigException.java#L32-L34).

Using that constructor with a message and an exception cause error messages like this to be logged:
```
Invalid value org.postgresql.util.PSQLException: FATAL: password authentication failed for user "fm_service_api_journal_usage" for configuration Couldn't open connection to jdbc:postgresql://db.my-env.local/db
```

The fix here replaces the `ConfigException` with a `ConnectException`, which should fix how errors are logged when the connector has trouble reading the list of tables from the source database.