### PR TITLE
CC-11940: fix a bug that happens when merging long text to oracle table

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -16,9 +16,13 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
@@ -72,6 +76,21 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     return "SELECT 1 FROM DUAL";
   }
 
+  @Override
+  protected boolean maybeBindPrimitive(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value
+  ) throws SQLException {
+    if (schema.type() == Type.STRING) {
+      statement.setNString(index, (String) value);
+      return true;
+    }
+    return super.maybeBindPrimitive(statement, index, schema, value);
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   protected String getSqlType(SinkRecordField field) {
     if (field.schemaName() != null) {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -413,7 +413,12 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     verifyBindField(++index, Schema.FLOAT64_SCHEMA, 42d).setDouble(index, 42d);
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
-    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
+    if (dialect instanceof OracleDatabaseDialect) {
+      verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setNString(index, "yep");
+    } else {
+      verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
+    }
+
     verifyBindField(
         ++index,
         Decimal.schema(0),

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -401,7 +401,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   }
 
   @Test
-  public void bindFieldPrimitiveValues() throws SQLException {
+  public void bindFieldPrimitiveValuesExceptString() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
     verifyBindField(++index, Schema.INT8_SCHEMA, (byte) 42).setByte(index, (byte) 42);
     verifyBindField(++index, Schema.INT16_SCHEMA, (short) 42).setShort(index, (short) 42);
@@ -413,11 +413,6 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     verifyBindField(++index, Schema.FLOAT64_SCHEMA, 42d).setDouble(index, 42d);
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
-    if (dialect instanceof OracleDatabaseDialect) {
-      verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setNString(index, "yep");
-    } else {
-      verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
-    }
 
     verifyBindField(
         ++index,
@@ -440,6 +435,12 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
       Timestamp.SCHEMA,
       new java.util.Date(100)
     ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
+  }
+
+  @Test
+  public void bindFieldStringValue() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -14,6 +14,14 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.TimeZone;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -32,6 +40,13 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Override
   protected OracleDatabaseDialect createDialect() {
     return new OracleDatabaseDialect(sourceConfigWithUrl("jdbc:oracle:thin://something"));
+  }
+
+  @Override
+  @Test
+  public void bindFieldStringValue() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setNString(index, "yep");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -324,7 +324,7 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
   }
 
   @Test
-  public void bindFieldPrimitiveValues() throws SQLException {
+  public void bindFieldPrimitiveValuesExceptString() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
     verifyBindField(++index, Schema.INT8_SCHEMA, (short) 42).setShort(index, (short) 42);
     verifyBindField(++index, Schema.INT8_SCHEMA, (short) -42).setShort(index, (short) -42);


### PR DESCRIPTION
## Problem
When use merge to upsert oracle table, if there is a long text (>=32 kb), there will be an exception "ORA-01461: can bind a LONG value only for insert into a LONG column". This happens even when the column type is CLOB. 

## Solution
replace PreparedStatement.setString() with PreparedStatement.setNString() in bindMaybePrimitive(). Manually tested that this works, and have no side effect.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
targeting 5.0.x; once merged, pint merge all the way to master; release a bug fix version from 5.4.x