### PR TITLE
Add WHERE clause to the config which will be applied on the tables/query #1022

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -44,9 +44,10 @@ public class BulkTableQuerier extends TableQuerier {
       QueryMode mode,
       String name,
       String topicPrefix,
+      String whereClause,
       String suffix
   ) {
-    super(dialect, mode, name, topicPrefix, suffix);
+    super(dialect, mode, name, topicPrefix, whereClause, suffix);
   }
 
   @Override
@@ -55,16 +56,19 @@ public class BulkTableQuerier extends TableQuerier {
     switch (mode) {
       case TABLE:
         builder.append("SELECT * FROM ").append(tableId);
-
+        
         break;
       case QUERY:
-        builder.append(query);  
+        builder.append(query);
         
         break;
       default:
         throw new ConnectException("Unknown mode: " + mode);
     }
 
+    if (!whereClause.isEmpty()) {
+      builder.append(" WHERE ").append(whereClause);
+    }
     addSuffixIfPresent(builder);
     
     String queryStr = builder.toString();

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -285,6 +285,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       "Suffix to append at the end of the generated query.";
   public static final String QUERY_SUFFIX_DISPLAY = "Query suffix";
 
+  public static final String QUERY_WHERE_CONFIG = "query.where";
+  public static final String QUERY_WHERE_DEFAULT = "";
+  public static final String QUERY_WHERE_DOC = 
+      "Filtering options as used in WHERE clause to include in the generated query.";
+  public static final String QUERY_WHERE_DISPLAY = "WHERE clause";
+  
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -546,7 +552,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         MODE_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        QUERY_SUFFIX_DISPLAY);
+        QUERY_SUFFIX_DISPLAY
+    ).define(
+        QUERY_WHERE_CONFIG,
+        Type.STRING,
+        QUERY_WHERE_DEFAULT,
+        Importance.MEDIUM,
+        QUERY_WHERE_DOC,
+        MODE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        QUERY_WHERE_DISPLAY);
   }
 
   private static final void addConnectorOptions(ConfigDef config) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -155,6 +155,8 @@ public class JdbcSourceTask extends SourceTask {
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
     TimeZone timeZone = config.timeZone();
     String suffix = config.getString(JdbcSourceTaskConfig.QUERY_SUFFIX_CONFIG).trim();
+    String whereClause
+        = config.getString(JdbcSourceTaskConfig.QUERY_WHERE_CONFIG).trim();
 
     for (String tableOrQuery : tablesOrQuery) {
       final List<Map<String, String>> tablePartitionsToCheck;
@@ -199,13 +201,18 @@ public class JdbcSourceTask extends SourceTask {
 
       String topicPrefix = config.topicPrefix();
 
+      Map<String, String> options = new HashMap<String, String>();
+      options.put("suffix", suffix);
+      options.put("whereClause", whereClause);
+      
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(
             new BulkTableQuerier(
-                dialect, 
-                queryMode, 
-                tableOrQuery, 
-                topicPrefix, 
+                dialect,
+                queryMode,
+                tableOrQuery,
+                topicPrefix,
+                whereClause,
                 suffix
             )
         );
@@ -221,7 +228,7 @@ public class JdbcSourceTask extends SourceTask {
                 offset,
                 timestampDelayInterval,
                 timeZone,
-                suffix
+                options
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -236,7 +243,7 @@ public class JdbcSourceTask extends SourceTask {
                 offset,
                 timestampDelayInterval,
                 timeZone,
-                suffix
+                options
             )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -251,7 +258,7 @@ public class JdbcSourceTask extends SourceTask {
                 offset,
                 timestampDelayInterval,
                 timeZone,
-                suffix
+                options
             )
         );
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -46,6 +46,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected final String query;
   protected final String topicPrefix;
   protected final TableId tableId;
+  protected final String whereClause;
   protected final String suffix;
 
   // Mutable state
@@ -62,6 +63,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       QueryMode mode,
       String nameOrQuery,
       String topicPrefix,
+      String whereClause,
       String suffix
   ) {
     this.dialect = dialect;
@@ -70,6 +72,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     this.query = mode.equals(QueryMode.QUERY) ? nameOrQuery : null;
     this.topicPrefix = topicPrefix;
     this.lastUpdate = 0;
+    this.whereClause = whereClause;
     this.suffix = suffix;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -303,7 +303,6 @@ public class TimestampIncrementingCriteria {
     //  timestamp 1235, id 22
     //  timestamp 1236, id 23
     // We should capture both id = 22 (an update) and id = 23 (a new row)
-    builder.append(" WHERE ");
     coalesceTimestampColumns(builder);
     builder.append(" < ? AND ((");
     coalesceTimestampColumns(builder);
@@ -321,7 +320,6 @@ public class TimestampIncrementingCriteria {
   }
 
   protected void incrementingWhereClause(ExpressionBuilder builder) {
-    builder.append(" WHERE ");
     builder.append(incrementingColumn);
     builder.append(" > ?");
     builder.append(" ORDER BY ");
@@ -330,7 +328,6 @@ public class TimestampIncrementingCriteria {
   }
 
   protected void timestampWhereClause(ExpressionBuilder builder) {
-    builder.append(" WHERE ");
     coalesceTimestampColumns(builder);
     builder.append(" > ? AND ");
     coalesceTimestampColumns(builder);

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -152,7 +152,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaInc.incrementingWhereClause(builder);
     assertEquals(
-        " WHERE \"myTable\".\"id\" > ? ORDER BY \"myTable\".\"id\" ASC",
+        "\"myTable\".\"id\" > ? ORDER BY \"myTable\".\"id\" ASC",
         builder.toString()
     );
 
@@ -160,7 +160,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaInc.incrementingWhereClause(builder);
     assertEquals(
-        " WHERE myTable.id > ? ORDER BY myTable.id ASC",
+        "myTable.id > ? ORDER BY myTable.id ASC",
         builder.toString()
     );
   }
@@ -170,8 +170,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaTs.timestampWhereClause(builder);
     assertEquals(
-        " WHERE "
-        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") > ? "
+        "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") > ? "
         + "AND "
         + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") < ? "
         + "ORDER BY "
@@ -184,8 +183,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaTs.timestampWhereClause(builder);
     assertEquals(
-        " WHERE "
-        + "COALESCE(myTable.ts1,myTable.ts2) > ? "
+        "COALESCE(myTable.ts1,myTable.ts2) > ? "
         + "AND "
         + "COALESCE(myTable.ts1,myTable.ts2) < ? "
         + "ORDER BY "
@@ -200,8 +198,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaIncTs.timestampIncrementingWhereClause(builder);
     assertEquals(
-        " WHERE "
-        + "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") < ? "
+        "COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") < ? "
         + "AND ("
         + "(COALESCE(\"myTable\".\"ts1\",\"myTable\".\"ts2\") = ? AND \"myTable\".\"id\" > ?) "
         + "OR "
@@ -215,8 +212,7 @@ public class TimestampIncrementingCriteriaTest {
     builder = builder();
     criteriaIncTs.timestampIncrementingWhereClause(builder);
     assertEquals(
-        " WHERE "
-        + "COALESCE(myTable.ts1,myTable.ts2) < ? "
+        "COALESCE(myTable.ts1,myTable.ts2) < ? "
         + "AND ("
         + "(COALESCE(myTable.ts1,myTable.ts2) = ? AND myTable.id > ?) "
         + "OR "


### PR DESCRIPTION
## Problem
##### Allow developers to add a WHERE clause in the connector config. Connectors may need to filter data from source.

See issue #1022 

## Solution
##### Add a new configuration property 'query.where' which can be used to specify the WHERE clause that should be added to the generated query.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
