### PR TITLE
Use fixed length type for primary keys in MySQL dialect (fixes #996)

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -116,7 +116,12 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
       case BOOLEAN:
         return "TINYINT";
       case STRING:
-        return "TEXT";
+        // MySQL only allows keys with fixed length type for keys up to a maximum length of 256
+        if (field.isPrimaryKey()) {
+          return "VARCHAR(256)";
+        } else {
+          return "TEXT";
+        }
       case BYTES:
         return "VARBINARY(1024)";
       default:

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -23,6 +24,7 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
@@ -254,5 +256,18 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
         + "db?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test
+  public void mustConvertStringTypeToVarcharWhenUsedAsKey(){
+
+    SinkRecordField f1 = new SinkRecordField(Schema.STRING_SCHEMA, "c1", true);
+    SinkRecordField f2 = new SinkRecordField(Schema.OPTIONAL_INT64_SCHEMA, "c2", false);
+
+    String expected =
+            "CREATE TABLE `myTable` (\n" + "`c1` VARCHAR(256) NOT NULL,\n" +
+                    "`c2` BIGINT NULL,\nPRIMARY KEY(`c1`))";
+    String sql = dialect.buildCreateTableStatement(tableId, Arrays.asList(f1,f2));
+    assertEquals(expected, sql);
   }
 }


### PR DESCRIPTION
See #996 for description