### PR TITLE
CCDB-3681: pick binding method wisely according to column def

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,7 +7,7 @@
 <suppressions>
 
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect).java"/>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -390,7 +390,6 @@ public interface DatabaseDialect extends ConnectionProvider {
 
   /**
    * Create a component that can bind record values into the supplied prepared statement.
-   *
    * @param statement      the prepared statement
    * @param pkMode         the primary key mode; may not be null
    * @param schemaPair     the key and value schemas; may not be null
@@ -399,19 +398,44 @@ public interface DatabaseDialect extends ConnectionProvider {
    * @return the statement binder; may not be null
    * @see #bindField(PreparedStatement, int, Schema, Object)
    */
+  @Deprecated
   StatementBinder statementBinder(
+      PreparedStatement statement,
+      JdbcSinkConfig.PrimaryKeyMode pkMode,
+      SchemaPair schemaPair,
+      FieldsMetadata fieldsMetadata,
+      JdbcSinkConfig.InsertMode insertMode
+  );
+
+  /**
+   * Create a component that can bind record values into the supplied prepared statement. By
+   * default, the behavior is the same as the other overloaded method with the extra parameter
+   * tableDefinition. This overloading method is introduced to deprecate the other overloaded
+   * method eventually.
+   *
+   * @param statement      the prepared statement
+   * @param pkMode         the primary key mode; may not be null
+   * @param schemaPair     the key and value schemas; may not be null
+   * @param fieldsMetadata the field metadata; may not be null
+   * @param tableDefinition the table definition; may be null
+   * @param insertMode     the insert mode; may not be null
+   * @return the statement binder; may not be null
+   * @see #bindField(PreparedStatement, int, Schema, Object)
+   */
+  default StatementBinder statementBinder(
       PreparedStatement statement,
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
       TableDefinition tableDefinition,
       JdbcSinkConfig.InsertMode insertMode
-  );
+  ) {
+    return statementBinder(statement, pkMode, schemaPair, fieldsMetadata, insertMode);
+  }
 
   /**
    * Method that binds a value with the given schema at the specified variable within a prepared
    * statement.
-   *
    * @param statement the prepared statement; may not be null
    * @param index     the 1-based index of the variable within the prepared statement
    * @param schema    the schema for the value; may be null only if the value is null
@@ -419,6 +443,7 @@ public interface DatabaseDialect extends ConnectionProvider {
    * @throws SQLException if there is a problem binding the value into the statement
    * @see #statementBinder
    */
