### PR TITLE
Adding more cases for JDBC DLQ

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -112,7 +112,7 @@ public class DbStructure {
       final FieldsMetadata fieldsMetadata
   ) throws SQLException {
     if (!config.autoCreate) {
-      throw new ConnectException(
+      throw new SQLException(
           String.format("Table %s is missing and auto-creation is disabled", tableId)
       );
     }
@@ -164,7 +164,7 @@ public class DbStructure {
         break;
       case VIEW:
       default:
-        throw new ConnectException(
+        throw new SQLException(
             String.format(
                 "%s %s is missing fields (%s) and ALTER %s is unsupported",
                 type.capitalized(),
@@ -177,7 +177,7 @@ public class DbStructure {
 
     for (SinkRecordField missingField: missingFields) {
       if (!missingField.isOptional() && missingField.defaultValue() == null) {
-        throw new ConnectException(String.format(
+        throw new SQLException(String.format(
             "Cannot ALTER %s %s to add missing field %s, as the field is not optional and does "
             + "not have a default value",
             type.jdbcName(),
@@ -188,7 +188,7 @@ public class DbStructure {
     }
 
     if (!config.autoEvolve) {
-      throw new ConnectException(String.format(
+      throw new SQLException(String.format(
           "%s %s is missing fields (%s) and auto-evolution is disabled",
           type.capitalized(),
           tableId,
@@ -208,7 +208,7 @@ public class DbStructure {
       dbDialect.applyDdlStatements(connection, amendTableQueries);
     } catch (SQLException sqle) {
       if (maxRetries <= 0) {
-        throw new ConnectException(
+        throw new SQLException(
             String.format(
                 "Failed to amend %s '%s' to add missing fields: %s",
                 type,

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.jdbc.sink;
 
-import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,7 +84,8 @@ public class JdbcSinkTask extends SinkTask {
     try {
       writer.write(records);
     } catch (SQLException sqle) {
-      if (reporter != null) {
+      Connection connection = writer.cachedConnectionProvider.getConnection();
+      if (reporter != null && connection == null) {
         for (SinkRecord record : records) {
           retryAndSendDLQ(Collections.singletonList(record));
         }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
@@ -55,6 +56,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 
 public class JdbcSinkTaskTest extends EasyMockSupport {
@@ -367,9 +369,13 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       }
     };
     task.initialize(ctx);
+    CachedConnectionProvider cachedConnectionProvider = createMock(CachedConnectionProvider.class);
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
+    Connection connection = createMock(Connection.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
     expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null)).times(batchSize);
+    expect(mockWriter.cachedConnectionProvider).andReturn(cachedConnectionProvider);
+    expect(mockWriter.cachedConnectionProvider.getConnection()).andReturn(null);
     replayAll();
 
     Map<String, String> props = new HashMap<>();


### PR DESCRIPTION
Signed-off-by: Aakash Shah <ashah@confluent.io>

## Problem
The current DLQ implementation doesn't account for certain cases, like schema mismatches, etc.

## Solution
Change throwing `ConnectException` to `SQLException` for these schema mismatches to ensure it is sent to the DLQ.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Merge to 10.0.x