### PR TITLE
CC-12468: Periodically return control flow to WorkerSourceTask

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,42 @@
             <version>2.5.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kafka.version}</version>
+            <type>test-jar</type>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <type>test-jar</type>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -303,7 +303,7 @@ public class JdbcSourceTask extends SourceTask {
   public List<SourceRecord> poll() throws InterruptedException {
     log.trace("{} Polling for new data");
 
-    Map<String, Integer> consecutiveEmptyResults = tableQueue.stream().collect(
+    Map<TableQuerier, Integer> consecutiveEmptyResults = tableQueue.stream().collect(
         Collectors.toMap(Function.identity(), (q) -> 0));
     while (running.get()) {
       final TableQuerier querier = tableQueue.peek();

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -352,7 +352,7 @@ public class JdbcSourceTask extends SourceTask {
             continue;
           }
         } else {
-          consecutiveEmptyResults.put(querier.toString(), 0);
+          consecutiveEmptyResults.put(querier, 0);
         }
 
         log.debug("Returning {} records for {}", results.size(), querier.toString());

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -340,7 +340,7 @@ public class JdbcSourceTask extends SourceTask {
         }
 
         if (results.isEmpty()) {
-          consecutiveEmptyResults.compute(querier.toString(), (k, v) -> v + 1);
+          consecutiveEmptyResults.compute(querier, (k, v) -> v + 1);
           log.trace("No updates for {}", querier.toString());
 
           if (Collections.min(consecutiveEmptyResults.values())

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -304,7 +304,7 @@ public class JdbcSourceTask extends SourceTask {
     log.trace("{} Polling for new data");
 
     Map<String, Integer> consecutiveEmptyResults = tableQueue.stream().collect(
-        Collectors.toMap(TableQuerier::toString, (q) -> 0));
+        Collectors.toMap(Function.identity(), (q) -> 0));
     while (running.get()) {
       final TableQuerier querier = tableQueue.peek();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -35,6 +35,7 @@ import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
@@ -218,6 +219,16 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
                    time.milliseconds());
       validatePollResultTable(records, 1, SECOND_TABLE_NAME);
     }
+  }
+
+  @Test
+  public void testMultipleTablesNothingToDoReturns() throws Exception {
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT");
+    db.createTable(SECOND_TABLE_NAME, "id", "INT");
+
+    task.start(twoTableConfig());
+
+    assertNull(task.poll());
   }
 
   private static void validatePollResultTable(List<SourceRecord> records,

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
@@ -1,0 +1,135 @@
+package io.confluent.connect.jdbc.source.integration;
+
+import ch.vorburger.mariadb4j.DBConfigurationBuilder;
+import ch.vorburger.mariadb4j.junit.MariaDB4jRule;
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.AbstractStatus.State;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.JdbcSourceConnector;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+
+@Category(IntegrationTest.class)
+public class PauseResumeIT {
+  private static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+  private static final long POLLING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
+  private static final String CONNECTOR_NAME = "JdbcSourceConnector";
+
+  private static Logger log = LoggerFactory.getLogger(PauseResumeIT.class);
+
+  @Rule
+  public MariaDB4jRule dbRule = new MariaDB4jRule(
+      DBConfigurationBuilder.newBuilder().setPort(0).build(),
+      "testdb", null);
+
+  EmbeddedConnectCluster connect;
+  Map<String, String> props;
+
+  @Before
+  public void before() throws Exception {
+    props = new HashMap<>();
+    props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, JdbcSourceConnector.class.getName());
+    props.put(TASKS_MAX_CONFIG, "1");
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, dbRule.getURL());
+    props.put(JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG, "root");
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    props.put(JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG, Long.toString(POLLING_INTERVAL_MS));
+    props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, "topic_");
+
+    connect = new EmbeddedConnectCluster.Builder()
+        .name("connect-cluster")
+        .numWorkers(1)
+        .brokerProps(new Properties())
+        .build();
+
+    // start the clusters
+    log.debug("Starting embedded Connect worker, Kafka broker, and ZK");
+    connect.start();
+  }
+
+  @After
+  public void after() {
+    if (connect != null) {
+      connect.stop();
+    }
+  }
+
+  @Test
+  public void testPauseResume() throws Exception {
+    try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
+      stmt.executeUpdate(
+          "CREATE TABLE accounts(id INTEGER AUTO_INCREMENT NOT NULL, name VARCHAR(255), PRIMARY KEY (id))" );
+    }
+
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+    Thread.sleep(POLLING_INTERVAL_MS);
+
+    connect.executePut(connect.endpointForResource(String.format("connectors/%s/pause", CONNECTOR_NAME)), "");
+
+    waitForConnectorState(CONNECTOR_NAME, 1,
+        3*POLLING_INTERVAL_MS, State.PAUSED);
+
+    connect.executePut(connect.endpointForResource(String.format("connectors/%s/resume", CONNECTOR_NAME)), "");
+    waitForConnectorState(CONNECTOR_NAME, 1,
+        3*POLLING_INTERVAL_MS, State.RUNNING);
+  }
+
+  protected Optional<Boolean> assertConnectorAndTasksStatus(String connectorName, int numTasks, AbstractStatus.State expectedStatus) {
+    try {
+      ConnectorStateInfo info = connect.connectorStatus(connectorName);
+      boolean result = info != null
+          && info.tasks().size() >= numTasks
+          && info.connector().state().equals(expectedStatus.toString())
+          && info.tasks().stream().allMatch(s -> s.state().equals(expectedStatus.toString()));
+      return Optional.of(result);
+    } catch (Exception e) {
+      log.debug("Could not check connector state info.", e);
+      return Optional.empty();
+    }
+  }
+
+  protected long waitForConnectorToStart(String name, int numTasks) throws InterruptedException {
+    return waitForConnectorState(name, numTasks, CONNECTOR_STARTUP_DURATION_MS, State.RUNNING);
+  }
+
+  protected long waitForConnectorState(String name, int numTasks, long timeoutMs, State state) throws InterruptedException {
+    TestUtils.waitForCondition(
+        () -> assertConnectorAndTasksStatus(name, numTasks, state).orElse(false),
+        timeoutMs,
+        "Connector tasks did not transition to state " + state + " in time"
+    );
+    return System.currentTimeMillis();
+  }
+
+  private Connection getConnection() throws SQLException {
+    return DriverManager.getConnection(dbRule.getURL(), "root", "");
+  }
+}


### PR DESCRIPTION
## Problem
As described in https://github.com/confluentinc/kafka-connect-jdbc/issues/374, CC-12468, and SourceTask [javadoc](https://github.com/apache/kafka/blob/trunk/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java#L48), `poll()` should block when no data is available, but periodically return control flow to caller to give it a chance to pause the connector. Failure to do so caused pause to not be reflected until any result was polled from the database. The workaround is to delete the connector and recreate to resume. But, it is not as convenient as pause/resume.

## Solution
Keep track of consecutive empty results. Return `null` to WorkerSourceTask once consecutive empty results pass a threshold.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Other source connectors will have the same issue and may need to be updated accordingly.

## Test Strategy
Added integration test for source connector pause/resume.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backport the bugfix as far back as `5.0.x`