### PR TITLE
CCDB-192: Implement Error Reporting Support in JDBC Sink

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.jdbc.sink;
 
-import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -117,7 +117,7 @@ public class DbStructure {
       final FieldsMetadata fieldsMetadata
   ) throws SQLException {
     if (!config.autoCreate) {
-      throw new SchemaMismatchException(
+      throw new TableAlterOrCreateException(
           String.format("Table %s is missing and auto-creation is disabled", tableId)
       );
     }
@@ -136,7 +136,7 @@ public class DbStructure {
       final TableId tableId,
       final FieldsMetadata fieldsMetadata,
       final int maxRetries
-  ) throws SQLException, SchemaMismatchException {
+  ) throws SQLException, TableAlterOrCreateException {
     // NOTE:
     //   The table might have extra columns defined (hopefully with default values), which is not
     //   a case we check for here.
@@ -169,7 +169,7 @@ public class DbStructure {
         break;
       case VIEW:
       default:
-        throw new SchemaMismatchException(
+        throw new TableAlterOrCreateException(
             String.format(
                 "%s %s is missing fields (%s) and ALTER %s is unsupported",
                 type.capitalized(),
@@ -182,7 +182,7 @@ public class DbStructure {
 
     for (SinkRecordField missingField: missingFields) {
       if (!missingField.isOptional() && missingField.defaultValue() == null) {
-        throw new SchemaMismatchException(String.format(
+        throw new TableAlterOrCreateException(String.format(
             "Cannot ALTER %s %s to add missing field %s, as the field is not optional and does "
             + "not have a default value",
             type.jdbcName(),
@@ -193,7 +193,7 @@ public class DbStructure {
     }
 
     if (!config.autoEvolve) {
-      throw new SchemaMismatchException(String.format(
+      throw new TableAlterOrCreateException(String.format(
           "%s %s is missing fields (%s) and auto-evolution is disabled",
           type.capitalized(),
           tableId,
@@ -213,7 +213,7 @@ public class DbStructure {
       dbDialect.applyDdlStatements(connection, amendTableQueries);
     } catch (SQLException sqle) {
       if (maxRetries <= 0) {
-        throw new SchemaMismatchException(
+        throw new TableAlterOrCreateException(
             String.format(
                 "Failed to amend %s '%s' to add missing fields: %s",
                 type,

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -136,7 +136,7 @@ public class DbStructure {
       final TableId tableId,
       final FieldsMetadata fieldsMetadata,
       final int maxRetries
-  ) throws SQLException {
+  ) throws SQLException, SchemaMismatchException {
     // NOTE:
     //   The table might have extra columns defined (hopefully with default values), which is not
     //   a case we check for here.

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -153,7 +153,7 @@ public class DbStructure {
     //    }
 
     final Set<SinkRecordField> missingFields = missingFields(
-        fieldsMetadata.getAllFields().values(),
+        fieldsMetadata.allFields.values(),
         tableDefn.columnNames()
     );
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -45,12 +45,6 @@ public class DbStructure {
     this.tableDefns = new TableDefinitions(dbDialect);
   }
 
-  // For testing
-  public DbStructure(DatabaseDialect dbDialect, TableDefinitions tableDefns) {
-    this.dbDialect = dbDialect;
-    this.tableDefns = tableDefns;
-  }
-
   /**
    * Create or amend table.
    *

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -59,7 +59,8 @@ public class JdbcDbWriter {
     };
   }
 
-  void write(final Collection<SinkRecord> records) throws SQLException, TableAlterOrCreateException {
+  void write(final Collection<SinkRecord> records)
+      throws SQLException, TableAlterOrCreateException {
     final Connection connection = cachedConnectionProvider.getConnection();
 
     final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -59,7 +59,7 @@ public class JdbcDbWriter {
     };
   }
 
-  void write(final Collection<SinkRecord> records) throws SQLException {
+  void write(final Collection<SinkRecord> records) throws SQLException, SchemaMismatchException {
     final Connection connection = cachedConnectionProvider.getConnection();
 
     final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -59,7 +59,7 @@ public class JdbcDbWriter {
     };
   }
 
-  void write(final Collection<SinkRecord> records) throws SQLException, SchemaMismatchException {
+  void write(final Collection<SinkRecord> records) throws SQLException, TableAlterOrCreateException {
     final Connection connection = cachedConnectionProvider.getConnection();
 
     final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -127,6 +127,7 @@ public class JdbcSinkTask extends SinkTask {
   }
 
   private void unrollAndRetry(Collection<SinkRecord> records) {
+    writer.closeQuietly();
     for (SinkRecord record : records) {
       try {
         writer.write(Collections.singletonList(record));

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -95,14 +95,11 @@ public class JdbcSinkTask extends SinkTask {
           remainingRetries,
           sqle
       );
-      String sqleAllMessages = "Exception chain:" + System.lineSeparator();
       int totalExceptions = 0;
-      for (Throwable e : sqle) {
-        sqleAllMessages += e + System.lineSeparator();
+      for (Throwable e :sqle) {
         totalExceptions++;
       }
-      SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
-      sqlAllMessagesException.setNextException(sqle);
+      SQLException sqlAllMessagesException = getAllMessagesException(sqle);
       if (remainingRetries > 0) {
         writer.closeQuietly();
         initWriter();
@@ -137,16 +134,21 @@ public class JdbcSinkTask extends SinkTask {
         reporter.report(record, tace);
         writer.closeQuietly();
       } catch (SQLException sqle) {
-        String sqleAllMessages = "Exception chain:" + System.lineSeparator();
-        for (Throwable e : sqle) {
-          sqleAllMessages += e + System.lineSeparator();
-        }
-        SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
-        sqlAllMessagesException.setNextException(sqle);
+        SQLException sqlAllMessagesException = getAllMessagesException(sqle);
         reporter.report(record, sqlAllMessagesException);
         writer.closeQuietly();
       }
     }
+  }
+
+  private SQLException getAllMessagesException(SQLException sqle) {
+    String sqleAllMessages = "Exception chain:" + System.lineSeparator();
+    for (Throwable e : sqle) {
+      sqleAllMessages += e + System.lineSeparator();
+    }
+    SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
+    sqlAllMessagesException.setNextException(sqle);
+    return sqlAllMessagesException;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -51,7 +51,7 @@ public class JdbcSinkTask extends SinkTask {
     remainingRetries = config.maxRetries;
     try {
       reporter = context.errantRecordReporter();
-    } catch (NoClassDefFoundError e) {
+    } catch (NoSuchMethodError | NoClassDefFoundError e) {
       // Will occur in Connect runtimes earlier than 2.6
       reporter = null;
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -82,11 +82,11 @@ public class JdbcSinkTask extends SinkTask {
     );
     try {
       writer.write(records);
-    } catch (SchemaMismatchException sme) {
+    } catch (TableAlterOrCreateException tace) {
       if (reporter != null) {
         unrollAndRetry(records);
       } else {
-        throw sme;
+        throw tace;
       }
     } catch (SQLException sqle) {
       log.warn(
@@ -133,8 +133,8 @@ public class JdbcSinkTask extends SinkTask {
     for (SinkRecord record : records) {
       try {
         writer.write(Collections.singletonList(record));
-      } catch (SchemaMismatchException sme) {
-        reporter.report(record, sme);
+      } catch (TableAlterOrCreateException tace) {
+        reporter.report(record, tace);
         writer.closeQuietly();
       } catch (SQLException sqle) {
         String sqleAllMessages = "Exception chain:" + System.lineSeparator();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
-import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.Version;
 
 public class JdbcSinkTask extends SinkTask {

--- a/src/main/java/io/confluent/connect/jdbc/sink/SchemaMismatchException.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/SchemaMismatchException.java
@@ -15,16 +15,16 @@
 
 package io.confluent.connect.jdbc.sink;
 
-import java.sql.SQLException;
+import org.apache.kafka.connect.errors.ConnectException;
 
-public class SchemaMismatchException extends SQLException {
+public class SchemaMismatchException extends ConnectException {
 
   public SchemaMismatchException(String reason) {
     super(reason);
   }
 
-  public SchemaMismatchException(String reason, Throwable cause) {
-    super(reason, cause);
+  public SchemaMismatchException(String reason, Throwable throwable) {
+    super(reason, throwable);
   }
 }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/SchemaMismatchException.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/SchemaMismatchException.java
@@ -1,0 +1,15 @@
+package io.confluent.connect.jdbc.sink;
+
+import java.sql.SQLException;
+
+public class SchemaMismatchException extends SQLException {
+
+  public SchemaMismatchException(String reason) {
+    super(reason);
+  }
+
+  public SchemaMismatchException(String reason, Throwable cause) {
+    super(reason, cause);
+  }
+}
+

--- a/src/main/java/io/confluent/connect/jdbc/sink/SchemaMismatchException.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/SchemaMismatchException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.connect.jdbc.sink;
 
 import java.sql.SQLException;

--- a/src/main/java/io/confluent/connect/jdbc/sink/TableAlterOrCreateException.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/TableAlterOrCreateException.java
@@ -17,13 +17,13 @@ package io.confluent.connect.jdbc.sink;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
-public class SchemaMismatchException extends ConnectException {
+public class TableAlterOrCreateException extends ConnectException {
 
-  public SchemaMismatchException(String reason) {
+  public TableAlterOrCreateException(String reason) {
     super(reason);
   }
 
-  public SchemaMismatchException(String reason, Throwable throwable) {
+  public TableAlterOrCreateException(String reason, Throwable throwable) {
     super(reason, throwable);
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -56,6 +56,10 @@ public class FieldsMetadata {
     this.allFields = allFields;
   }
 
+  public Map<String, SinkRecordField> getAllFields() {
+    return allFields;
+  }
+
   public static FieldsMetadata extract(
       final String tableName,
       final JdbcSinkConfig.PrimaryKeyMode pkMode,

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -37,7 +37,8 @@ public class FieldsMetadata {
   public final Set<String> nonKeyFieldNames;
   public final Map<String, SinkRecordField> allFields;
 
-  private FieldsMetadata(
+  // visible for testing
+  public FieldsMetadata(
       Set<String> keyFieldNames,
       Set<String> nonKeyFieldNames,
       Map<String, SinkRecordField> allFields
@@ -54,10 +55,6 @@ public class FieldsMetadata {
     this.keyFieldNames = keyFieldNames;
     this.nonKeyFieldNames = nonKeyFieldNames;
     this.allFields = allFields;
-  }
-
-  public Map<String, SinkRecordField> getAllFields() {
-    return allFields;
   }
 
   public static FieldsMetadata extract(

--- a/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
@@ -51,10 +51,6 @@ public abstract class BaseConnectorIT {
 
     protected EmbeddedConnectCluster connect;
 
-    public JsonConverter jsonConverter;
-    public Map<String, String> props;
-
-
     protected void startConnect() {
         connect = new EmbeddedConnectCluster.Builder()
                 .name("jdbc-connect-cluster")
@@ -64,14 +60,18 @@ public abstract class BaseConnectorIT {
         connect.start();
     }
 
-    protected void setUpForSinkIt() {
-        jsonConverter = new JsonConverter();
+    protected JsonConverter jsonConverter() {
+        JsonConverter jsonConverter = new JsonConverter();
         jsonConverter.configure(Collections.singletonMap(
             ConverterConfig.TYPE_CONFIG,
             ConverterType.VALUE.getName()
         ));
 
-        props = new HashMap<>();
+        return jsonConverter;
+    }
+
+    protected Map<String, String> baseSinkProps() {
+        Map<String, String> props = new HashMap<>();
         props.put(CONNECTOR_CLASS_CONFIG, "JdbcSinkConnector");
         // converters
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
@@ -79,6 +79,7 @@ public abstract class BaseConnectorIT {
         // license properties
         props.put("confluent.topic.bootstrap.servers", connect.kafka().bootstrapServers());
         props.put("confluent.topic.replication.factor", "1");
+        return props;
     }
 
     protected void stopConnect() {

--- a/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
@@ -79,7 +79,6 @@ public abstract class BaseConnectorIT {
         // license properties
         props.put("confluent.topic.bootstrap.servers", connect.kafka().bootstrapServers());
         props.put("confluent.topic.replication.factor", "1");
-
     }
 
     protected void stopConnect() {

--- a/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/BaseConnectorIT.java
@@ -15,12 +15,18 @@
 
 package io.confluent.connect.jdbc.integration;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -29,7 +35,7 @@ import org.apache.kafka.connect.storage.ConverterType;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.TestUtils;
+import org.apache.kafka.test.NoRetryException;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,17 +43,22 @@ import org.slf4j.LoggerFactory;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertTrue;
 
 @Category(IntegrationTest.class)
 public abstract class BaseConnectorIT {
 
     public static final String DLQ_TOPIC_NAME = "dlq-topic";
-    public static final long CONSUME_MAX_DURATION_MS = 30000;
-    public static final long VERIFY_MAX_DURATION_MS = 20000;
 
     private static final Logger log = LoggerFactory.getLogger(BaseConnectorIT.class);
 
+    protected static final long CONSUME_MAX_DURATION_MS = TimeUnit.SECONDS.toMillis(10);
     protected static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+    protected static final long OFFSET_COMMIT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
+    protected static final long OFFSETS_READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+
+    private Admin kafkaAdminClient;
 
     protected EmbeddedConnectCluster connect;
 
@@ -58,6 +69,8 @@ public abstract class BaseConnectorIT {
 
         // start the clusters
         connect.start();
+
+        kafkaAdminClient = connect.kafka().createAdminClient();
     }
 
     protected JsonConverter jsonConverter() {
@@ -83,6 +96,11 @@ public abstract class BaseConnectorIT {
     }
 
     protected void stopConnect() {
+        if (kafkaAdminClient !=  null) {
+            kafkaAdminClient.close();
+            kafkaAdminClient = null;
+        }
+
         // stop all Connect, Kafka and Zk threads.
         if (connect != null) {
             connect.stop();
@@ -99,7 +117,7 @@ public abstract class BaseConnectorIT {
      * @throws InterruptedException if this was interrupted
      */
     protected long waitForConnectorToStart(String name, int numTasks) throws InterruptedException {
-        TestUtils.waitForCondition(
+        waitForCondition(
                 () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
                 CONNECTOR_STARTUP_DURATION_MS,
                 "Connector tasks did not start in time."
@@ -126,5 +144,50 @@ public abstract class BaseConnectorIT {
             log.warn("Could not check connector state info.");
             return Optional.empty();
         }
+    }
+
+    protected void waitForCommittedRecords(
+        String connector, Collection<String> topics, long numRecords, int numTasks, long timeoutMs
+    ) throws InterruptedException {
+        waitForCondition(
+            () -> {
+                long totalCommittedRecords = totalCommittedRecords(connector, topics);
+                if (totalCommittedRecords >= numRecords) {
+                    return true;
+                } else {
+                    // Check to make sure the connector is still running. If not, fail fast
+                    try {
+                        assertTrue(
+                            "Connector or one of its tasks failed during testing",
+                            assertConnectorAndTasksRunning(connector, numTasks).orElse(false));
+                    } catch (AssertionError e) {
+                        throw new NoRetryException(e);
+                    }
+                    log.debug("Connector has only committed {} records for topics {} so far; {} " +
+                            "expected",
+                        totalCommittedRecords, topics, numRecords);
+                    // Sleep here so as not to spam Kafka with list-offsets requests
+                    Thread.sleep(OFFSET_COMMIT_INTERVAL_MS / 2);
+                    return false;
+                }
+            },
+            timeoutMs,
+            "Either the connector failed, or the message commit duration expired without all expected messages committed");
+    }
+
+    protected synchronized long totalCommittedRecords(String connector, Collection<String> topics) throws TimeoutException, ExecutionException, InterruptedException {
+        // See https://github.com/apache/kafka/blob/f7c38d83c727310f4b0678886ba410ae2fae9379/connect/runtime/src/main/java/org/apache/kafka/connect/util/SinkUtils.java
+        // for how the consumer group ID is constructed for sink connectors
+        Map<TopicPartition, OffsetAndMetadata> offsets = kafkaAdminClient
+            .listConsumerGroupOffsets("connect-" + connector)
+            .partitionsToOffsetAndMetadata()
+            .get(OFFSETS_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        log.trace("Connector {} has so far committed offsets {}", connector, offsets);
+
+        return offsets.entrySet().stream()
+            .filter(entry -> topics.contains(entry.getKey().topic()))
+            .mapToLong(entry -> entry.getValue().offset())
+            .sum();
     }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -73,7 +73,7 @@ public class DbStructureTest {
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
 
     FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-    when(fieldsMetadata.getAllFields()).thenReturn(mock(Map.class));
+    when(fieldsMetadata.getAllFields()).thenReturn(new HashMap<>());
 
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.OPTIONAL_INT32_SCHEMA,
@@ -110,7 +110,7 @@ public class DbStructureTest {
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
 
     FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-    when(fieldsMetadata.getAllFields()).thenReturn(mock(Map.class));
+    when(fieldsMetadata.getAllFields()).thenReturn(new HashMap<>());
 
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.INT32_SCHEMA,
@@ -133,7 +133,7 @@ public class DbStructureTest {
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
 
     FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-    when(fieldsMetadata.getAllFields()).thenReturn(mock(Map.class));
+    when(fieldsMetadata.getAllFields()).thenReturn(new HashMap<>());
 
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.OPTIONAL_INT32_SCHEMA,

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -124,7 +124,7 @@ public class DbStructureTest {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
-    
+
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.OPTIONAL_INT32_SCHEMA,
         "test",

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -71,7 +71,7 @@ public class DbStructureTest {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(dbDialect.tableExists(any(), any())).thenReturn(true);
     when(dbDialect.describeTable(any(), any())).thenReturn(tableDefinition);
-    when(tableDefinition.type()).thenReturn(TableType.VIEW);
+    when(tableDefinition.type()).thenReturn(TableType.TABLE);
 
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.OPTIONAL_INT32_SCHEMA,
@@ -96,7 +96,7 @@ public class DbStructureTest {
     when(tableDefinition.type()).thenReturn(TableType.VIEW);
 
     SinkRecordField sinkRecordField = new SinkRecordField(
-        Schema.INT32_SCHEMA,
+        Schema.OPTIONAL_INT32_SCHEMA,
         "test",
         true
     );

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -1,23 +1,44 @@
 package io.confluent.connect.jdbc.sink;
 
 import org.apache.kafka.connect.data.Schema;
+import org.eclipse.jetty.util.Fields;
 import org.junit.Test;
+import sun.tools.jconsole.Tab;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.TableDefinition;
+import io.confluent.connect.jdbc.util.TableDefinitions;
+import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.TableType;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class DbStructureTest {
 
-  DbStructure structure = new DbStructure(null);
+  TableDefinitions tableDefinitions = mock(TableDefinitions.class);
+  DatabaseDialect dbDialect = mock(DatabaseDialect.class);
+  DbStructure structure = new DbStructure(dbDialect, tableDefinitions);
+  DbStructure spyStructure = spy(structure);
 
   @Test
   public void testNoMissingFields() {
@@ -39,6 +60,108 @@ public class DbStructureTest {
     assertTrue(missingFields(sinkRecords("aaa", "bbb"), columns("AaA", "BbB")).isEmpty());
     assertTrue(missingFields(sinkRecords("AaA", "bBb"), columns("aaa", "bbb")).isEmpty());
     assertTrue(missingFields(sinkRecords("AaA", "bBb"), columns("aAa", "BbB")).isEmpty());
+  }
+
+  @Test (expected = SchemaMismatchException.class)
+  public void testMissingTableNoAutoCreate() throws Exception {
+    structure.create(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
+        mock(FieldsMetadata.class));
+  }
+
+  @Test (expected = SchemaMismatchException.class)
+  public void testAlterNoAutoEvolve() throws Exception {
+    TableDefinition tableDefinition = mock(TableDefinition.class);
+    when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
+    when(tableDefinition.type()).thenReturn(TableType.TABLE);
+
+    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
+    when(fieldsMetadata.getAllFields()).thenReturn(mock(Map.class));
+
+    SinkRecordField sinkRecordField = new SinkRecordField(
+        Schema.OPTIONAL_INT32_SCHEMA,
+        "test",
+        false
+    );
+    Set<SinkRecordField> missingFields = new HashSet<>();
+    missingFields.add(sinkRecordField);
+
+    doReturn(missingFields).when(spyStructure).missingFields(any(), any());
+
+    spyStructure.amendIfNecessary(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
+        fieldsMetadata, 5);
+  }
+
+  @Test (expected = SchemaMismatchException.class)
+  public void testAlterNotSupported() throws Exception {
+    TableDefinition tableDefinition = mock(TableDefinition.class);
+    when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
+    when(tableDefinition.type()).thenReturn(TableType.VIEW);
+
+    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
+
+    doReturn(mock(Set.class)).when(spyStructure).missingFields(any(), any());
+
+    spyStructure.amendIfNecessary(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
+        fieldsMetadata, 5);
+  }
+
+  @Test (expected = SchemaMismatchException.class)
+  public void testCannotAlterBecauseFieldNotOptionalAndNoDefaultValue() throws Exception {
+    TableDefinition tableDefinition = mock(TableDefinition.class);
+    when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
+    when(tableDefinition.type()).thenReturn(TableType.TABLE);
+
+    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
+    when(fieldsMetadata.getAllFields()).thenReturn(mock(Map.class));
+
+    SinkRecordField sinkRecordField = new SinkRecordField(
+        Schema.INT32_SCHEMA,
+        "test",
+        true
+    );
+    Set<SinkRecordField> missingFields = new HashSet<>();
+    missingFields.add(sinkRecordField);
+
+    doReturn(missingFields).when(spyStructure).missingFields(any(), any());
+
+    spyStructure.amendIfNecessary(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
+        fieldsMetadata, 5);
+  }
+
+  @Test (expected = SchemaMismatchException.class)
+  public void testFailedToAmendExhaustedRetry() throws Exception {
+    TableDefinition tableDefinition = mock(TableDefinition.class);
+    when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
+    when(tableDefinition.type()).thenReturn(TableType.TABLE);
+
+    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
+    when(fieldsMetadata.getAllFields()).thenReturn(mock(Map.class));
+
+    SinkRecordField sinkRecordField = new SinkRecordField(
+        Schema.OPTIONAL_INT32_SCHEMA,
+        "test",
+        false
+    );
+    Set<SinkRecordField> missingFields = new HashSet<>();
+    missingFields.add(sinkRecordField);
+
+    doReturn(missingFields).when(spyStructure).missingFields(any(), any());
+
+    Map<String, String> props = new HashMap<>();
+
+    // Required configurations, set to empty strings because they are irrelevant for the test
+    props.put("connection.url", "");
+    props.put("connection.user", "");
+    props.put("connection.password", "");
+
+    // Set to true so that the connector does not throw the exception on a different condition
+    props.put("auto.evolve", "true");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    doThrow(new SQLException()).when(dbDialect).applyDdlStatements(any(), any());
+
+    spyStructure.amendIfNecessary(config, mock(Connection.class), mock(TableId.class),
+        fieldsMetadata, 0);
   }
 
   private Set<SinkRecordField> missingFields(

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -37,6 +37,7 @@ public class DbStructureTest {
   DatabaseDialect dbDialect = mock(DatabaseDialect.class);
   DbStructure structure = new DbStructure(dbDialect, tableDefinitions);
   DbStructure spyStructure = spy(structure);
+  FieldsMetadata fieldsMetadata = new FieldsMetadata(new HashSet<>(), new HashSet<>(), new HashMap<>());
 
   @Test
   public void testNoMissingFields() {
@@ -63,7 +64,7 @@ public class DbStructureTest {
   @Test (expected = SchemaMismatchException.class)
   public void testMissingTableNoAutoCreate() throws Exception {
     structure.create(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
-        mock(FieldsMetadata.class));
+        fieldsMetadata);
   }
 
   @Test (expected = SchemaMismatchException.class)
@@ -71,9 +72,6 @@ public class DbStructureTest {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
-
-    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-    when(fieldsMetadata.getAllFields()).thenReturn(new HashMap<>());
 
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.OPTIONAL_INT32_SCHEMA,
@@ -95,8 +93,6 @@ public class DbStructureTest {
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
     when(tableDefinition.type()).thenReturn(TableType.VIEW);
 
-    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-
     doReturn(mock(Set.class)).when(spyStructure).missingFields(any(), any());
 
     spyStructure.amendIfNecessary(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
@@ -108,9 +104,6 @@ public class DbStructureTest {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
-
-    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-    when(fieldsMetadata.getAllFields()).thenReturn(new HashMap<>());
 
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.INT32_SCHEMA,
@@ -131,10 +124,7 @@ public class DbStructureTest {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
     when(tableDefinition.type()).thenReturn(TableType.TABLE);
-
-    FieldsMetadata fieldsMetadata = mock(FieldsMetadata.class);
-    when(fieldsMetadata.getAllFields()).thenReturn(new HashMap<>());
-
+    
     SinkRecordField sinkRecordField = new SinkRecordField(
         Schema.OPTIONAL_INT32_SCHEMA,
         "test",

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -59,13 +59,13 @@ public class DbStructureTest {
     assertTrue(missingFields(sinkRecords("AaA", "bBb"), columns("aAa", "BbB")).isEmpty());
   }
 
-  @Test (expected = SchemaMismatchException.class)
+  @Test (expected = TableAlterOrCreateException.class)
   public void testMissingTableNoAutoCreate() throws Exception {
     structure.create(mock(JdbcSinkConfig.class), mock(Connection.class), mock(TableId.class),
         fieldsMetadata);
   }
 
-  @Test (expected = SchemaMismatchException.class)
+  @Test (expected = TableAlterOrCreateException.class)
   public void testAlterNoAutoEvolve() throws Exception {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
@@ -86,7 +86,7 @@ public class DbStructureTest {
         fieldsMetadata, 5);
   }
 
-  @Test (expected = SchemaMismatchException.class)
+  @Test (expected = TableAlterOrCreateException.class)
   public void testAlterNotSupported() throws Exception {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
@@ -106,7 +106,7 @@ public class DbStructureTest {
         fieldsMetadata, 5);
   }
 
-  @Test (expected = SchemaMismatchException.class)
+  @Test (expected = TableAlterOrCreateException.class)
   public void testCannotAlterBecauseFieldNotOptionalAndNoDefaultValue() throws Exception {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);
@@ -126,7 +126,7 @@ public class DbStructureTest {
         fieldsMetadata, 5);
   }
 
-  @Test (expected = SchemaMismatchException.class)
+  @Test (expected = TableAlterOrCreateException.class)
   public void testFailedToAmendExhaustedRetry() throws Exception {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(tableDefinitions.get(any(), any())).thenReturn(tableDefinition);

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -1,9 +1,7 @@
 package io.confluent.connect.jdbc.sink;
 
 import org.apache.kafka.connect.data.Schema;
-import org.eclipse.jetty.util.Fields;
 import org.junit.Test;
-import sun.tools.jconsole.Tab;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -345,7 +345,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     SinkTaskContext ctx = createMock(SinkTaskContext.class);
 
     mockWriter.write(records);
-    SQLException exception = new SchemaMismatchException("cause 1");
+    SchemaMismatchException exception = new SchemaMismatchException("cause 1");
     expectLastCall().andThrow(exception);
     mockWriter.write(anyObject());
     expectLastCall().andThrow(exception);

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -338,7 +338,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
   }
 
   @Test
-  public void errorReportingSchemaMisMatchException() throws SQLException {
+  public void errorReportingSchemaMismatchException() throws SQLException {
     final int maxRetries = 0;
     final int retryBackoffMs = 1000;
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -409,7 +409,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
     expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null)).times(batchSize);
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < batchSize; i++) {
       mockWriter.closeQuietly();
       expectLastCall();
     }
@@ -446,8 +446,59 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     SQLException exception = new SQLException("cause 1");
     expectLastCall().andThrow(exception);
     mockWriter.write(anyObject());
-    expectLastCall().times(2);
+    expectLastCall().times(batchSize - 1);
     expectLastCall().andThrow(exception);
+
+    JdbcSinkTask task = new JdbcSinkTask() {
+      @Override
+      void initWriter() {
+        this.writer = mockWriter;
+      }
+    };
+    task.initialize(ctx);
+    ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
+    expect(ctx.errantRecordReporter()).andReturn(reporter);
+    expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null));
+    mockWriter.closeQuietly();
+    expectLastCall();
+    replayAll();
+
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSinkConfig.CONNECTION_URL, "stub");
+    props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
+    props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
+    task.start(props);
+
+    task.put(records);
+
+    verifyAll();
+  }
+
+  @Test
+  public void oneInMiddleBatchErrorReporting() throws SQLException {
+    final int maxRetries = 0;
+    final int retryBackoffMs = 1000;
+    final int batchSize = 3;
+
+    List<SinkRecord> records = new ArrayList<>();
+    SinkRecord record = new SinkRecord("stub", 0, null, null, null, null, 0);
+
+    for (int i = 0; i < batchSize; i++) {
+      records.add(record);
+    }
+
+    final JdbcDbWriter mockWriter = createMock(JdbcDbWriter.class);
+    SinkTaskContext ctx = createMock(SinkTaskContext.class);
+
+    mockWriter.write(records);
+    SQLException exception = new SQLException("cause 1");
+    expectLastCall().andThrow(exception);
+    mockWriter.write(anyObject());
+    expectLastCall();
+    mockWriter.write(anyObject());
+    expectLastCall().andThrow(exception);
+    mockWriter.write(anyObject());
+    expectLastCall();
 
     JdbcSinkTask task = new JdbcSinkTask() {
       @Override

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -322,6 +322,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
     expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null));
+    mockWriter.closeQuietly();
+    expectLastCall();
     replayAll();
 
     Map<String, String> props = new HashMap<>();
@@ -360,6 +362,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
     expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null));
+    mockWriter.closeQuietly();
+    expectLastCall();
     replayAll();
 
     Map<String, String> props = new HashMap<>();
@@ -405,6 +409,10 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
     expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null)).times(batchSize);
+    for (int i = 0; i < 3; i++) {
+      mockWriter.closeQuietly();
+      expectLastCall();
+    }
     replayAll();
 
     Map<String, String> props = new HashMap<>();
@@ -451,6 +459,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
     expect(ctx.errantRecordReporter()).andReturn(reporter);
     expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null));
+    mockWriter.closeQuietly();
+    expectLastCall();
     replayAll();
 
     Map<String, String> props = new HashMap<>();

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -241,14 +241,14 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       }
     };
     task.initialize(ctx);
+    expect(ctx.errantRecordReporter()).andReturn(null);
+    replayAll();
 
     Map<String, String> props = new HashMap<>();
     props.put(JdbcSinkConfig.CONNECTION_URL, "stub");
     props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
     task.start(props);
-
-    replayAll();
 
     try {
       task.put(records);

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -338,7 +338,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
   }
 
   @Test
-  public void errorReportingSchemaMismatchException() throws SQLException {
+  public void errorReportingTableAlterOrCreateException() throws SQLException {
     final int maxRetries = 0;
     final int retryBackoffMs = 1000;
 
@@ -347,7 +347,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     SinkTaskContext ctx = createMock(SinkTaskContext.class);
 
     mockWriter.write(records);
-    SchemaMismatchException exception = new SchemaMismatchException("cause 1");
+    TableAlterOrCreateException exception = new TableAlterOrCreateException("cause 1");
     expectLastCall().andThrow(exception);
     mockWriter.write(anyObject());
     expectLastCall().andThrow(exception);

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -309,6 +309,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     mockWriter.write(records);
     SQLException exception = new SQLException("cause 1");
     expectLastCall().andThrow(exception);
+    mockWriter.closeQuietly();
+    expectLastCall();
     mockWriter.write(anyObject());
     expectLastCall().andThrow(exception);
 
@@ -339,6 +341,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     mockWriter.write(records);
     TableAlterOrCreateException exception = new TableAlterOrCreateException("cause 1");
     expectLastCall().andThrow(exception);
+    mockWriter.closeQuietly();
+    expectLastCall();
     mockWriter.write(anyObject());
     expectLastCall().andThrow(exception);
 
@@ -371,6 +375,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     mockWriter.write(records);
     SQLException exception = new SQLException("cause 1");
     expectLastCall().andThrow(exception);
+    mockWriter.closeQuietly();
+    expectLastCall();
     mockWriter.write(anyObject());
     expectLastCall().andThrow(exception).times(batchSize);
 
@@ -405,6 +411,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     mockWriter.write(records);
     SQLException exception = new SQLException("cause 1");
     expectLastCall().andThrow(exception);
+    mockWriter.closeQuietly();
+    expectLastCall();
     mockWriter.write(anyObject());
     expectLastCall().times(2);
     expectLastCall().andThrow(exception);
@@ -438,6 +446,8 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     mockWriter.write(records);
     SQLException exception = new SQLException("cause 1");
     expectLastCall().andThrow(exception);
+    mockWriter.closeQuietly();
+    expectLastCall();
     mockWriter.write(anyObject());
     expectLastCall();
     mockWriter.write(anyObject());

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -211,11 +211,11 @@ public final class PostgresDatatypeIT extends BaseConnectorIT {
     try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
       try (Statement s = c.createStatement()) {
         try (ResultSet rs = s.executeQuery("SELECT * FROM " + tableName)) {
-          assertTrue(rs.next()
-              && struct.getString("firstname").equals(rs.getString("firstname"))
-              && struct.getString("lastname").equals(rs.getString("lastname"))
-              && struct.getString("jsonid").equals(rs.getString("jsonid"))
-              && struct.getString("userid").equals(rs.getString("userid")));
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(struct.getString("lastname"), rs.getString("lastname"));
+          assertEquals(struct.getString("jsonid"), rs.getString("jsonid"));
+          assertEquals(struct.getString("userid"), rs.getString("userid"));
         }
       }
     }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -96,10 +96,10 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC_NAME);
     props.put(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
 
+    createTableWithLessFields();
     connect.configureConnector("jdbc-sink-connector", props);
     waitForConnectorToStart("jdbc-sink-connector", 1);
 
-    createTableWithLessFields();
     final Schema schema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstname", Schema.STRING_SCHEMA)
         .field("lastname", Schema.STRING_SCHEMA)
@@ -124,10 +124,10 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
 
   @Test
   public void testWriteToTableWithUuidColumn() throws Exception {
+    createTableWithUuidColumns();
     connect.configureConnector("jdbc-sink-connector", props);
     waitForConnectorToStart("jdbc-sink-connector", 1);
 
-    createTableWithUuidColumns();
     final Schema schema = SchemaBuilder.struct().name("com.example.Person")
                                        .field("firstname", Schema.STRING_SCHEMA)
                                        .field("lastname", Schema.STRING_SCHEMA)

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -166,8 +166,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .put("jsonid", "5")
         .put("userid", UUID.randomUUID().toString());
 
-    String kafkaValue = new String(jsonConverter.fromConnectData(tableName, schema, struct));
-    connect.kafka().produce(tableName, null, kafkaValue);
+    produceRecord(schema, struct);
 
     waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
         TimeUnit.MINUTES.toMillis(2));
@@ -196,8 +195,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .put("jsonid", "5")
         .put("userid", UUID.randomUUID().toString());
 
-    String kafkaValue = new String(jsonConverter.fromConnectData(tableName, schema, struct));
-    connect.kafka().produce(tableName, null, kafkaValue);
+    produceRecord(schema, struct);
 
     waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
         TimeUnit.MINUTES.toMillis(2));

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -19,6 +19,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import io.confluent.common.utils.IntegrationTest;
@@ -172,9 +173,9 @@ public final class PostgresViewIT extends BaseConnectorIT  {
     try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
       try (Statement s = c.createStatement()) {
         try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
-          assertTrue(rs.next()
-              && struct.getString("firstname").equals(rs.getString("firstname"))
-              && rs.getString("lastname") == null);
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertNull(rs.getString("lastname"));
         }
       }
     }
@@ -202,9 +203,9 @@ public final class PostgresViewIT extends BaseConnectorIT  {
     try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
       try (Statement s = c.createStatement()) {
         try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
-          assertTrue(rs.next()
-              && struct.getString("firstname").equals(rs.getString("firstname"))
-              && struct.getString("lastname").equals(rs.getString("lastname")));
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(struct.getString("lastname"), rs.getString("lastname"));
         }
       }
     }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -97,10 +97,10 @@ public class PostgresViewIT extends BaseConnectorIT  {
     props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC_NAME);
     props.put(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
 
+    createTestTableAndView("firstName");
     connect.configureConnector("jdbc-sink-connector", props);
     waitForConnectorToStart("jdbc-sink-connector", 1);
 
-    createTestTableAndView("firstName");
     final Schema schema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstname", Schema.STRING_SCHEMA)
         .field("lastname", Schema.STRING_SCHEMA)
@@ -121,10 +121,10 @@ public class PostgresViewIT extends BaseConnectorIT  {
 
   @Test
   public void testRecordSchemaLessFieldsThanView() throws Exception {
+    createTestTableAndView("firstName, lastName");
     connect.configureConnector("jdbc-sink-connector", props);
     waitForConnectorToStart("jdbc-sink-connector", 1);
 
-    createTestTableAndView("firstName, lastName");
     final Schema schema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstname", Schema.STRING_SCHEMA)
         .build();
@@ -154,10 +154,10 @@ public class PostgresViewIT extends BaseConnectorIT  {
 
   @Test
   public void testWriteToView() throws Exception {
+    createTestTableAndView("firstName, lastName");
     connect.configureConnector("jdbc-sink-connector", props);
     waitForConnectorToStart("jdbc-sink-connector", 1);
 
-    createTestTableAndView("firstName, lastName");
     final Schema schema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstname", Schema.STRING_SCHEMA)
         .field("lastname", Schema.STRING_SCHEMA)

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -138,10 +138,16 @@ public class PostgresViewIT extends BaseConnectorIT  {
       }
     }
 
-    ConsumerRecords<byte[], byte[]> records = connect.kafka().consume(3, CONSUME_MAX_DURATION_MS,
-        DLQ_TOPIC_NAME);
-
-    assertEquals(3, records.count());
+    try {
+      // Consume the number of records produced since this is the upper bound of records that
+      // could be sent to the error reporter.
+      ConsumerRecords<byte[], byte[]> records = connect.kafka().consume(6,
+          CONSUME_MAX_DURATION_MS, DLQ_TOPIC_NAME);
+    } catch (RuntimeException e) {
+      // Check that the amount of records that were actually found by the consumer matches the
+      // number of records expected to be sent to the error reporter.
+      assertEquals("3", e.toString().substring(65, 66));
+    }
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresViewIT.java
@@ -18,7 +18,8 @@ package io.confluent.connect.jdbc.sink.integration;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
-import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.connect.jdbc.integration.BaseConnectorIT;
@@ -30,9 +31,13 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -99,7 +104,7 @@ public final class PostgresViewIT extends BaseConnectorIT  {
    * are sent to the error reporter. The test also intersperses correct schema records to verify
    * that only the errant records are being sent to the error reporter.
    */
-  @Test (expected = RuntimeException.class)
+  @Test
   public void testRecordSchemaMoreFieldsThanViewSendsToErrorReporter() throws Exception {
     props.put(ERRORS_TOLERANCE_CONFIG, ToleranceType.ALL.value());
     props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC_NAME);
@@ -135,11 +140,16 @@ public final class PostgresViewIT extends BaseConnectorIT  {
       }
     }
 
-    // Consume the expected number of records that should be sent to the error reporter.
-    connect.kafka().consume(3, CONSUME_MAX_DURATION_MS, DLQ_TOPIC_NAME);
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(topic), 6, 1,
+        TimeUnit.MINUTES.toMillis(4));
 
-    // Try to consume one more record than expected from the topic, which should fail.
-    connect.kafka().consume(4, 5000, DLQ_TOPIC_NAME);
+    KafkaConsumer<byte[], byte[]> consumer =
+        connect.kafka().createConsumerAndSubscribeTo(Collections.emptyMap(), DLQ_TOPIC_NAME);
+
+    ConsumerRecords<byte[], byte[]> records =
+        consumer.poll(Duration.ofMillis(CONSUME_MAX_DURATION_MS));
+
+    assertEquals(3, records.count());
   }
 
   @Test
@@ -156,22 +166,18 @@ public final class PostgresViewIT extends BaseConnectorIT  {
 
     produceRecord(schema, struct);
 
-    waitForCondition(
-        () -> {
-          try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
-            try (Statement s = c.createStatement()) {
-              try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
-                boolean result = rs.next()
-                    && struct.getString("firstname").equals(rs.getString("firstname"))
-                    && rs.getString("lastname") == null;
-                return Optional.of(result).orElse(false);
-              }
-            }
-          }
-        },
-        VERIFY_MAX_DURATION_MS,
-        "The database content did not match the record's content."
-    );
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(topic), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
+          assertTrue(rs.next()
+              && struct.getString("firstname").equals(rs.getString("firstname"))
+              && rs.getString("lastname") == null);
+        }
+      }
+    }
   }
 
   @Test
@@ -190,22 +196,18 @@ public final class PostgresViewIT extends BaseConnectorIT  {
 
     produceRecord(schema, struct);
 
-    waitForCondition(
-        () -> {
-          try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
-            try (Statement s = c.createStatement()) {
-              try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
-                boolean result = rs.next()
-                    && struct.getString("firstname").equals(rs.getString("firstname"))
-                    && struct.getString("lastname").equals(rs.getString("lastname"));
-                return Optional.of(result).orElse(false);
-              }
-            }
-          }
-        },
-        VERIFY_MAX_DURATION_MS,
-        "The database content did not match the record's content."
-    );
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(topic), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery("SELECT * FROM " + topic)) {
+          assertTrue(rs.next()
+              && struct.getString("firstname").equals(rs.getString("firstname"))
+              && struct.getString("lastname").equals(rs.getString("lastname")));
+        }
+      }
+    }
   }
 
   private void createTestTableAndView(String viewFields) throws SQLException {


### PR DESCRIPTION
Signed-off-by: Aakash Shah <ashah@confluent.io>

## Problem
Certain errors encountered in the JDBC Sink Connector can be deferred to the error reporter for later access, e.g, a failure to bind a SinkRecord to the statement.

## Solution
When encountering these errors, send the record and its corresponding error to the error reporter.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Other connectors that may want error reporting.

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backport to 10.0.x