### PR TITLE
changed \n character to System.lineSeparator() api.

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
@@ -93,11 +93,11 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected =
-        "CREATE TABLE \"myTable\" (\n" + "\"c1\" INTEGER NOT NULL,\n" + "\"c2\" BIGINT NOT NULL,\n"
-        + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
-        + "\"c9\" SMALLINT DEFAULT 1,\n"
+        "CREATE TABLE \"myTable\" ("+System.lineSeparator() + "\"c1\" INTEGER NOT NULL,"+System.lineSeparator() + "\"c2\" BIGINT NOT NULL,"+System.lineSeparator()
+        + "\"c3\" VARCHAR(32672) NOT NULL,"+System.lineSeparator() + "\"c4\" VARCHAR(32672) NULL,"+System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator() + "\"c6\" TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() + "\"c8\" DECIMAL(31,4) NULL,"+System.lineSeparator()
+        + "\"c9\" SMALLINT DEFAULT 1,"+System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -109,16 +109,16 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
     dialect = createDialect();
 
     String expected =
-        "CREATE TABLE myTable (\n"
-        + "c1 INTEGER NOT NULL,\n"
-        + "c2 BIGINT NOT NULL,\n"
-        + "c3 VARCHAR(32672) NOT NULL,\n"
-        + "c4 VARCHAR(32672) NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\n"
-        + "c6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 DECIMAL(31,4) NULL,\n"
-        + "c9 SMALLINT DEFAULT 1,\n"
+        "CREATE TABLE myTable ("+System.lineSeparator()
+        + "c1 INTEGER NOT NULL,"+System.lineSeparator()
+        + "c2 BIGINT NOT NULL,"+System.lineSeparator()
+        + "c3 VARCHAR(32672) NOT NULL,"+System.lineSeparator()
+        + "c4 VARCHAR(32672) NULL,"+System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "c8 DECIMAL(31,4) NULL,"+System.lineSeparator()
+        + "c9 SMALLINT DEFAULT 1,"+System.lineSeparator()
         + "PRIMARY KEY(c1))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -127,15 +127,15 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
   @Test
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" \n"
-                    + "ADD \"c1\" INTEGER NOT NULL,\n"
-                    + "ADD \"c2\" BIGINT NOT NULL,\n"
-                    + "ADD \"c3\" VARCHAR(32672) NOT NULL,\n"
-                    + "ADD \"c4\" VARCHAR(32672) NULL,\n"
-                    + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
-                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD \"c8\" DECIMAL(31,4) NULL,\n"
+    String[] sql = {"ALTER TABLE \"myTable\" "+System.lineSeparator()
+                    + "ADD \"c1\" INTEGER NOT NULL,"+System.lineSeparator()
+                    + "ADD \"c2\" BIGINT NOT NULL,"+System.lineSeparator()
+                    + "ADD \"c3\" VARCHAR(32672) NOT NULL,"+System.lineSeparator()
+                    + "ADD \"c4\" VARCHAR(32672) NULL,"+System.lineSeparator()
+                    + "ADD \"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+                    + "ADD \"c8\" DECIMAL(31,4) NULL,"+System.lineSeparator()
                     + "ADD \"c9\" SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
@@ -146,15 +146,15 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
     dialect = createDialect();
 
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE myTable \n"
-                    + "ADD c1 INTEGER NOT NULL,\n"
-                    + "ADD c2 BIGINT NOT NULL,\n"
-                    + "ADD c3 VARCHAR(32672) NOT NULL,\n"
-                    + "ADD c4 VARCHAR(32672) NULL,\n"
-                    + "ADD c5 DATE DEFAULT '2001-03-15',\n"
-                    + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD c8 DECIMAL(31,4) NULL,\n"
+    String[] sql = {"ALTER TABLE myTable "+System.lineSeparator()
+                    + "ADD c1 INTEGER NOT NULL,"+System.lineSeparator()
+                    + "ADD c2 BIGINT NOT NULL,"+System.lineSeparator()
+                    + "ADD c3 VARCHAR(32672) NOT NULL,"+System.lineSeparator()
+                    + "ADD c4 VARCHAR(32672) NULL,"+System.lineSeparator()
+                    + "ADD c5 DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+                    + "ADD c6 TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+                    + "ADD c8 DECIMAL(31,4) NULL,"+System.lineSeparator()
                     + "ADD c9 SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -93,11 +94,11 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected =
-        "CREATE TABLE \"myTable\" (\n" + "\"c1\" INTEGER NOT NULL,\n" + "\"c2\" BIGINT NOT NULL,\n"
-        + "\"c3\" VARCHAR(32672) NOT NULL,\n" + "\"c4\" VARCHAR(32672) NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n" + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" DECIMAL(31,4) NULL,\n"
-        + "\"c9\" SMALLINT DEFAULT 1,\n"
+        "CREATE TABLE \"myTable\" ("+ System.lineSeparator() + "\"c1\" INTEGER NOT NULL,"+ System.lineSeparator() + "\"c2\" BIGINT NOT NULL,"+ System.lineSeparator()
+        + "\"c3\" VARCHAR(32672) NOT NULL,"+ System.lineSeparator() + "\"c4\" VARCHAR(32672) NULL,"+ System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15',"+ System.lineSeparator() + "\"c6\" TIME DEFAULT '00:00:00.000',"+ System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+ System.lineSeparator() + "\"c8\" DECIMAL(31,4) NULL,"+ System.lineSeparator()
+        + "\"c9\" SMALLINT DEFAULT 1,"+ System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -109,11 +110,11 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
     dialect = createDialect();
 
     String expected =
-        "CREATE TABLE myTable (\nc1 INTEGER NOT NULL,\nc2 BIGINT NOT NULL,\n"
-        + "c3 VARCHAR(32672) NOT NULL,\nc4 VARCHAR(32672) NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\nc6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\nc8 DECIMAL(31,4) NULL,\n"
-        + "c9 SMALLINT DEFAULT 1,\n"
+        "CREATE TABLE myTable ("+ System.lineSeparator() +"c1 INTEGER NOT NULL,"+ System.lineSeparator() +"c2 BIGINT NOT NULL,"+ System.lineSeparator()
+        + "c3 VARCHAR(32672) NOT NULL,"+ System.lineSeparator() +"c4 VARCHAR(32672) NULL,"+ System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15',"+ System.lineSeparator() +"c6 TIME DEFAULT '00:00:00.000',"+ System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+ System.lineSeparator() +"c8 DECIMAL(31,4) NULL,"+ System.lineSeparator()
+        + "c9 SMALLINT DEFAULT 1,"+ System.lineSeparator()
         + "PRIMARY KEY(c1))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -122,13 +123,13 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
   @Test
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE \"myTable\" \n" + "ADD \"c1\" INTEGER NOT NULL,\n"
-                    + "ADD \"c2\" BIGINT NOT NULL,\n" + "ADD \"c3\" VARCHAR(32672) NOT NULL,\n"
-                    + "ADD \"c4\" VARCHAR(32672) NULL,\n"
-                    + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
-                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD \"c8\" DECIMAL(31,4) NULL,\n"
+    String[] sql = {"ALTER TABLE \"myTable\" " + System.lineSeparator() + "ADD \"c1\" INTEGER NOT NULL,"+ System.lineSeparator()
+                    + "ADD \"c2\" BIGINT NOT NULL,"+ System.lineSeparator() + "ADD \"c3\" VARCHAR(32672) NOT NULL,"+ System.lineSeparator()
+                    + "ADD \"c4\" VARCHAR(32672) NULL,"+ System.lineSeparator()
+                    + "ADD \"c5\" DATE DEFAULT '2001-03-15',"+ System.lineSeparator()
+                    + "ADD \"c6\" TIME DEFAULT '00:00:00.000',"+ System.lineSeparator()
+                    + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+ System.lineSeparator()
+                    + "ADD \"c8\" DECIMAL(31,4) NULL,"+ System.lineSeparator()
                     + "ADD \"c9\" SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }
@@ -139,15 +140,15 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
     dialect = createDialect();
 
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
-    String[] sql = {"ALTER TABLE myTable \n"
-                    + "ADD c1 INTEGER NOT NULL,\n"
-                    + "ADD c2 BIGINT NOT NULL,\n"
-                    + "ADD c3 VARCHAR(32672) NOT NULL,\n"
-                    + "ADD c4 VARCHAR(32672) NULL,\n"
-                    + "ADD c5 DATE DEFAULT '2001-03-15',\n"
-                    + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
-                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-                    + "ADD c8 DECIMAL(31,4) NULL,\n"
+    String[] sql = {"ALTER TABLE myTable "+ System.lineSeparator()
+                    + "ADD c1 INTEGER NOT NULL,"+ System.lineSeparator()
+                    + "ADD c2 BIGINT NOT NULL,"+ System.lineSeparator()
+                    + "ADD c3 VARCHAR(32672) NOT NULL,"+ System.lineSeparator()
+                    + "ADD c4 VARCHAR(32672) NULL,"+ System.lineSeparator()
+                    + "ADD c5 DATE DEFAULT '2001-03-15',"+ System.lineSeparator()
+                    + "ADD c6 TIME DEFAULT '00:00:00.000',"+ System.lineSeparator()
+                    + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+ System.lineSeparator()
+                    + "ADD c8 DECIMAL(31,4) NULL,"+ System.lineSeparator()
                     + "ADD c9 SMALLINT DEFAULT 1"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -94,11 +94,11 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected =
-        "CREATE TABLE `myTable` (\n" + "`c1` INT NOT NULL,\n" + "`c2` BIGINT NOT NULL,\n" +
-        "`c3` TEXT NOT NULL,\n" + "`c4` TEXT NULL,\n" +
-        "`c5` DATE DEFAULT '2001-03-15',\n" + "`c6` TIME(3) DEFAULT '00:00:00.000',\n" +
-        "`c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" + "`c8` DECIMAL(65,4) NULL,\n" +
-        "`c9` TINYINT DEFAULT 1,\n" +
+        "CREATE TABLE `myTable` ("+System.lineSeparator() + "`c1` INT NOT NULL,"+System.lineSeparator() + "`c2` BIGINT NOT NULL,"+System.lineSeparator() +
+        "`c3` TEXT NOT NULL,"+System.lineSeparator() + "`c4` TEXT NULL,"+System.lineSeparator() +
+        "`c5` DATE DEFAULT '2001-03-15',"+System.lineSeparator() + "`c6` TIME(3) DEFAULT '00:00:00.000',"+System.lineSeparator() +
+        "`c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() + "`c8` DECIMAL(65,4) NULL,"+System.lineSeparator() +
+        "`c9` TINYINT DEFAULT 1,"+System.lineSeparator() +
         "PRIMARY KEY(`c1`))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -108,11 +108,11 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
     String[] sql = {
-        "ALTER TABLE `myTable` \n" + "ADD `c1` INT NOT NULL,\n" + "ADD `c2` BIGINT NOT NULL,\n" +
-        "ADD `c3` TEXT NOT NULL,\n" + "ADD `c4` TEXT NULL,\n" +
-        "ADD `c5` DATE DEFAULT '2001-03-15',\n" + "ADD `c6` TIME(3) DEFAULT '00:00:00.000',\n" +
-        "ADD `c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',\n" +
-        "ADD `c8` DECIMAL(65,4) NULL,\n" +
+        "ALTER TABLE `myTable` "+System.lineSeparator() + "ADD `c1` INT NOT NULL,"+System.lineSeparator() + "ADD `c2` BIGINT NOT NULL,"+System.lineSeparator() +
+        "ADD `c3` TEXT NOT NULL,"+System.lineSeparator() + "ADD `c4` TEXT NULL,"+System.lineSeparator() +
+        "ADD `c5` DATE DEFAULT '2001-03-15',"+System.lineSeparator() + "ADD `c6` TIME(3) DEFAULT '00:00:00.000',"+System.lineSeparator() +
+        "ADD `c7` DATETIME(3) DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() +
+        "ADD `c8` DECIMAL(65,4) NULL,"+System.lineSeparator() +
         "ADD `c9` TINYINT DEFAULT 1"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -125,13 +125,13 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
   @Test
   public void shouldBuildCreateQueryStatement() {
-    String expected = "CREATE TABLE \"myTable\" (\n" + "\"c1\" NUMBER(10,0) NOT NULL,\n" +
-                      "\"c2\" NUMBER(19,0) NOT NULL,\n" + "\"c3\" CLOB NOT NULL,\n" +
-                      "\"c4\" CLOB NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
-                      "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
-                      "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-                      "\"c8\" NUMBER(*,4) NULL,\n" +
-                      "\"c9\" NUMBER(1,0) DEFAULT 1,\n" +
+    String expected = "CREATE TABLE \"myTable\" ("+System.lineSeparator() + "\"c1\" NUMBER(10,0) NOT NULL,"+System.lineSeparator() +
+                      "\"c2\" NUMBER(19,0) NOT NULL,"+System.lineSeparator() + "\"c3\" CLOB NOT NULL,"+System.lineSeparator() +
+                      "\"c4\" CLOB NULL,"+System.lineSeparator() + "\"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator() +
+                      "\"c6\" DATE DEFAULT '00:00:00.000',"+System.lineSeparator() +
+                      "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() +
+                      "\"c8\" NUMBER(*,4) NULL,"+System.lineSeparator() +
+                      "\"c9\" NUMBER(1,0) DEFAULT 1,"+System.lineSeparator() +
                       "PRIMARY KEY(\"c1\"))";
     String sql = dialect.buildCreateTableStatement(tableId, sinkRecordFields);
     assertEquals(expected, sql);
@@ -141,15 +141,15 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   public void shouldBuildAlterTableStatement() {
     assertStatements(
         new String[]{
-            "ALTER TABLE \"myTable\" ADD(\n" +
-            "\"c1\" NUMBER(10,0) NOT NULL,\n" +
-            "\"c2\" NUMBER(19,0) NOT NULL,\n" +
-            "\"c3\" CLOB NOT NULL,\n" +
-            "\"c4\" CLOB NULL,\n" +
-            "\"c5\" DATE DEFAULT '2001-03-15',\n" +
-            "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
-            "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-            "\"c8\" NUMBER(*,4) NULL,\n" +
+            "ALTER TABLE \"myTable\" ADD("+System.lineSeparator() +
+            "\"c1\" NUMBER(10,0) NOT NULL,"+System.lineSeparator() +
+            "\"c2\" NUMBER(19,0) NOT NULL,"+System.lineSeparator() +
+            "\"c3\" CLOB NOT NULL,"+System.lineSeparator() +
+            "\"c4\" CLOB NULL,"+System.lineSeparator() +
+            "\"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator() +
+            "\"c6\" DATE DEFAULT '00:00:00.000',"+System.lineSeparator() +
+            "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() +
+            "\"c8\" NUMBER(*,4) NULL,"+System.lineSeparator() +
             "\"c9\" NUMBER(1,0) DEFAULT 1)"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
@@ -160,15 +160,15 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
 
     assertStatements(
         new String[]{
-            "ALTER TABLE myTable ADD(\n" +
-            "c1 NUMBER(10,0) NOT NULL,\n" +
-            "c2 NUMBER(19,0) NOT NULL,\n" +
-            "c3 CLOB NOT NULL,\n" +
-            "c4 CLOB NULL,\n" +
-            "c5 DATE DEFAULT '2001-03-15',\n" +
-            "c6 DATE DEFAULT '00:00:00.000',\n" +
-            "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
-            "c8 NUMBER(*,4) NULL,\n" +
+            "ALTER TABLE myTable ADD("+System.lineSeparator() +
+            "c1 NUMBER(10,0) NOT NULL,"+System.lineSeparator() +
+            "c2 NUMBER(19,0) NOT NULL,"+System.lineSeparator() +
+            "c3 CLOB NOT NULL,"+System.lineSeparator() +
+            "c4 CLOB NULL,"+System.lineSeparator() +
+            "c5 DATE DEFAULT '2001-03-15',"+System.lineSeparator() +
+            "c6 DATE DEFAULT '00:00:00.000',"+System.lineSeparator() +
+            "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() +
+            "c8 NUMBER(*,4) NULL,"+System.lineSeparator() +
             "c9 NUMBER(1,0) DEFAULT 1)"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -109,16 +109,16 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE \"myTable\" (\n"
-        + "\"c1\" INT NOT NULL,\n"
-        + "\"c2\" BIGINT NOT NULL,\n"
-        + "\"c3\" TEXT NOT NULL,\n"
-        + "\"c4\" TEXT NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
-        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" DECIMAL NULL,\n"
-        + "\"c9\" BOOLEAN DEFAULT TRUE,\n"
+        "CREATE TABLE \"myTable\" ("+System.lineSeparator()
+        + "\"c1\" INT NOT NULL,"+System.lineSeparator()
+        + "\"c2\" BIGINT NOT NULL,"+System.lineSeparator()
+        + "\"c3\" TEXT NOT NULL,"+System.lineSeparator()
+        + "\"c4\" TEXT NULL,"+System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "\"c6\" TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "\"c8\" DECIMAL NULL,"+System.lineSeparator()
+        + "\"c9\" BOOLEAN DEFAULT TRUE,"+System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -127,16 +127,16 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     dialect = createDialect();
 
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 INT NOT NULL,\n"
-        + "c2 BIGINT NOT NULL,\n"
-        + "c3 TEXT NOT NULL,\n"
-        + "c4 TEXT NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\n"
-        + "c6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 DECIMAL NULL,\n"
-        + "c9 BOOLEAN DEFAULT TRUE,\n"
+        "CREATE TABLE myTable ("+System.lineSeparator()
+        + "c1 INT NOT NULL,"+System.lineSeparator()
+        + "c2 BIGINT NOT NULL,"+System.lineSeparator()
+        + "c3 TEXT NOT NULL,"+System.lineSeparator()
+        + "c4 TEXT NULL,"+System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "c8 DECIMAL NULL,"+System.lineSeparator()
+        + "c9 BOOLEAN DEFAULT TRUE,"+System.lineSeparator()
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -146,15 +146,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldBuildAlterTableStatement() {
     assertEquals(
         Arrays.asList(
-            "ALTER TABLE \"myTable\" \n"
-            + "ADD \"c1\" INT NOT NULL,\n"
-            + "ADD \"c2\" BIGINT NOT NULL,\n"
-            + "ADD \"c3\" TEXT NOT NULL,\n"
-            + "ADD \"c4\" TEXT NULL,\n"
-            + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
-            + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
-            + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "ADD \"c8\" DECIMAL NULL,\n"
+            "ALTER TABLE \"myTable\" "+System.lineSeparator()
+            + "ADD \"c1\" INT NOT NULL,"+System.lineSeparator()
+            + "ADD \"c2\" BIGINT NOT NULL,"+System.lineSeparator()
+            + "ADD \"c3\" TEXT NOT NULL,"+System.lineSeparator()
+            + "ADD \"c4\" TEXT NULL,"+System.lineSeparator()
+            + "ADD \"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+            + "ADD \"c6\" TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+            + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+            + "ADD \"c8\" DECIMAL NULL,"+System.lineSeparator()
             + "ADD \"c9\" BOOLEAN DEFAULT TRUE"
         ),
         dialect.buildAlterTable(tableId, sinkRecordFields)
@@ -165,15 +165,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     assertEquals(
         Arrays.asList(
-            "ALTER TABLE myTable \n"
-            + "ADD c1 INT NOT NULL,\n"
-            + "ADD c2 BIGINT NOT NULL,\n"
-            + "ADD c3 TEXT NOT NULL,\n"
-            + "ADD c4 TEXT NULL,\n"
-            + "ADD c5 DATE DEFAULT '2001-03-15',\n"
-            + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
-            + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "ADD c8 DECIMAL NULL,\n"
+            "ALTER TABLE myTable "+System.lineSeparator()
+            + "ADD c1 INT NOT NULL,"+System.lineSeparator()
+            + "ADD c2 BIGINT NOT NULL,"+System.lineSeparator()
+            + "ADD c3 TEXT NOT NULL,"+System.lineSeparator()
+            + "ADD c4 TEXT NULL,"+System.lineSeparator()
+            + "ADD c5 DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+            + "ADD c6 TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+            + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+            + "ADD c8 DECIMAL NULL,"+System.lineSeparator()
             + "ADD c9 BOOLEAN DEFAULT TRUE"
         ),
         dialect.buildAlterTable(tableId, sinkRecordFields)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -143,16 +143,16 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE [myTable] (\n"
-        + "[c1] int NOT NULL,\n"
-        + "[c2] bigint NOT NULL,\n"
-        + "[c3] varchar(max) NOT NULL,\n"
-        + "[c4] varchar(max) NULL,\n"
-        + "[c5] date DEFAULT '2001-03-15',\n"
-        + "[c6] time DEFAULT '00:00:00.000',\n"
-        + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "[c8] decimal(38,4) NULL,\n"
-        + "[c9] bit DEFAULT 1,\n" +
+        "CREATE TABLE [myTable] ("+System.lineSeparator()
+        + "[c1] int NOT NULL,"+System.lineSeparator()
+        + "[c2] bigint NOT NULL,"+System.lineSeparator()
+        + "[c3] varchar(max) NOT NULL,"+System.lineSeparator()
+        + "[c4] varchar(max) NULL,"+System.lineSeparator()
+        + "[c5] date DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "[c6] time DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "[c8] decimal(38,4) NULL,"+System.lineSeparator()
+        + "[c9] bit DEFAULT 1,"+System.lineSeparator() +
         "PRIMARY KEY([c1]))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -160,16 +160,16 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 int NOT NULL,\n"
-        + "c2 bigint NOT NULL,\n"
-        + "c3 varchar(max) NOT NULL,\n"
-        + "c4 varchar(max) NULL,\n"
-        + "c5 date DEFAULT '2001-03-15',\n"
-        + "c6 time DEFAULT '00:00:00.000',\n"
-        + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 decimal(38,4) NULL,\n"
-        + "c9 bit DEFAULT 1,\n" +
+        "CREATE TABLE myTable ("+System.lineSeparator()
+        + "c1 int NOT NULL,"+System.lineSeparator()
+        + "c2 bigint NOT NULL,"+System.lineSeparator()
+        + "c3 varchar(max) NOT NULL,"+System.lineSeparator()
+        + "c4 varchar(max) NULL,"+System.lineSeparator()
+        + "c5 date DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "c6 time DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "c8 decimal(38,4) NULL,"+System.lineSeparator()
+        + "c9 bit DEFAULT 1,"+System.lineSeparator() +
         "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -179,15 +179,15 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
   public void shouldBuildAlterTableStatement() {
     assertStatements(
         new String[]{
-            "ALTER TABLE [myTable] ADD\n"
-            + "[c1] int NOT NULL,\n"
-            + "[c2] bigint NOT NULL,\n"
-            + "[c3] varchar(max) NOT NULL,\n"
-            + "[c4] varchar(max) NULL,\n"
-            + "[c5] date DEFAULT '2001-03-15',\n"
-            + "[c6] time DEFAULT '00:00:00.000',\n"
-            + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "[c8] decimal(38,4) NULL,\n"
+            "ALTER TABLE [myTable] ADD"+System.lineSeparator()
+            + "[c1] int NOT NULL,"+System.lineSeparator()
+            + "[c2] bigint NOT NULL,"+System.lineSeparator()
+            + "[c3] varchar(max) NOT NULL,"+System.lineSeparator()
+            + "[c4] varchar(max) NULL,"+System.lineSeparator()
+            + "[c5] date DEFAULT '2001-03-15',"+System.lineSeparator()
+            + "[c6] time DEFAULT '00:00:00.000',"+System.lineSeparator()
+            + "[c7] datetime2 DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+            + "[c8] decimal(38,4) NULL,"+System.lineSeparator()
             + "[c9] bit DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)
@@ -197,15 +197,15 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     dialect = createDialect();
     assertStatements(
         new String[]{
-            "ALTER TABLE myTable ADD\n"
-            + "c1 int NOT NULL,\n"
-            + "c2 bigint NOT NULL,\n"
-            + "c3 varchar(max) NOT NULL,\n"
-            + "c4 varchar(max) NULL,\n"
-            + "c5 date DEFAULT '2001-03-15',\n"
-            + "c6 time DEFAULT '00:00:00.000',\n"
-            + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',\n"
-            + "c8 decimal(38,4) NULL,\n"
+            "ALTER TABLE myTable ADD"+System.lineSeparator()
+            + "c1 int NOT NULL,"+System.lineSeparator()
+            + "c2 bigint NOT NULL,"+System.lineSeparator()
+            + "c3 varchar(max) NOT NULL,"+System.lineSeparator()
+            + "c4 varchar(max) NULL,"+System.lineSeparator()
+            + "c5 date DEFAULT '2001-03-15',"+System.lineSeparator()
+            + "c6 time DEFAULT '00:00:00.000',"+System.lineSeparator()
+            + "c7 datetime2 DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+            + "c8 decimal(38,4) NULL,"+System.lineSeparator()
             + "c9 bit DEFAULT 1"
         },
         dialect.buildAlterTable(tableId, sinkRecordFields)

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -118,16 +118,16 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE `myTable` (\n"
-        + "`c1` INTEGER NOT NULL,\n"
-        + "`c2` INTEGER NOT NULL,\n"
-        + "`c3` TEXT NOT NULL,\n"
-        + "`c4` TEXT NULL,\n"
-        + "`c5` NUMERIC DEFAULT '2001-03-15',\n"
-        + "`c6` NUMERIC DEFAULT '00:00:00.000',\n"
-        + "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "`c8` NUMERIC NULL,\n"
-        + "`c9` INTEGER DEFAULT 1,\n"
+        "CREATE TABLE `myTable` ("+System.lineSeparator()
+        + "`c1` INTEGER NOT NULL,"+System.lineSeparator()
+        + "`c2` INTEGER NOT NULL,"+System.lineSeparator()
+        + "`c3` TEXT NOT NULL,"+System.lineSeparator()
+        + "`c4` TEXT NULL,"+System.lineSeparator()
+        + "`c5` NUMERIC DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "`c6` NUMERIC DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "`c7` NUMERIC DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "`c8` NUMERIC NULL,"+System.lineSeparator()
+        + "`c9` INTEGER DEFAULT 1,"+System.lineSeparator()
         + "PRIMARY KEY(`c1`))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -135,16 +135,16 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 INTEGER NOT NULL,\n"
-        + "c2 INTEGER NOT NULL,\n"
-        + "c3 TEXT NOT NULL,\n"
-        + "c4 TEXT NULL,\n"
-        + "c5 NUMERIC DEFAULT '2001-03-15',\n"
-        + "c6 NUMERIC DEFAULT '00:00:00.000',\n"
-        + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 NUMERIC NULL,\n"
-        + "c9 INTEGER DEFAULT 1,\n"
+        "CREATE TABLE myTable ("+System.lineSeparator()
+        + "c1 INTEGER NOT NULL,"+System.lineSeparator()
+        + "c2 INTEGER NOT NULL,"+System.lineSeparator()
+        + "c3 TEXT NOT NULL,"+System.lineSeparator()
+        + "c4 TEXT NULL,"+System.lineSeparator()
+        + "c5 NUMERIC DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "c6 NUMERIC DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "c7 NUMERIC DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "c8 NUMERIC NULL,"+System.lineSeparator()
+        + "c9 INTEGER DEFAULT 1,"+System.lineSeparator()
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -110,16 +110,16 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
   @Test
   public void shouldBuildCreateTableStatement() {
     assertEquals(
-        "CREATE TABLE \"myTable\" (\n"
-        + "\"c1\" int NOT NULL,\n"
-        + "\"c2\" bigint NOT NULL,\n"
-        +"\"c3\" text NOT NULL,\n"
-        + "\"c4\" text NULL,\n"
-        + "\"c5\" date DEFAULT '2001-03-15',\n"
-        + "\"c6\" time DEFAULT '00:00:00.000',\n"
-        + "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" decimal(38,4) NULL,\n"
-        + "\"c9\" bit DEFAULT 1,\n" +
+        "CREATE TABLE \"myTable\" ("+System.lineSeparator()
+        + "\"c1\" int NOT NULL,"+System.lineSeparator()
+        + "\"c2\" bigint NOT NULL,"+System.lineSeparator()
+        +"\"c3\" text NOT NULL,"+System.lineSeparator()
+        + "\"c4\" text NULL,"+System.lineSeparator()
+        + "\"c5\" date DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "\"c6\" time DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "\"c8\" decimal(38,4) NULL,"+System.lineSeparator()
+        + "\"c9\" bit DEFAULT 1,"+System.lineSeparator() +
         "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -127,16 +127,16 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 int NOT NULL,\n"
-        + "c2 bigint NOT NULL,\n"
-        + "c3 text NOT NULL,\n"
-        + "c4 text NULL,\n"
-        + "c5 date DEFAULT '2001-03-15',\n"
-        + "c6 time DEFAULT '00:00:00.000',\n"
-        + "c7 datetime DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 decimal(38,4) NULL,\n"
-        + "c9 bit DEFAULT 1,\n" +
+        "CREATE TABLE myTable ("+System.lineSeparator()
+        + "c1 int NOT NULL,"+System.lineSeparator()
+        + "c2 bigint NOT NULL,"+System.lineSeparator()
+        + "c3 text NOT NULL,"+System.lineSeparator()
+        + "c4 text NULL,"+System.lineSeparator()
+        + "c5 date DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "c6 time DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "c7 datetime DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "c8 decimal(38,4) NULL,"+System.lineSeparator()
+        + "c9 bit DEFAULT 1,"+System.lineSeparator() +
         "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -181,10 +181,10 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
   public void shouldBuildAlterTableStatement() {
     List<String> statements = dialect.buildAlterTable(tableId, sinkRecordFields);
     String[] sql = {
-        "ALTER TABLE \"myTable\" ADD\n" + "\"c1\" int NOT NULL,\n" + "\"c2\" bigint NOT NULL,\n" +
-        "\"c3\" text NOT NULL,\n" + "\"c4\" text NULL,\n" +
-        "\"c5\" date DEFAULT '2001-03-15',\n" + "\"c6\" time DEFAULT '00:00:00.000',\n" +
-        "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',\n" + "\"c8\" decimal(38,4) NULL,\n" +
+        "ALTER TABLE \"myTable\" ADD"+System.lineSeparator() + "\"c1\" int NOT NULL,"+System.lineSeparator() + "\"c2\" bigint NOT NULL,"+System.lineSeparator() +
+        "\"c3\" text NOT NULL,"+System.lineSeparator() + "\"c4\" text NULL,"+System.lineSeparator() +
+        "\"c5\" date DEFAULT '2001-03-15',"+System.lineSeparator() + "\"c6\" time DEFAULT '00:00:00.000',"+System.lineSeparator() +
+        "\"c7\" datetime DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator() + "\"c8\" decimal(38,4) NULL,"+System.lineSeparator() +
         "\"c9\" bit DEFAULT 1"};
     assertStatements(sql, statements);
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
@@ -92,16 +92,16 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
   @Test
   public void shouldBuildCreateQueryStatement() {
     assertEquals(
-        "CREATE TABLE \"myTable\" (\n"
-        + "\"c1\" INT NOT NULL,\n"
-        + "\"c2\" INT NOT NULL,\n"
-        + "\"c3\" VARCHAR(1024) NOT NULL,\n"
-        + "\"c4\" VARCHAR(1024) NULL,\n"
-        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
-        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
-        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "\"c8\" DECIMAL(18,4) NULL,\n"
-        + "\"c9\" BOOLEAN DEFAULT 1,\n"
+        "CREATE TABLE \"myTable\" ("+System.lineSeparator()
+        + "\"c1\" INT NOT NULL,"+System.lineSeparator()
+        + "\"c2\" INT NOT NULL,"+System.lineSeparator()
+        + "\"c3\" VARCHAR(1024) NOT NULL,"+System.lineSeparator()
+        + "\"c4\" VARCHAR(1024) NULL,"+System.lineSeparator()
+        + "\"c5\" DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "\"c6\" TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "\"c8\" DECIMAL(18,4) NULL,"+System.lineSeparator()
+        + "\"c9\" BOOLEAN DEFAULT 1,"+System.lineSeparator()
         + "PRIMARY KEY(\"c1\"))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );
@@ -109,16 +109,16 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "CREATE TABLE myTable (\n"
-        + "c1 INT NOT NULL,\n"
-        + "c2 INT NOT NULL,\n"
-        + "c3 VARCHAR(1024) NOT NULL,\n"
-        + "c4 VARCHAR(1024) NULL,\n"
-        + "c5 DATE DEFAULT '2001-03-15',\n"
-        + "c6 TIME DEFAULT '00:00:00.000',\n"
-        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
-        + "c8 DECIMAL(18,4) NULL,\n"
-        + "c9 BOOLEAN DEFAULT 1,\n"
+        "CREATE TABLE myTable ("+System.lineSeparator()
+        + "c1 INT NOT NULL,"+System.lineSeparator()
+        + "c2 INT NOT NULL,"+System.lineSeparator()
+        + "c3 VARCHAR(1024) NOT NULL,"+System.lineSeparator()
+        + "c4 VARCHAR(1024) NULL,"+System.lineSeparator()
+        + "c5 DATE DEFAULT '2001-03-15',"+System.lineSeparator()
+        + "c6 TIME DEFAULT '00:00:00.000',"+System.lineSeparator()
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',"+System.lineSeparator()
+        + "c8 DECIMAL(18,4) NULL,"+System.lineSeparator()
+        + "c9 BOOLEAN DEFAULT 1,"+System.lineSeparator()
         + "PRIMARY KEY(c1))",
         dialect.buildCreateTableStatement(tableId, sinkRecordFields)
     );


### PR DESCRIPTION
## Problem
Issue #1024 Different OS has different line feed characters . Windows has default linefeed character '\r\n' , unix system has '\n'
Unit test has hardcoded line feed characters as \n . These test were not running on Windows system.

## Solution
changed \n character to System.lineSeparator() api.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
