### PR TITLE
CCDB-3732: Disable table monitor thread when in query mode

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -121,7 +121,9 @@ public class JdbcSourceConnector extends SourceConnector {
         whitelistSet,
         blacklistSet
     );
-    tableMonitorThread.start();
+    if (query.isEmpty()) {
+      tableMonitorThread.start();
+    }
   }
 
   protected CachedConnectionProvider connectionProvider(int maxConnAttempts, long retryBackoff) {


### PR DESCRIPTION
Signed-off-by: Greg Harris <gregh@confluent.io>

## Problem

The table monitor thread isn't used in query mode, but still runs in the background locking up database tables.
For databases with large numbers of tables this generates significant extra unproductive database load.

## Solution

Only start the table monitor thread when the query config is empty.
All other call sites are safe to execute on the not-running thread, and avoids multiple nullchecks.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
This targets 10.0.x, since this is the first version which does not have the TableRecommender in use.
