### PR TITLE
Update GenericDatabaseDialect.java

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1094,6 +1094,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         log.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
         SchemaBuilder fieldBuilder = Decimal.builder(scale);
+        fieldBuilder.parameter("connect.decimal.precision", String.valueOf(precision));
         if (optional) {
           fieldBuilder.optional();
         }


### PR DESCRIPTION
This plug-in does not limit the length of decimal data in the schema encapsulation. It is recommended to perfect the schema information according to the metadata information of the table during the schema encapsulation to ensure that the length of Decimal is less than 38 bits, which will also cause hive to be unable to parse the data type of Decimal.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
