### PR TITLE
MINOR: Fix logger classes for dialects

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -120,7 +120,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  protected final Logger log = LoggerFactory.getLogger(getClass());
+  private final Logger log = LoggerFactory.getLogger(GenericDatabaseDialect.class);
   protected final AbstractConfig config;
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -120,7 +120,12 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  private final Logger log = LoggerFactory.getLogger(GenericDatabaseDialect.class);
+  // This field should be private as it should only be used by this class and subclasses should
+  // instantiate their own loggers. However, it was originally declared as protected, and changing
+  // it to private now would break existing dialects that inherit from this class and rely on this
+  // field. So we leave it as protected now, but strongly recommend that all dialects use their own
+  // loggers (as all dialects in this code base do).
+  protected final Logger log = LoggerFactory.getLogger(GenericDatabaseDialect.class);
   protected final AbstractConfig config;
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -35,11 +35,16 @@ import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
 import io.confluent.connect.jdbc.util.IdentifierRules;
 import io.confluent.connect.jdbc.util.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link DatabaseDialect} for MySQL.
  */
 public class MySqlDatabaseDialect extends GenericDatabaseDialect {
+
+  private final Logger log = LoggerFactory.getLogger(MySqlDatabaseDialect.class);
+
   /**
    * The provider for {@link MySqlDatabaseDialect}.
    */

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -42,11 +42,15 @@ import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
 import io.confluent.connect.jdbc.util.IdentifierRules;
 import io.confluent.connect.jdbc.util.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link DatabaseDialect} for PostgreSQL.
  */
 public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
+
+  private final Logger log = LoggerFactory.getLogger(PostgreSqlDatabaseDialect.class);
 
   /**
    * The provider for {@link PostgreSqlDatabaseDialect}.


### PR DESCRIPTION
## Problem
Inaccurate log namespaces caused by `GenericDatabaseDialect` subclasses inheriting the logger from their parent. Results in logs with weird things like `PostgreSqlDatabaseDialect:571` when the Postgres dialect has, to date, only 423 lines total.

## Solution
Give each database dialect its own logger.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Jenkins build.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests

## Release Plan
Target 5.0.x, port forward through to master.