### PR TITLE
MINOR: Fix documentation link for Confluent Hub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
                         </goals>
                         <configuration>
                             <title>Kafka Connect JDBC</title>
-                            <documentationUrl>https://docs.confluent.io/${project.version}/connect/connect-jdbc/docs/index.html</documentationUrl>
+                            <documentationUrl>https://docs.confluent.io/${confluent.version}/connect/connect-jdbc/docs/index.html</documentationUrl>
                             <description>
                                 The JDBC source and sink connectors allow you to exchange data between relational databases and Kafka.
 


### PR DESCRIPTION
## Problem
Docs link is broken. Should have been caught in https://github.com/confluentinc/kafka-connect-jdbc/pull/931 as it was in https://github.com/confluentinc/kafka-connect-storage-cloud/pull/363.

## Solution
Pin to a Confluent Platform version instead of the connector version for the docs link.

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Put out a new 10.0.x release immediately after merging.