### PR TITLE
MINOR: Fix JdbcSinkTask::version

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import io.confluent.connect.jdbc.sink.dialect.DbDialect;
+import io.confluent.connect.jdbc.util.Version;
 
 public class JdbcSinkTask extends SinkTask {
   private static final Logger log = LoggerFactory.getLogger(JdbcSinkTask.class);
@@ -104,7 +105,7 @@ public class JdbcSinkTask extends SinkTask {
 
   @Override
   public String version() {
-    return getClass().getPackage().getImplementationVersion();
+    return Version.getVersion();
   }
 
 }


### PR DESCRIPTION
Version is showing up as `null` in logs, but just for the sink task (and not the sink connector or the source connector or task). This should fix it by using the same strategy for the sink task's `version` method that's used by the other relevant classes.