+  @Deprecated
   void bindField(
       PreparedStatement statement,
       int index,
@@ -428,7 +453,9 @@ public interface DatabaseDialect extends ConnectionProvider {
 
   /**
    * Method that binds a value with the given schema at the specified variable within a prepared
-   * statement.
+   * statement. By default, the behavior is the same as the other overloaded method with the extra
+   * parameter colDef. This overloading method is introduced to deprecate the other overloaded
+   * method eventually.
    *
    * @param statement the prepared statement; may not be null
    * @param index     the 1-based index of the variable within the prepared statement
@@ -438,13 +465,15 @@ public interface DatabaseDialect extends ConnectionProvider {
    * @throws SQLException if there is a problem binding the value into the statement
    * @see #statementBinder
    */
-  void bindField(
+  default void bindField(
       PreparedStatement statement,
       int index,
       Schema schema,
       Object value,
       ColumnDefinition colDef
-  ) throws SQLException;
+  ) throws SQLException {
+    bindField(statement, index, schema, value);
+  }
 
   /**
    * A function to bind the values from a sink record into a prepared statement.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -423,6 +423,25 @@ public interface DatabaseDialect extends ConnectionProvider {
       PreparedStatement statement,
       int index,
       Schema schema,
+      Object value
+  ) throws SQLException;
+
+  /**
+   * Method that binds a value with the given schema at the specified variable within a prepared
+   * statement.
+   *
+   * @param statement the prepared statement; may not be null
+   * @param index     the 1-based index of the variable within the prepared statement
+   * @param schema    the schema for the value; may be null only if the value is null
+   * @param value     the value to be bound to the variable; may be null
+   * @param colDef    the Definition of the column to be bound; may be null
+   * @throws SQLException if there is a problem binding the value into the statement
+   * @see #statementBinder
+   */
+  void bindField(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
       Object value,
       ColumnDefinition colDef
   ) throws SQLException;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -404,6 +404,7 @@ public interface DatabaseDialect extends ConnectionProvider {
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
+      TableDefinition tableDefinition,
       JdbcSinkConfig.InsertMode insertMode
   );
 
@@ -422,7 +423,8 @@ public interface DatabaseDialect extends ConnectionProvider {
       PreparedStatement statement,
       int index,
       Schema schema,
-      Object value
+      Object value,
+      ColumnDefinition colDef
   ) throws SQLException;
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -98,6 +98,7 @@ import io.confluent.connect.jdbc.util.TableId;
  * how a column value is converted to a field value for use in a {@link Struct}. To also change the
  * field's type or schema, also override the {@link #addFieldToSchema} method.
  */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class GenericDatabaseDialect implements DatabaseDialect {
 
   protected static final int NUMERIC_TYPE_SCALE_LOW = -84;
@@ -816,6 +817,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    * @param isPrimaryKey     true if the column is part of the primary key; null if not known known
    * @return the column definition; never null
    */
+  @SuppressWarnings("checkstyle:ParameterNumber")
   protected ColumnDefinition columnDefinition(
       ResultSet resultSet,
       ColumnId id,
@@ -893,7 +895,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    * @param optional   true if the field is to be optional as obtained from the column definition
    * @return the name of the field, or null if no field was added
    */
-  @SuppressWarnings("fallthrough")
+  @SuppressWarnings({"fallthrough", "checkstyle:CyclomaticComplexity"})
   protected String addFieldToSchema(
       final ColumnDefinition columnDefn,
       final SchemaBuilder builder,
@@ -1434,6 +1436,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
+      TableDefinition tableDef,
       InsertMode insertMode
   ) {
     return new PreparedStatementBinder(
@@ -1442,6 +1445,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         pkMode,
         schemaPair,
         fieldsMetadata,
+        tableDef,
         insertMode
     );
   }
@@ -1451,14 +1455,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       PreparedStatement statement,
       int index,
       Schema schema,
-      Object value
+      Object value,
+      ColumnDefinition colDef
   ) throws SQLException {
     if (value == null) {
       statement.setObject(index, null);
     } else {
       boolean bound = maybeBindLogical(statement, index, schema, value);
       if (!bound) {
-        bound = maybeBindPrimitive(statement, index, schema, value);
+        bound = maybeBindPrimitive(statement, index, schema, value, colDef);
       }
       if (!bound) {
         throw new ConnectException("Unsupported source data type: " + schema.type());
@@ -1466,11 +1471,13 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   protected boolean maybeBindPrimitive(
       PreparedStatement statement,
       int index,
       Schema schema,
-      Object value
+      Object value,
+      ColumnDefinition colDef
   ) throws SQLException {
     switch (schema.type()) {
       case INT8:
@@ -1672,6 +1679,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return field.isOptional();
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   protected void formatColumnValue(
       ExpressionBuilder builder,
       String schemaName,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -98,7 +98,6 @@ import io.confluent.connect.jdbc.util.TableId;
  * how a column value is converted to a field value for use in a {@link Struct}. To also change the
  * field's type or schema, also override the {@link #addFieldToSchema} method.
  */
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class GenericDatabaseDialect implements DatabaseDialect {
 
   protected static final int NUMERIC_TYPE_SCALE_LOW = -84;
@@ -817,7 +816,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    * @param isPrimaryKey     true if the column is part of the primary key; null if not known known
    * @return the column definition; never null
    */
-  @SuppressWarnings("checkstyle:ParameterNumber")
   protected ColumnDefinition columnDefinition(
       ResultSet resultSet,
       ColumnId id,
@@ -895,7 +893,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    * @param optional   true if the field is to be optional as obtained from the column definition
    * @return the name of the field, or null if no field was added
    */
-  @SuppressWarnings({"fallthrough", "checkstyle:CyclomaticComplexity"})
+  @SuppressWarnings("fallthrough")
   protected String addFieldToSchema(
       final ColumnDefinition columnDefn,
       final SchemaBuilder builder,
@@ -1116,7 +1114,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     );
   }
 
-  @SuppressWarnings({"deprecation", "fallthrough", "checkstyle:CyclomaticComplexity"})
+  @SuppressWarnings({"deprecation", "fallthrough"})
   protected ColumnConverter columnConverterFor(
       final ColumnMapping mapping,
       final ColumnDefinition defn,
@@ -1430,13 +1428,13 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     throw new UnsupportedOperationException();
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public StatementBinder statementBinder(
       PreparedStatement statement,
       PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      TableDefinition tableDef,
       InsertMode insertMode
   ) {
     return new PreparedStatementBinder(
@@ -1445,27 +1443,17 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         pkMode,
         schemaPair,
         fieldsMetadata,
-        tableDef,
         insertMode
     );
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void bindField(
       PreparedStatement statement,
       int index,
       Schema schema,
       Object value
-  ) throws SQLException {
-    bindField(statement, index, schema, value, null);
-  }
-
-  public void bindField(
-      PreparedStatement statement,
-      int index,
-      Schema schema,
-      Object value,
-      ColumnDefinition colDef
   ) throws SQLException {
     if (value == null) {
       statement.setObject(index, null);
@@ -1480,7 +1468,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   protected boolean maybeBindPrimitive(
       PreparedStatement statement,
       int index,
@@ -1527,16 +1514,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         return false;
     }
     return true;
-  }
-
-  protected boolean maybeBindPrimitive(
-      PreparedStatement statement,
-      int index,
-      Schema schema,
-      Object value,
-      ColumnDefinition colDef
-  ) throws SQLException {
-    return maybeBindPrimitive(statement, index, schema, value);
   }
 
   protected boolean maybeBindLogical(
@@ -1697,7 +1674,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return field.isOptional();
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   protected void formatColumnValue(
       ExpressionBuilder builder,
       String schemaName,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1116,7 +1116,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     );
   }
 
-  @SuppressWarnings({"deprecation", "fallthrough"})
+  @SuppressWarnings({"deprecation", "fallthrough", "checkstyle:CyclomaticComplexity"})
   protected ColumnConverter columnConverterFor(
       final ColumnMapping mapping,
       final ColumnDefinition defn,
@@ -1455,6 +1455,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       PreparedStatement statement,
       int index,
       Schema schema,
+      Object value
+  ) throws SQLException {
+    bindField(statement, index, schema, value, null);
+  }
+
+  public void bindField(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
       Object value,
       ColumnDefinition colDef
   ) throws SQLException {
@@ -1463,7 +1472,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     } else {
       boolean bound = maybeBindLogical(statement, index, schema, value);
       if (!bound) {
-        bound = maybeBindPrimitive(statement, index, schema, value, colDef);
+        bound = maybeBindPrimitive(statement, index, schema, value);
       }
       if (!bound) {
         throw new ConnectException("Unsupported source data type: " + schema.type());
@@ -1476,8 +1485,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       PreparedStatement statement,
       int index,
       Schema schema,
-      Object value,
-      ColumnDefinition colDef
+      Object value
   ) throws SQLException {
     switch (schema.type()) {
       case INT8:
@@ -1519,6 +1527,16 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         return false;
     }
     return true;
+  }
+
+  protected boolean maybeBindPrimitive(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value,
+      ColumnDefinition colDef
+  ) throws SQLException {
+    return maybeBindPrimitive(statement, index, schema, value);
   }
 
   protected boolean maybeBindLogical(

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -82,6 +82,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     return "SELECT 1 FROM DUAL";
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   protected boolean maybeBindPrimitive(
       PreparedStatement statement,
@@ -98,7 +99,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
       if (colDef.type() == Types.CLOB || colDef.type() == Types.NCLOB) {
         statement.setCharacterStream(index, new StringReader((String) value));
         return true;
-      } else if (colDef.type() == Types.NVARCHAR) {
+      } else if (colDef.type() == Types.NVARCHAR || colDef.type() == Types.NCHAR) {
         statement.setNString(index, (String) value);
         return true;
       } else {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -16,7 +16,13 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig.InsertMode;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig.PrimaryKeyMode;
+import io.confluent.connect.jdbc.sink.PreparedStatementBinder;
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.TableDefinition;
 import java.io.ByteArrayInputStream;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
@@ -83,6 +89,26 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
   }
 
   @Override
+  public StatementBinder statementBinder(
+      PreparedStatement statement,
+      PrimaryKeyMode pkMode,
+      SchemaPair schemaPair,
+      FieldsMetadata fieldsMetadata,
+      TableDefinition tableDefinition,
+      InsertMode insertMode
+  ) {
+    return new PreparedStatementBinder(
+        this,
+        statement,
+        pkMode,
+        schemaPair,
+        fieldsMetadata,
+        tableDefinition,
+        insertMode
+    );
+  }
+
+  @Override
   public void bindField(
       PreparedStatement statement,
       int index,
@@ -103,8 +129,6 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
-  @Override
   protected boolean maybeBindPrimitive(
       PreparedStatement statement,
       int index,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -85,7 +85,6 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
     return "SELECT 1";
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   protected String getSqlType(SinkRecordField field) {
     if (field.schemaName() != null) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.util.ColumnDefinition;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -85,6 +86,7 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
     return "SELECT 1";
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   protected String getSqlType(SinkRecordField field) {
     if (field.schemaName() != null) {
@@ -141,7 +143,8 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
       PreparedStatement statement,
       int index,
       Schema schema,
-      Object value
+      Object value,
+      ColumnDefinition colDef
   ) throws SQLException {
     // First handle non-standard bindings ...
     switch (schema.type()) {
@@ -154,7 +157,7 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
       default:
         break;
     }
-    return super.maybeBindPrimitive(statement, index, schema, value);
+    return super.maybeBindPrimitive(statement, index, schema, value, colDef);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.jdbc.dialect;
 
-import io.confluent.connect.jdbc.util.ColumnDefinition;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -143,8 +142,7 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
       PreparedStatement statement,
       int index,
       Schema schema,
-      Object value,
-      ColumnDefinition colDef
+      Object value
   ) throws SQLException {
     // First handle non-standard bindings ...
     switch (schema.type()) {
@@ -157,7 +155,7 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
       default:
         break;
     }
-    return super.maybeBindPrimitive(statement, index, schema, value, colDef);
+    return super.maybeBindPrimitive(statement, index, schema, value);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -131,7 +131,6 @@ public class BufferedRecords {
     return flushed;
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public List<SinkRecord> flush() throws SQLException {
     if (records.isEmpty()) {
       log.debug("Records is empty");

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -103,6 +103,7 @@ public class BufferedRecords {
           config.pkMode,
           schemaPair,
           fieldsMetadata,
+          dbStructure.tableDefinition(connection, tableId),
           config.insertMode
       );
     }
@@ -130,6 +131,7 @@ public class BufferedRecords {
     return flushed;
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public List<SinkRecord> flush() throws SQLException {
     if (records.isEmpty()) {
       log.debug("Records is empty");

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -228,4 +228,9 @@ public class DbStructure {
 
     return missingFieldsIgnoreCase;
   }
+
+  protected TableDefinition tableDefinition(Connection connection, TableId tableId)
+      throws SQLException {
+    return tableDefns.get(connection, tableId);
+  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -98,16 +98,16 @@ public class PreparedStatementBinder implements StatementBinder {
 
       case KAFKA: {
         assert fieldsMetadata.keyFieldNames.size() == 3;
-        bindField(index++, Schema.STRING_SCHEMA, record.topic(), null);
-        bindField(index++, Schema.INT32_SCHEMA, record.kafkaPartition(), null);
-        bindField(index++, Schema.INT64_SCHEMA, record.kafkaOffset(), null);
+        bindField(index++, Schema.STRING_SCHEMA, record.topic());
+        bindField(index++, Schema.INT32_SCHEMA, record.kafkaPartition());
+        bindField(index++, Schema.INT64_SCHEMA, record.kafkaOffset());
       }
       break;
 
       case RECORD_KEY: {
         if (schemaPair.keySchema.type().isPrimitive()) {
           assert fieldsMetadata.keyFieldNames.size() == 1;
-          bindField(index++, schemaPair.keySchema, record.key(), null);
+          bindField(index++, schemaPair.keySchema, record.key());
         } else {
           for (String fieldName : fieldsMetadata.keyFieldNames) {
             final Field field = schemaPair.keySchema.field(fieldName);
@@ -144,6 +144,11 @@ public class PreparedStatementBinder implements StatementBinder {
           tableDef.definitionForColumn(fieldName));
     }
     return index;
+  }
+
+  protected void bindField(int index, Schema schema, Object value)
+      throws SQLException {
+    dialect.bindField(statement, index, schema, value);
   }
 
   protected void bindField(int index, Schema schema, Object value, ColumnDefinition colDef)

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -40,7 +40,27 @@ public class PreparedStatementBinder implements StatementBinder {
   private final FieldsMetadata fieldsMetadata;
   private final JdbcSinkConfig.InsertMode insertMode;
   private final DatabaseDialect dialect;
-  private final TableDefinition tableDef;
+  private final TableDefinition tabDef;
+
+  @Deprecated
+  public PreparedStatementBinder(
+      DatabaseDialect dialect,
+      PreparedStatement statement,
+      JdbcSinkConfig.PrimaryKeyMode pkMode,
+      SchemaPair schemaPair,
+      FieldsMetadata fieldsMetadata,
+      JdbcSinkConfig.InsertMode insertMode
+  ) {
+    this(
+        dialect,
+        statement,
+        pkMode,
+        schemaPair,
+        fieldsMetadata,
+        null,
+        insertMode
+    );
+  }
 
   public PreparedStatementBinder(
       DatabaseDialect dialect,
@@ -48,7 +68,7 @@ public class PreparedStatementBinder implements StatementBinder {
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      TableDefinition tableDef,
+      TableDefinition tabDef,
       JdbcSinkConfig.InsertMode insertMode
   ) {
     this.dialect = dialect;
@@ -57,7 +77,7 @@ public class PreparedStatementBinder implements StatementBinder {
     this.schemaPair = schemaPair;
     this.fieldsMetadata = fieldsMetadata;
     this.insertMode = insertMode;
-    this.tableDef = tableDef;
+    this.tabDef = tabDef;
   }
 
   @Override
@@ -98,21 +118,24 @@ public class PreparedStatementBinder implements StatementBinder {
 
       case KAFKA: {
         assert fieldsMetadata.keyFieldNames.size() == 3;
-        bindField(index++, Schema.STRING_SCHEMA, record.topic());
-        bindField(index++, Schema.INT32_SCHEMA, record.kafkaPartition());
-        bindField(index++, Schema.INT64_SCHEMA, record.kafkaOffset());
+        bindField(index++, Schema.STRING_SCHEMA, record.topic(),
+            JdbcSinkConfig.DEFAULT_KAFKA_PK_NAMES.get(0));
+        bindField(index++, Schema.INT32_SCHEMA, record.kafkaPartition(),
+            JdbcSinkConfig.DEFAULT_KAFKA_PK_NAMES.get(1));
+        bindField(index++, Schema.INT64_SCHEMA, record.kafkaOffset(),
+            JdbcSinkConfig.DEFAULT_KAFKA_PK_NAMES.get(2));
       }
       break;
 
       case RECORD_KEY: {
         if (schemaPair.keySchema.type().isPrimitive()) {
           assert fieldsMetadata.keyFieldNames.size() == 1;
-          bindField(index++, schemaPair.keySchema, record.key());
+          bindField(index++, schemaPair.keySchema, record.key(),
+              fieldsMetadata.keyFieldNames.iterator().next());
         } else {
           for (String fieldName : fieldsMetadata.keyFieldNames) {
             final Field field = schemaPair.keySchema.field(fieldName);
-            bindField(index++, field.schema(), ((Struct) record.key()).get(field),
-                tableDef.definitionForColumn(fieldName));
+            bindField(index++, field.schema(), ((Struct) record.key()).get(field), fieldName);
           }
         }
       }
@@ -121,8 +144,7 @@ public class PreparedStatementBinder implements StatementBinder {
       case RECORD_VALUE: {
         for (String fieldName : fieldsMetadata.keyFieldNames) {
           final Field field = schemaPair.valueSchema.field(fieldName);
-          bindField(index++, field.schema(), ((Struct) record.value()).get(field),
-              tableDef.definitionForColumn(fieldName));
+          bindField(index++, field.schema(), ((Struct) record.value()).get(field), fieldName);
         }
       }
       break;
@@ -140,19 +162,20 @@ public class PreparedStatementBinder implements StatementBinder {
   ) throws SQLException {
     for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
       final Field field = record.valueSchema().field(fieldName);
-      bindField(index++, field.schema(), valueStruct.get(field),
-          tableDef.definitionForColumn(fieldName));
+      bindField(index++, field.schema(), valueStruct.get(field), fieldName);
     }
     return index;
   }
 
+  @Deprecated
   protected void bindField(int index, Schema schema, Object value)
       throws SQLException {
     dialect.bindField(statement, index, schema, value);
   }
 
-  protected void bindField(int index, Schema schema, Object value, ColumnDefinition colDef)
+  protected void bindField(int index, Schema schema, Object value, String fieldName)
       throws SQLException {
+    ColumnDefinition colDef = tabDef == null ? null : tabDef.definitionForColumn(fieldName);
     dialect.bindField(statement, index, schema, value, colDef);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -14,10 +14,15 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -34,6 +39,12 @@ import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDialect> {
 
@@ -46,7 +57,15 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Test
   public void bindFieldStringValue() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
-    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setNString(index, "yep");
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setCharacterStream(eq(index), any(StringReader.class));
+  }
+
+  @Override
+  @Test
+  public void bindFieldBytesValue() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBlob(eq(index), any(ByteArrayInputStream.class));
+    verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBlob(eq(index), any(ByteArrayInputStream.class));
   }
 
   @Test
@@ -259,37 +278,77 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   public void shouldSanitizeUrlWithKerberosCredentialsInUrlProperties() {
     assertSanitizedUrl(
         "jdbc:oracle:thin:@myhost:1111/db?"
-        + "password=secret&"
-        + "javax.net.ssl.keyStorePassword=secret2&"
-        + "key1=value1&"
-        + "key2=value2&"
-        + "key3=value3&"
-        + "user=smith&"
-        + "password=secret&"
-        + "passworNotSanitized=not-secret&"
-        + "passwordShouldBeSanitized=value3&"
-        + "javax.net.ssl.trustStorePassword=superSecret&"
-        + "OCINewPassword=secret2&"
-        + "oracle.net.wallet_password=secret3&"
-        + "proxy_password=secret4&"
-        + "PROXY_USER_PASSWORD=secret5&"
-        + "other=value",
+            + "password=secret&"
+            + "javax.net.ssl.keyStorePassword=secret2&"
+            + "key1=value1&"
+            + "key2=value2&"
+            + "key3=value3&"
+            + "user=smith&"
+            + "password=secret&"
+            + "passworNotSanitized=not-secret&"
+            + "passwordShouldBeSanitized=value3&"
+            + "javax.net.ssl.trustStorePassword=superSecret&"
+            + "OCINewPassword=secret2&"
+            + "oracle.net.wallet_password=secret3&"
+            + "proxy_password=secret4&"
+            + "PROXY_USER_PASSWORD=secret5&"
+            + "other=value",
         "jdbc:oracle:thin:@myhost:1111/db?"
-        + "password=****&"
-        + "javax.net.ssl.keyStorePassword=****&"
-        + "key1=value1&"
-        + "key2=value2&"
-        + "key3=value3&"
-        + "user=smith&"
-        + "password=****&"
-        + "passworNotSanitized=not-secret&"
-        + "passwordShouldBeSanitized=****&"
-        + "javax.net.ssl.trustStorePassword=****&"
-        + "OCINewPassword=****&"
-        + "oracle.net.wallet_password=****&"
-        + "proxy_password=****&"
-        + "PROXY_USER_PASSWORD=****&"
-        + "other=value"
+            + "password=****&"
+            + "javax.net.ssl.keyStorePassword=****&"
+            + "key1=value1&"
+            + "key2=value2&"
+            + "key3=value3&"
+            + "user=smith&"
+            + "password=****&"
+            + "passworNotSanitized=not-secret&"
+            + "passwordShouldBeSanitized=****&"
+            + "javax.net.ssl.trustStorePassword=****&"
+            + "OCINewPassword=****&"
+            + "oracle.net.wallet_password=****&"
+            + "proxy_password=****&"
+            + "PROXY_USER_PASSWORD=****&"
+            + "other=value"
     );
+  }
+
+  @Test
+  public void shouldBindStringAccordingToColumnDef() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    String value = "random text";
+    Schema schema = Schema.STRING_SCHEMA;
+    PreparedStatement statement = mock(PreparedStatement.class);
+    ColumnDefinition colDefVarchar = mock(ColumnDefinition.class);
+    when(colDefVarchar.type()).thenReturn(Types.VARCHAR);
+    ColumnDefinition colDefNvarchar = mock(ColumnDefinition.class);
+    when(colDefNvarchar.type()).thenReturn(Types.NVARCHAR);
+    ColumnDefinition colDefClob = mock(ColumnDefinition.class);
+    when(colDefClob.type()).thenReturn(Types.CLOB);
+
+    dialect.bindField(statement, index, schema, value, colDefVarchar);
+    verify(statement, times(1)).setString(index, value);
+
+    dialect.bindField(statement, index, schema, value, colDefNvarchar);
+    verify(statement, times(1)).setNString(index, value);
+
+    dialect.bindField(statement, index, schema, value, colDefClob);
+    verify(statement, times(1)).setCharacterStream(eq(index), any(StringReader.class));
+  }
+
+  @Test
+  public void shouldBindBytesAccordingToColumnDef() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    byte[] value = new byte[]{42};
+    Schema schema = Schema.BYTES_SCHEMA;
+    PreparedStatement statement = mock(PreparedStatement.class);
+    ColumnDefinition colDefBlob = mock(ColumnDefinition.class);
+    when(colDefBlob.type()).thenReturn(Types.BLOB);
+    ColumnDefinition colDefBinary = mock(ColumnDefinition.class);
+    when(colDefBinary.type()).thenReturn(Types.BINARY);
+
+    dialect.bindField(statement, index, schema, value, colDefBlob);
+    verify(statement, times(1)).setBlob(eq(index), any(ByteArrayInputStream.class));
+    dialect.bindField(statement, index, schema, value, colDefBinary);
+    verify(statement, times(1)).setBytes(index, value);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -317,22 +317,33 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     int index = ThreadLocalRandom.current().nextInt();
     String value = "random text";
     Schema schema = Schema.STRING_SCHEMA;
-    PreparedStatement statement = mock(PreparedStatement.class);
+    PreparedStatement stmtVarchar = mock(PreparedStatement.class);
     ColumnDefinition colDefVarchar = mock(ColumnDefinition.class);
     when(colDefVarchar.type()).thenReturn(Types.VARCHAR);
+
+    PreparedStatement stmtNchar = mock(PreparedStatement.class);
+    ColumnDefinition colDefNchar = mock(ColumnDefinition.class);
+    when(colDefNchar.type()).thenReturn(Types.NCHAR);
+
+    PreparedStatement stmtNvarchar = mock(PreparedStatement.class);
     ColumnDefinition colDefNvarchar = mock(ColumnDefinition.class);
     when(colDefNvarchar.type()).thenReturn(Types.NVARCHAR);
+
+    PreparedStatement stmtClob = mock(PreparedStatement.class);
     ColumnDefinition colDefClob = mock(ColumnDefinition.class);
     when(colDefClob.type()).thenReturn(Types.CLOB);
 
-    dialect.bindField(statement, index, schema, value, colDefVarchar);
-    verify(statement, times(1)).setString(index, value);
+    dialect.bindField(stmtVarchar, index, schema, value, colDefVarchar);
+    verify(stmtVarchar, times(1)).setString(index, value);
 
-    dialect.bindField(statement, index, schema, value, colDefNvarchar);
-    verify(statement, times(1)).setNString(index, value);
+    dialect.bindField(stmtNchar, index, schema, value, colDefNchar);
+    verify(stmtNchar, times(1)).setNString(index, value);
 
-    dialect.bindField(statement, index, schema, value, colDefClob);
-    verify(statement, times(1)).setCharacterStream(eq(index), any(StringReader.class));
+    dialect.bindField(stmtNvarchar, index, schema, value, colDefNvarchar);
+    verify(stmtNvarchar, times(1)).setNString(index, value);
+
+    dialect.bindField(stmtClob, index, schema, value, colDefClob);
+    verify(stmtClob, times(1)).setCharacterStream(eq(index), any(StringReader.class));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -58,6 +58,13 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     assertPrimitiveMapping(Type.STRING, "text");
   }
 
+  @Override
+  @Test
+  public void bindFieldByteValue() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.INT8_SCHEMA, (byte) 42).setShort(index, (byte) 42);
+  }
+
   @Test
   public void shouldMapDecimalSchemaTypeToDecimalSqlType() {
     assertDecimalMapping(0, "decimal(38,0)");

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -16,6 +16,9 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.TableDefinition;
+import java.sql.Types;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -43,6 +46,7 @@ import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -122,12 +126,19 @@ public class BufferedRecordsTest {
     batchResponse[0] = Statement.SUCCESS_NO_INFO;
     batchResponse[1] = Statement.SUCCESS_NO_INFO;
 
+    final ColumnDefinition colDefMock = mock(ColumnDefinition.class);
+    when(colDefMock.type()).thenReturn(Types.VARCHAR);
+    final TableDefinition tabDefMock = mock(TableDefinition.class);
+    when(tabDefMock.definitionForColumn("name")).thenReturn(colDefMock);
+
+
     final DbStructure dbStructureMock = mock(DbStructure.class);
     when(dbStructureMock.createOrAmendIfNecessary(Matchers.any(JdbcSinkConfig.class),
                                                   Matchers.any(Connection.class),
                                                   Matchers.any(TableId.class),
                                                   Matchers.any(FieldsMetadata.class)))
         .thenReturn(true);
+    when(dbStructureMock.tableDefinition(any(), any())).thenReturn(tabDefMock);
 
     PreparedStatement preparedStatementMock = mock(PreparedStatement.class);
     when(preparedStatementMock.executeBatch()).thenReturn(batchResponse);

--- a/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
@@ -16,6 +16,7 @@ package io.confluent.connect.jdbc.util;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;


### PR DESCRIPTION
## Problem
Currently for string value, jdbc sink always use setString() to bind, and for bytes value, always use setBytes() to bind. This is causing several escalations. Please see https://confluentinc.atlassian.net/browse/CCDB-3681 for more details.

## Solution
Now choose binding method wisely according to column def. For string value, if the column def is CLOB or NCLOB, use setCharacterStream() to bind, whereas if the column def is NVARCHAR2, use setNString() to bind, otherwise use setString(); For bytes value, if the column def is BLOB, use setBlob(), otherwise use setBytes().

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
targeting 5.0.x, will pint merge to master.