### PR TITLE
Remove Connect-utils and Licensing-Extensions Deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,12 +177,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>connect-licensing-extensions</artifactId>
-            <version>${confluent.licensing.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>
@@ -213,14 +207,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>connect-utils</artifactId>
-            <version>${connect.utils.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.12.2</version>
+            <version>1.15.0-rc2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <connect.utils.version>0.1.11</connect.utils.version>
-        <confluent.licensing.version>0.5.2</confluent.licensing.version>
     </properties>
 
     <repositories>

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
@@ -49,13 +49,6 @@ import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TIMESTA
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG;
 
-import static io.confluent.connect.utils.licensing.LicenseConfigUtil.CONFLUENT_TOPIC_BOOTSTRAP_SERVERS_CONFIG;
-import static io.confluent.connect.utils.licensing.LicenseConfigUtil.CONFLUENT_TOPIC_REPLICATION_FACTOR_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
-
 /**
  * This test is to verify that JDBC source connector forbids Datetime column type
  * for MSSQL Server (2016 and after).
@@ -251,7 +244,7 @@ public class MSSQLDateTimeIT extends BaseConnectorIT {
     private Map<String, String> configProperties() {
         // Create a hashmap to setup source connector config properties
         Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, "JdbcSourceConnector");
+        props.put("connector.class", "JdbcSourceConnector");
         props.put(CONNECTION_URL_CONFIG, MSSQL_URL);
         props.put(CONNECTION_USER_CONFIG, "sa");
         props.put(CONNECTION_PASSWORD_CONFIG, "reallyStrongPwd123");
@@ -259,11 +252,11 @@ public class MSSQLDateTimeIT extends BaseConnectorIT {
         props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "start_time");
         props.put(TOPIC_PREFIX_CONFIG, "test-");
         props.put(POLL_INTERVAL_MS_CONFIG, "30");
-        props.put(TASKS_MAX_CONFIG, Integer.toString(TASKS_MAX));
-        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-        props.put(CONFLUENT_TOPIC_BOOTSTRAP_SERVERS_CONFIG, connect.kafka().bootstrapServers());
-        props.put(CONFLUENT_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+        props.put("tasks.max", Integer.toString(TASKS_MAX));
+        props.put("key.converter", StringConverter.class.getName());
+        props.put("value.converter", StringConverter.class.getName());
+        props.put("confluent.topic.bootstrap.servers", connect.kafka().bootstrapServers());
+        props.put("confluent.topic.replication.factor", "1");
 
         return props;
     }

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
@@ -49,6 +49,11 @@ import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TIMESTA
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG;
 
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+
 /**
  * This test is to verify that JDBC source connector forbids Datetime column type
  * for MSSQL Server (2016 and after).
@@ -244,7 +249,7 @@ public class MSSQLDateTimeIT extends BaseConnectorIT {
     private Map<String, String> configProperties() {
         // Create a hashmap to setup source connector config properties
         Map<String, String> props = new HashMap<>();
-        props.put("connector.class", "JdbcSourceConnector");
+        props.put(CONNECTOR_CLASS_CONFIG, "JdbcSourceConnector");
         props.put(CONNECTION_URL_CONFIG, MSSQL_URL);
         props.put(CONNECTION_USER_CONFIG, "sa");
         props.put(CONNECTION_PASSWORD_CONFIG, "reallyStrongPwd123");
@@ -252,12 +257,9 @@ public class MSSQLDateTimeIT extends BaseConnectorIT {
         props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "start_time");
         props.put(TOPIC_PREFIX_CONFIG, "test-");
         props.put(POLL_INTERVAL_MS_CONFIG, "30");
-        props.put("tasks.max", Integer.toString(TASKS_MAX));
-        props.put("key.converter", StringConverter.class.getName());
-        props.put("value.converter", StringConverter.class.getName());
-        props.put("confluent.topic.bootstrap.servers", connect.kafka().bootstrapServers());
-        props.put("confluent.topic.replication.factor", "1");
-
+        props.put(TASKS_MAX_CONFIG, Integer.toString(TASKS_MAX));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         return props;
     }
 


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

## Problem
Now merged #918 included some dependencies (connect-utils, licensing-extensions) that were not available in JDBC. 
Also noted that with a current docker update, test containers used for #918 were failing
## Solution
- Replaced connect utils, licensing extensions config, with raw strings, and removed the dependency
- Bumped [test containers version](https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.0-rc2)
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ x] Unit tests
- [x ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Pint merge up 