### PR TITLE
MINOR: fix the build for 5.2.x

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
@@ -92,12 +92,12 @@ public class PauseResumeIT {
 
     Thread.sleep(POLLING_INTERVAL_MS);
 
-    connect.executePut(connect.endpointForResource(String.format("connectors/%s/pause", CONNECTOR_NAME)), "");
+    connect.requestPut(connect.endpointForResource(String.format("connectors/%s/pause", CONNECTOR_NAME)), "");
 
     waitForConnectorState(CONNECTOR_NAME, 1,
         3*POLLING_INTERVAL_MS, State.PAUSED);
 
-    connect.executePut(connect.endpointForResource(String.format("connectors/%s/resume", CONNECTOR_NAME)), "");
+    connect.requestPut(connect.endpointForResource(String.format("connectors/%s/resume", CONNECTOR_NAME)), "");
     waitForConnectorState(CONNECTOR_NAME, 1,
         3*POLLING_INTERVAL_MS, State.RUNNING);
   }


### PR DESCRIPTION
## Problem
The executePut method was deprecated. Using it causes a warning at compile time, failing the build.

## Solution
Replace usage with requestPut.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
