### PR TITLE
MINOR: Change TableRecommender to return empty list if unable to connect and obtain list of available tables

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -659,7 +660,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         }
         return result;
       } catch (SQLException e) {
-        throw new ConfigException("Couldn't open connection to " + dbUrl, e);
+        // We're just recommending values, so just return an empty list if we run into
+        // any connectivity problems
+        LOG.debug(
+            "Recommending no tables due to error opening connection to {}",
+            dialect.identifier(),
+            e
+        );
+        return Collections.emptyList();
       }
     }
 


### PR DESCRIPTION
## Problem
The source connector's `TableRecommender` does not have visibility to the non-parsed configuration properties (e.g., those that don't have a ConfigDef). This means that any extra `connection.*` properties enabled via #870 are simply not visible to any recommenders.

## Solution
Rather than fail if the `TableRecommender` is not able to connect and list available tables, simply return an empty list. Any connection-related properties will be reported on the connection-related properties themselves, so failing with an error is really not helpful and, in the case of extra properties, the recommender actually prevents otherwise valid configurations from being used.

TBD: The `TableRecommender` has been only semi-functional for some time, and it can lead to excessive validation times. It may be better to simply remove this altogether.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Existing unit tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
