### PR TITLE
Update pom.mxl with correct path to docs page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
                         </goals>
                         <configuration>
                             <title>Kafka Connect JDBC</title>
-                            <documentationUrl>https://docs.confluent.io/${confluent.version}/connect/connect-jdbc/docs/index.html</documentationUrl>
+                            <documentationUrl>https://docs.confluent.io/kafka-connect-jdbc/current/</documentationUrl>
                             <description>
                                 The JDBC source and sink connectors allow you to exchange data between relational databases and Kafka.
 


### PR DESCRIPTION
## Problem
Confluent Hub documentation links not redirecting properly.

## Solution
Update pom.mxl with correct path to docs page

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
