### PR TITLE
CC-11984: Remove the `table.whitelist` and `table.blacklist` recommended values

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,8 +15,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -25,15 +23,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
-import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.EnumRecommender;
 import io.confluent.connect.jdbc.util.QuoteMethod;
-import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.TimeZoneValidator;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -289,13 +283,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String MODE_GROUP = "Mode";
   public static final String CONNECTOR_GROUP = "Connector";
 
-  // We want the table recommender to only cache values for a short period of time so that the
-  // blacklist and whitelist config properties can use a single query.
-  private static final Recommender TABLE_RECOMMENDER = new CachingRecommender(
-      new TableRecommender(),
-      Time.SYSTEM,
-      TimeUnit.SECONDS.toMillis(5)
-  );
   private static final Recommender MODE_DEPENDENTS_RECOMMENDER =  new ModeDependentsRecommender();
 
 
@@ -385,8 +372,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         DATABASE_GROUP,
         ++orderInGroup,
         Width.LONG,
-        TABLE_WHITELIST_DISPLAY,
-        TABLE_RECOMMENDER
+        TABLE_WHITELIST_DISPLAY
     ).define(
         TABLE_BLACKLIST_CONFIG,
         Type.LIST,
@@ -396,8 +382,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         DATABASE_GROUP,
         ++orderInGroup,
         Width.LONG,
-        TABLE_BLACKLIST_DISPLAY,
-        TABLE_RECOMMENDER
+        TABLE_BLACKLIST_DISPLAY
     ).define(
         CATALOG_PATTERN_CONFIG,
         Type.STRING,
@@ -636,36 +621,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     String mode = getString(JdbcSourceConnectorConfig.MODE_CONFIG);
     if (mode.equals(JdbcSourceConnectorConfig.MODE_UNSPECIFIED)) {
       throw new ConfigException("Query mode must be specified");
-    }
-  }
-
-  private static class TableRecommender implements Recommender {
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public List<Object> validValues(String name, Map<String, Object> config) {
-      String dbUrl = (String) config.get(CONNECTION_URL_CONFIG);
-      if (dbUrl == null) {
-        throw new ConfigException(CONNECTION_URL_CONFIG + " cannot be null.");
-      }
-      // Create the dialect to get the tables ...
-      AbstractConfig jdbcConfig = new AbstractConfig(CONFIG_DEF, config);
-      DatabaseDialect dialect = DatabaseDialects.findBestFor(dbUrl, jdbcConfig);
-      try (Connection db = dialect.getConnection()) {
-        List<Object> result = new LinkedList<>();
-        for (TableId id : dialect.tableIds(db)) {
-          // Just add the unqualified table name
-          result.add(id.tableName());
-        }
-        return result;
-      } catch (SQLException e) {
-        throw new ConfigException("Couldn't open connection to " + dbUrl, e);
-      }
-    }
-
-    @Override
-    public boolean visible(String name, Map<String, Object> config) {
-      return true;
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -98,8 +98,9 @@ public class JdbcSourceConnectorConfigTest {
     props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
-    assertWhitelistRecommendations("some_table", "public_table", "private_table", "another_private_table");
-    assertBlacklistRecommendations("some_table", "public_table", "private_table", "another_private_table");
+    // Should have no recommended values
+    assertWhitelistRecommendations();
+    assertBlacklistRecommendations();
   }
 
   @Test
@@ -108,8 +109,9 @@ public class JdbcSourceConnectorConfigTest {
     props.put(JdbcSourceConnectorConfig.SCHEMA_PATTERN_CONFIG, "PRIVATE_SCHEMA");
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
-    assertWhitelistRecommendations("private_table", "another_private_table");
-    assertBlacklistRecommendations("private_table", "another_private_table");
+    // Should have no recommended values
+    assertWhitelistRecommendations();
+    assertBlacklistRecommendations();
   }
 
   @Test


### PR DESCRIPTION
## Problem
The JDBC source connector uses a `TableRecommender` for the `table.whitelist` and `table.blacklist` properties. This recommender uses the connector properties to establish a connection, and then read the accessible tables.

Unfortunately, AK's `ConfigDef` and `AbstractConfig` class only pass to each `Recommender.validValues(...)` methods the **_parsed_** configuration properties, which are only those properties that are defined with a `ConfigDef`. 

In #870 we added the ability for users to define extra properties that would be passed to the JDBC driver when connecting to the database. These extra properties are not defined by `ConfigDef` as they vary by DBMS/driver, and therefore are not included when passed to any Recommender instances. In the case of the `TableRecommender`, if the extra properties included any properties required for connections (e.g., kerberos-related properties for the JDBC driver), then the recommender would fail to connect and would throw a ConnectException. The `ConfigDef` and `AbstractConfig` then record this as a configuration error on the property with the recommender (e.g., `table.whitelist` or `table.blacklist`).

IOW, if you use those extra `connector.*` properties to enable Kerberos, the connector would otherwise be able to connect except for the failing `TableRecommender` that does not see/use those `connector.*` properties.

One solution is to just change the `TableRecommender` to return an empty list if it could not connect, since any properties that prohibited connecting would have their own errors. Unfortunately, that results in a poor and inconsistent user experience, because **_sometimes_** the user would get recommended values in C3 for `table.whitelist` and `table.blacklist`, while **_other times_** they would get no recommended values. This behavior would not be very intuitive and would cause lots of headaches, since it would depend upon whether any `connection.*` properties were required to connect to the database and read the accessible tables.

Instead, the proposed solution is to simply remove `TableRecommender` altogether. This class has been a problem for quite some time:

1. If the database user has access to lots of tables, this recommender may take a long time to read the list of accessible tables, leading to long validation times or failed validations.
2. If the database user has access to lots of tables, the choice lists in C3 are super long and not really useable.
3. If the recommender returns large numbers of tables, the validation result can be very large, since these are once for `table.whitelist` and another time for `table.blacklist`.
4. The TableRecommender creates a new connection with every validation attempt for **_each_** of the two properties. This is exacerbated if the user is quickly trying different combinations of other properties. (Each connection is indeed closed via a try-with-resources block.)
5. Recommenders are always populated, but only used in tools like C3. Most other applications that validate a config with the REST API do not use the recommendations.

Since we're about to release the 10.0.0 version of the JDBC source and sink connectors, now would be a good time to change this behavior and remove this particular recommender. (The only other recommender in the JDBC source does not use a connection and is literally just a decision tree with other property values, so it’s worth keeping.)

## Solution
Remove the `TableRecommender` to simplify the connector and eliminate potentially long-running operations. As a result, tools like C3 would no longer show recommended values for `table.whitelist` and `table.blacklist` properties.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
The test cases that verified the `TableRecommender` values were modified to assert that an empty list of tables is returned.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Include in the upcoming 10.0.0 release. Since there is no `10.0.x` branch yet, this should be applied to the `master` branch.
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
