### PR TITLE
MINOR: fix the build for 5.5.x

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -952,6 +952,9 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
                               String topic)
       throws Exception {
     List<SourceRecord> records = task.poll();
+    while(records == null) {
+      records = task.poll();
+    }
     assertEquals(numRecords, records.size());
 
     HashMap<T, Integer> valueCounts = new HashMap<>();

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -18,10 +18,12 @@ package io.confluent.connect.jdbc.source;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -952,9 +954,12 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
                               String topic)
       throws Exception {
     List<SourceRecord> records = task.poll();
-    while(records == null) {
+    int count = 0;
+    while(records == null && count++ < 5) {
       records = task.poll();
+      Thread.sleep(500);
     }
+    assertNotNull(records);
     assertEquals(numRecords, records.size());
 
     HashMap<T, Integer> valueCounts = new HashMap<>();


### PR DESCRIPTION
## Problem
With https://github.com/confluentinc/kafka-connect-jdbc/pull/947, poll periodically returns null

## Solution
Update test expectation to call poll until result not null

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
