### PR TITLE
Maven: Removed build property ${confluent.maven.repo}.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,13 @@
         <licenses.version>${project.version}</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
 
     <repositories>
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Problem
This property was used in repository/url definition.  This causes a problem with resolution of the parent project/pom, since
property-evaluation occurs in Maven after the parent project is resolved.

## Solution
Remove the property in favour of hard-coded repo URL.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

##### If yes, where?
Several other connector projects

## Test Strategy

- Failed Travis test build: https://travis-ci.org/github/javabrett/kafka-connect-jdbc/builds/734927879
- Passing Travis test build: https://travis-ci.org/github/javabrett/kafka-connect-jdbc/builds/734957751

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
