### PR TITLE
CC-12626: validate topic.prefix to disallow spaces in between

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -195,7 +195,7 @@ public class JdbcSourceTask extends SourceTask {
         }
       }
 
-      String topicPrefix = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
+      String topicPrefix = config.topicPrefix();
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -190,6 +190,68 @@ public class JdbcSourceConnectorConfigTest {
     assertNull(cached.cachedValue(config2, expiry + 1L));
   }
 
+  @Test
+  public void testSpacesInTopicPrefix() {
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, " withLeadingTailingSpaces ");
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    ConfigValue connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertTrue(connectionAttemptsConfig.errorMessages().isEmpty());
+
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "with spaces");
+    validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertFalse(connectionAttemptsConfig.errorMessages().isEmpty());
+  }
+
+  @Test
+  public void testInvalidCharsInTopicPrefix() {
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "az_-.09");
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    ConfigValue connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertTrue(connectionAttemptsConfig.errorMessages().isEmpty());
+
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "az_-.!@#$%^&*09");
+    validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertFalse(connectionAttemptsConfig.errorMessages().isEmpty());
+  }
+
+  @Test
+  public void testTooLongTopicPrefix() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 249; i++) {
+      sb.append("a");
+    }
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, sb.toString());
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    ConfigValue connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertTrue(connectionAttemptsConfig.errorMessages().isEmpty());
+
+    sb.append("a");
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, sb.toString());
+    validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    connectionAttemptsConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
+    assertNotNull(connectionAttemptsConfig);
+    assertFalse(connectionAttemptsConfig.errorMessages().isEmpty());
+  }
+
   @SuppressWarnings("unchecked")
   protected <T> void assertContains(Collection<T> actual, T... expected) {
     for (T e : expected) {


### PR DESCRIPTION
## Problem
The source connector did not validate topic.prefix. If there is a space in it, the connector will eventually end up with an exception, with a message totally irrelevant to the the very root cause.

## Solution
Validate the config in the first place to disallow spaces in between, and automatically trim leading and tailing spaces.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
targeting 5.0.x, will push to master.