### PR TITLE
MINOR: Add validation that `table.name.format` is non-empty

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -382,6 +382,7 @@ public class JdbcSinkConfig extends AbstractConfig {
             TABLE_NAME_FORMAT,
             ConfigDef.Type.STRING,
             TABLE_NAME_FORMAT_DEFAULT,
+            new ConfigDef.NonEmptyString(),
             ConfigDef.Importance.MEDIUM,
             TABLE_NAME_FORMAT_DOC,
             DATAMAPPING_GROUP,

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -51,6 +51,12 @@ public class JdbcSinkConfigTest {
     createConfig();
   }
 
+  @Test(expected = ConfigException.class)
+  public void shouldFailToCreateConfigWithEmptyTableNameFormat() {
+    props.put(JdbcSinkConfig.TABLE_NAME_FORMAT, "");
+    createConfig();
+  }
+
   @Test
   public void shouldCreateConfigWithMinimalConfigs() {
     createConfig();


### PR DESCRIPTION
## Problem
Without validation, a configuration with empty `table.name.format` is allowed to create the connector but fails later on in writer with exception `Destination table name for topic 'redacted' is empty using the format string ''`

## Solution
Add non-empty string validation to the configdef.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Added unittest in `JdbcSinkConfigTest`

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Included in bugfix release of `10.0.x` and going forward.