### PR TITLE
Implement Insert with Ignore statement on database dialects

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -309,6 +309,52 @@ public interface DatabaseDialect extends ConnectionProvider {
   void applyDdlStatements(Connection connection, List<String> statements) throws SQLException;
 
   /**
+   * Build the INSERT IGNORE prepared statement expression for the given table and its columns.
+   *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildInsertIgnoreStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildInsertIgnoreStatement(TableId, Collection, Collection, TableDefinition)} is suggested.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @return the INSERT IGNORE statement; may not be null
+   */
+  String buildInsertIgnoreStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  );
+
+  /**
+   * Build the INSERT IGNORE prepared statement expression for the given table and its columns.
+   *
+   * <p>By default this method calls
+   * {@link #buildInsertIgnoreStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildInsertIgnoreStatement(TableId, Collection, Collection)}.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @param definition    the table definition; may be null if unknown
+   * @return the INSERT IGNORE statement; may not be null
+   */
+  default String buildInsertIgnoreStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns,
+          TableDefinition definition
+  ) {
+    return buildInsertIgnoreStatement(table, keyColumns, nonKeyColumns);
+  }
+
+  /**
    * Build the INSERT prepared statement expression for the given table and its columns.
    *
    * <p>This method is only called by the default implementation of

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -314,7 +314,8 @@ public interface DatabaseDialect extends ConnectionProvider {
    * <p>This method is only called by the default implementation of
    * {@link #buildInsertIgnoreStatement(TableId, Collection, Collection, TableDefinition)}, since
    * many dialects implement this variant of the method. However, overriding
-   * {@link #buildInsertIgnoreStatement(TableId, Collection, Collection, TableDefinition)} is suggested.
+   * {@link #buildInsertIgnoreStatement(TableId, Collection, Collection, TableDefinition)}
+   * is suggested.
    *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1460,18 +1460,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           Collection<ColumnId> keyColumns,
           Collection<ColumnId> nonKeyColumns
   ) {
-    ExpressionBuilder builder = expressionBuilder();
-    builder.append("INSERT IGNORE INTO ");
-    builder.append(table);
-    builder.append("(");
-    builder.appendList()
-            .delimitedBy(",")
-            .transformedBy(ExpressionBuilder.columnNames())
-            .of(keyColumns, nonKeyColumns);
-    builder.append(") VALUES(");
-    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
-    builder.append(")");
-    return builder.toString();
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1455,6 +1455,26 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
+  public String buildInsertIgnoreStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT IGNORE INTO ");
+    builder.append(table);
+    builder.append("(");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES(");
+    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
   @SuppressWarnings("deprecation")
   public String buildInsertStatement(
       TableId table,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -125,6 +125,26 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   @Override
+  public String buildInsertIgnoreStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT IGNORE INTO ");
+    builder.append(table);
+    builder.append("(");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES(");
+    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
   public String buildUpsertQueryStatement(
       TableId table,
       Collection<ColumnId> keyColumns,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -131,6 +131,33 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
   }
 
   @Override
+  public String buildInsertIgnoreStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT /*+ ignore_row_on_dupkey_index(");
+    builder.append(table);
+    builder.append(",");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns);
+    builder.append(") */ INTO ");
+    builder.append(table);
+    builder.append("(");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES(");
+    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
   public String buildDropTableStatement(
       TableId table,
       DropOptions options

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -257,6 +257,30 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   @Override
   public String buildInsertStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns,
+          TableDefinition definition
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(table);
+    builder.append(" (");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES (");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(this.columnValueVariables(definition))
+            .of(keyColumns, nonKeyColumns);
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
+  public String buildInsertIgnoreStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
       Collection<ColumnId> nonKeyColumns,
@@ -275,7 +299,12 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
            .delimitedBy(",")
            .transformedBy(this.columnValueVariables(definition))
            .of(keyColumns, nonKeyColumns);
-    builder.append(")");
+    builder.append(") ON CONFLICT (");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns);
+    builder.append(") DO NOTHING");
     return builder.toString();
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialect.java
@@ -112,6 +112,26 @@ public class SqliteDatabaseDialect extends GenericDatabaseDialect {
   }
 
   @Override
+  public String buildInsertIgnoreStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT OR IGNORE INTO ");
+    builder.append(table);
+    builder.append("(");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES(");
+    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
   public String buildUpsertQueryStatement(
       TableId table,
       Collection<ColumnId> keyColumns,

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -264,6 +264,13 @@ public class BufferedRecords {
 
   private String getInsertSql() throws SQLException {
     switch (config.insertMode) {
+      case IGNORE:
+        return dbDialect.buildInsertIgnoreStatement(
+                tableId,
+                asColumns(fieldsMetadata.keyFieldNames),
+                asColumns(fieldsMetadata.nonKeyFieldNames),
+                dbStructure.tableDefinition(connection, tableId)
+        );
       case INSERT:
         return dbDialect.buildInsertStatement(
             tableId,

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -46,6 +46,7 @@ import org.apache.kafka.common.config.types.Password;
 public class JdbcSinkConfig extends AbstractConfig {
 
   public enum InsertMode {
+    IGNORE,
     INSERT,
     UPSERT,
     UPDATE;

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -208,6 +208,15 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   }
 
   @Test
+  public void ignore() {
+    TableId customers = tableId("customers");
+    String expected = "INSERT IGNORE INTO `customers`(`age`,`firstName`,`lastName`) VALUES(?,?,?)";
+    String sql = dialect.buildInsertIgnoreStatement(customers, columns(customers),
+            columns(customers, "age", "firstName", "lastName"));
+    assertEquals(expected, sql);
+  }
+
+  @Test
   public void insert() {
     TableId customers = tableId("customers");
     String expected = "INSERT INTO `customers`(`age`,`firstName`,`lastName`) VALUES(?,?,?)";

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -157,6 +157,14 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   }
 
   @Test
+  public void shouldBuildInsertIgnoreStatement() {
+    String expected = "INSERT /*+ ignore_row_on_dupkey_index(\"myTable\",\"id1\",\"id2\") */ INTO \"myTable\"(\"id1\",\"id2\"," +
+                      "\"columnA\",\"columnB\",\"columnC\",\"columnD\") VALUES(?,?,?,?,?,?)";
+    String sql = dialect.buildInsertIgnoreStatement(tableId, pkColumns, columnsAtoD);
+    assertEquals(expected, sql);
+  }
+
+  @Test
   public void shouldBuildUpsertStatement() {
     String expected = "merge into \"myTable\" using (select ? \"id1\", ? \"id2\", ? \"columnA\", " +
                       "? \"columnB\", ? \"columnC\", ? \"columnD\" FROM dual) incoming on" +

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -223,6 +223,25 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.buildInsertStatement(tableId, pkColumns, nonPkColumns, tableDefn)
     );
   }
+
+  @Test
+  public void shouldBuildInsertIgnoreStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    assertEquals(
+            "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+                    "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
+                    "\"id2\") DO NOTHING",
+            dialect.buildInsertIgnoreStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+  }
+
   @Test
   public void shouldBuildUpsertStatement() {
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -186,6 +186,14 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
   }
 
   @Test
+  public void shouldBuildInsertIgnoreStatement() {
+    String expected = "INSERT OR IGNORE INTO `myTable`(`id1`,`id2`,`columnA`,`columnB`," +
+            "`columnC`,`columnD`) VALUES(?,?,?,?,?,?)";
+    String sql = dialect.buildInsertIgnoreStatement(tableId, pkColumns, columnsAtoD);
+    assertEquals(expected, sql);
+  }
+
+  @Test
   public void shouldBuildUpsertStatement() {
     String expected = "INSERT OR REPLACE INTO `myTable`(`id1`,`id2`,`columnA`,`columnB`," +
                       "`columnC`,`columnD`) VALUES(?,?,?,?,?,?)";


### PR DESCRIPTION
In some cases such as the existence of duplicating records, the sink connector task is going to fail if the `insert.mode=insert` in such a case. Also, the `upsert` mode is not efficient and fast enough in such cases with a large amount of data and data-append only(Such as logs or any event-based records). So here is the deal: Just insert the data into the database without any interruption on connectors task and  other effects that interruption on tasks might happen

## Test Strategy
<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests
