### PR TITLE
Cron scheduling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             <version>${kafka.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.cronutils</groupId>
+            <artifactId>cron-utils</artifactId>
+            <version>9.1.2</version>
+        </dependency>
          <!-- JDBC drivers, only included in runtime so they get packaged -->
         <dependency>
             <groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <compilerArgs>
-<!--                        <arg>-Xlint:all</arg>-->
-<!--                        <arg>-Werror</arg>-->
+                        <arg>-Xlint:all</arg>
+                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
                         <phase>validate</phase>
                         <configuration>
                             <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
-                            <skip>true</skip>
                         </configuration>
                         <goals>
                             <goal>check</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <properties>
         <derby.version>10.14.2.0</derby.version>
         <commons-io.version>2.4</commons-io.version>
+        <cron-utils.version>9.1.2</cron-utils.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>42.2.10</postgresql.version>
@@ -90,7 +91,7 @@
         <dependency>
             <groupId>com.cronutils</groupId>
             <artifactId>cron-utils</artifactId>
-            <version>9.1.2</version>
+            <version>${cron-utils.version}</version>
         </dependency>
          <!-- JDBC drivers, only included in runtime so they get packaged -->
         <dependency>
@@ -247,8 +248,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <arg>-Werror</arg>
+<!--                        <arg>-Xlint:all</arg>-->
+<!--                        <arg>-Werror</arg>-->
                     </compilerArgs>
                 </configuration>
             </plugin>
@@ -382,6 +383,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
+                            <skip>true</skip>
                         </configuration>
                         <goals>
                             <goal>check</goal>

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -84,6 +84,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final int POLL_INTERVAL_MS_DEFAULT = 5000;
   private static final String POLL_INTERVAL_MS_DISPLAY = "Poll Interval (ms)";
 
+  public static final String POLL_INTERVAL_CRON_CONFIG = "poll.interval.cron";
+  private static final String POLL_INTERVAL_CRON_DOC = "Frequency in cron format to poll for new "
+                                          + "data in each table. Using the QUARTZ cron format: * * * * * * *";
+  private static final String POLL_INTERVAL_CRON_DISPLAY = "Poll Interval (cron)";
+
   public static final String BATCH_MAX_ROWS_CONFIG = "batch.max.rows";
   private static final String BATCH_MAX_ROWS_DOC =
       "Maximum number of rows to include in a single batch when polling for new data. This "
@@ -562,6 +567,15 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         POLL_INTERVAL_MS_DISPLAY
+    ).define(
+        POLL_INTERVAL_CRON_CONFIG,
+        Type.STRING,
+        Importance.MEDIUM,
+        POLL_INTERVAL_CRON_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.SHORT,
+        POLL_INTERVAL_CRON_DISPLAY
     ).define(
         BATCH_MAX_ROWS_CONFIG,
         Type.INT,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -301,7 +301,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String CONNECTOR_GROUP = "Connector";
 
   private static final Recommender MODE_DEPENDENTS_RECOMMENDER =  new ModeDependentsRecommender();
-  private static final Recommender POLL_INTERVAL_MODE_DEPENDENTS_RECOMMENDER =  new PollIntervalModeDependentsRecommender();
+  private static final Recommender POLL_INTERVAL_MODE_DEPENDENTS_RECOMMENDER =
+      new PollIntervalModeDependentsRecommender();
 
 
   public static final String TABLE_TYPE_DEFAULT = "TABLE";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -458,13 +458,10 @@ public class JdbcSourceTask extends SourceTask {
       Optional<Duration> optionalDuration =
           cronExecutionTime.timeToNextExecution(ZonedDateTime.now(ZoneOffset.UTC));
       if (optionalDuration.isPresent()) {
-        // TODO: add more checks, we might need to increase the min time to sleep
         return optionalDuration.get().toMillis();
       } else {
-        // todo clarify exactly when this may happen
-        throw new ConnectException(
-            "Cannot compute the next execution time from the poll interval defined in the cron"
-                + " format.");
+        log.warn("Cron expression provided does not define a next execution.");
+        return Duration.ofMinutes(10).toMillis();
       }
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -389,7 +389,7 @@ public class JdbcSourceTask extends SourceTask {
         final long sleepMs = Math.min(nextUpdate - now, 100);
 
         if (sleepMs > 0) {
-          log.trace("Waiting {} ms to poll {} next", sleepMs, querier.toString());
+          log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
           time.sleep(sleepMs);
           continue; // Re-check stop flag before continuing
         }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -119,8 +119,8 @@ public class JdbcSourceTask extends SourceTask {
       CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
       CronParser parser = new CronParser(cronDefinition);
       try {
-        Cron unixCron = parser.parse(cronString);
-        cronExecutionTime = ExecutionTime.forCron(unixCron);
+        Cron cron = parser.parse(cronString);
+        cronExecutionTime = ExecutionTime.forCron(cron);
       } catch (IllegalArgumentException e) {
         throw new ConnectException("Invalid configuration: the poll interval defined in the cron format is invalid.", e);
       }
@@ -392,9 +392,9 @@ public class JdbcSourceTask extends SourceTask {
           final long now = time.milliseconds();
           sleepMs = Math.min(nextUpdate - now, 100);
         }
-        log.trace("Waiting {} ms to poll {} next", sleepMs, querier.toString());
 
         if (sleepMs > 0) {
+          log.trace("Waiting {} ms to poll {} next", sleepMs, querier.toString());
           time.sleep(sleepMs);
           continue; // Re-check stop flag before continuing
         }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -495,7 +495,7 @@ public class JdbcSourceTask extends SourceTask {
   ) {
     try {
       Set<String> lowercaseTsColumns = new HashSet<>();
-      for (String timestampColumn : timestampColumns) {
+      for (String timestampColumn: timestampColumns) {
         lowercaseTsColumns.add(timestampColumn.toLowerCase(Locale.getDefault()));
       }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -112,6 +112,34 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     task.stop();
   }
 
+  @Test
+  public void testPollIntervalCron() throws Exception {
+    // Here we just want to verify behavior of the poll method, not any loading of data, so we
+    // specifically want an empty
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT");
+    // Need data or poll() never returns
+    db.insert(SINGLE_TABLE_NAME, "id", 1);
+
+    long startTime = time.milliseconds();
+    Map<String, String> configCronInterval = singleTableConfig();
+    configCronInterval.put(JdbcSourceConnectorConfig.POLL_INTERVAL_MODE_CONFIG, JdbcSourceConnectorConfig.POLL_INTERVAL_MODE_CRON);
+
+    // configure to poll once per second
+    configCronInterval.put(JdbcSourceConnectorConfig.POLL_INTERVAL_CRON_CONFIG, "* * * ? * *");
+    task.start(configCronInterval);
+
+    // First poll should happen in less than 1s
+    task.poll();
+    assertEquals(startTime, time.milliseconds());
+
+    // Subsequent polls have to wait for timeout (default 1 second)
+    task.poll();
+    assertEquals(startTime + 1000, time.milliseconds());
+    task.poll();
+
+    assertEquals(startTime + 2 * 1000, time.milliseconds());
+    task.stop();
+  }
 
   @Test
   public void testSingleUpdateMultiplePoll() throws Exception {

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -87,7 +87,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testPollInterval() throws Exception {
+  public void testPollIntervalMs() throws Exception {
     // Here we just want to verify behavior of the poll method, not any loading of data, so we
     // specifically want an empty
     db.createTable(SINGLE_TABLE_NAME, "id", "INT");

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -128,16 +128,17 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     configCronInterval.put(JdbcSourceConnectorConfig.POLL_INTERVAL_CRON_CONFIG, "* * * ? * *");
     task.start(configCronInterval);
 
-    // First poll should happen in less than 1s
+    // First poll should happen in 1s
     task.poll();
-    assertEquals(startTime, time.milliseconds());
+    assertEquals(startTime + 1000, time.milliseconds());
 
     // Subsequent polls have to wait for timeout (default 1 second)
     task.poll();
-    assertEquals(startTime + 1000, time.milliseconds());
+    assertEquals(startTime + 2 * 1000, time.milliseconds());
     task.poll();
 
-    assertEquals(startTime + 2 * 1000, time.milliseconds());
+    assertEquals(startTime + 3 * 1000, time.milliseconds());
+
     task.stop();
   }
 


### PR DESCRIPTION
## Problem

The JDBC Source Connector polls the source databases according to the configuration poll.interval.ms, starting from when the connector started. Considering that the connector may be restarted or rescheduled at any time, poll.interval.ms represents a maximum interval between pulls (plus some time for the connector to start up).

Our users would like to have more control over when the data is pulled, for example "Bulk load every day at 3 AM".

## Solution

This PR adds the ability for users to select the poll times according to a cron schedule. When the connector starts up in poll.interval.mode "cron", it will schedule the next executions according to the given expression.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
