### PR TITLE
Drop records if older than what is in the target table

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -286,7 +286,8 @@ public class BufferedRecords {
               tableId,
               asColumns(fieldsMetadata.keyFieldNames),
               asColumns(fieldsMetadata.nonKeyFieldNames),
-              dbStructure.tableDefinition(connection, tableId)
+              dbStructure.tableDefinition(connection, tableId),
+              config.updateDropConditions
           );
         } catch (UnsupportedOperationException e) {
           throw new ConnectException(String.format(
@@ -300,7 +301,8 @@ public class BufferedRecords {
             tableId,
             asColumns(fieldsMetadata.keyFieldNames),
             asColumns(fieldsMetadata.nonKeyFieldNames),
-            dbStructure.tableDefinition(connection, tableId)
+            dbStructure.tableDefinition(connection, tableId),
+            config.updateDropConditions
         );
       default:
         throw new ConnectException("Invalid insert mode");

--- a/src/main/java/io/confluent/connect/jdbc/util/UpdateDropCondition.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/UpdateDropCondition.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import io.confluent.connect.jdbc.util.ExpressionBuilder.Expressable;
+
+import java.util.Objects;
+
+public class UpdateDropCondition implements Expressable {
+
+  private final ColumnId field;
+  private final String operator;
+  private final int hash;
+
+  public UpdateDropCondition(String field) {
+    this(new ColumnId(null, field.trim(), field.trim()));
+  }
+
+  public UpdateDropCondition(ColumnId field) {
+    this.field = field;
+    this.operator = "<";
+    this.hash = Objects.hash(this.field.name(), this.operator);
+  }
+
+  public ColumnId field() {
+    return this.field;
+  }
+
+  public String operator() {
+    return this.operator;
+  }
+
+  @Override
+  public void appendTo(ExpressionBuilder builder, boolean useQuotes) {
+    appendTo(builder, useQuotes ? QuoteMethod.ALWAYS : QuoteMethod.NEVER);
+  }
+
+  @Override
+  public void appendTo(
+      ExpressionBuilder builder,
+      QuoteMethod useQuotes
+  ) {
+    builder.appendColumnName(this.field.name(), useQuotes);
+    builder.append(this.operator);
+    builder.appendColumnName(this.field.name(), useQuotes);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj instanceof UpdateDropCondition) {
+      UpdateDropCondition that = (UpdateDropCondition) obj;
+      return Objects.equals(this.field.name(), that.field.name())
+             && Objects.equals(this.operator, that.operator);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return ExpressionBuilder.create().append(this).toString();
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -274,6 +274,19 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   }
 
   @Test
+  public void testBuildUpdateStatement() {
+    newDialectFor(TABLE_TYPES, null);
+    Collection<UpdateDropCondition> conditions =
+            Collections.singletonList(new UpdateDropCondition(columnA));
+    assertEquals(
+            "UPDATE \"myTable\" SET \"columnA\" = ?, \"columnB\" = ?, " +
+            "\"columnC\" = ?, \"columnD\" = ? WHERE \"columnA\" < ?" +
+            " AND \"id1\" = ? AND \"id2\" = ?",
+            dialect.buildUpdateStatement(tableId, pkColumns, columnsAtoD, conditions));
+  }
+
+
+  @Test
   public void testBuildDeleteStatement() {
     newDialectFor(TABLE_TYPES, null);
     assertEquals(

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.util.UpdateDropCondition;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -23,6 +24,9 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
@@ -124,6 +128,20 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
                       "`columnB`=values(`columnB`),`columnC`=values(`columnC`),`columnD`=values" +
                       "(`columnD`)";
     String sql = dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD);
+    assertEquals(expected, sql);
+  }
+
+  @Test
+  public void shouldBuildUpsertStatementWithConditions() {
+    Collection<UpdateDropCondition> conditions =
+            Collections.singletonList(new UpdateDropCondition(columnA));
+    String expected = "insert into `myTable`(`id1`,`id2`,`columnA`,`columnB`,`columnC`" +
+            ",`columnD`) values(?,?,?,?,?,?) on duplicate key update " +
+            "`columnA` = IF(`columnA` < values(`columnA`), values(`columnA`), `columnA`)," +
+            "`columnB` = IF(`columnA` < values(`columnA`), values(`columnB`), `columnB`)," +
+            "`columnC` = IF(`columnA` < values(`columnA`), values(`columnC`), `columnC`)," +
+            "`columnD` = IF(`columnA` < values(`columnA`), values(`columnD`), `columnD`)";
+    String sql = dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, conditions);
     assertEquals(expected, sql);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -67,6 +67,17 @@ public class JdbcSinkConfigTest {
   }
 
   @Test
+  public void shouldCreateConfigWithDropConditions() {
+    props.put("update.drop.if.fields.older", "columnA,columnB");
+    createConfig();
+    assertEquals(2, config.updateDropConditions.size());
+    assertEquals("columnA", config.updateDropConditions.get(0).field().name());
+    assertEquals("columnB", config.updateDropConditions.get(1).field().name());
+    assertEquals("<",config.updateDropConditions.get(0).operator());
+    assertEquals("<",config.updateDropConditions.get(1).operator());
+  }
+
+  @Test
   public void shouldCreateConfigWithViewOnly() {
     props.put("table.types", "view");
     createConfig();


### PR DESCRIPTION
## Problem
When using insert.mode `upsert` or `update`, the connector overwrites data even when the records come out of order (i.e., a newer record is sinked before and older one, the older one then overwrites the newer record).
This brings up the need for either a custom connector or a ksql/kstreams service that filters these out of order messages out.

## Solution
Add conditions (I called them drop conditions) that, if met, drop the incoming record instead of upserting/updating the table.
The fields on which the conditions apply can be specified as a comma separate list of field names using the config `update.drop.if.fields.older`, default is empty string.

Currently the update logic is implemented in GenericDatabaseDialect and available to all dialects, while the upsert logic is only working for MS SQL server (using MERGE conditions) and MySQL (using IF clauses in the UPDATE statement).
Certain dialects (e.g. SQLite) don't support this, so they will throw an UnsupportedOperationException as expected.
Still checking for more dialects supporting this.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Merge to master
