### PR TITLE
informix dialect added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.ibm.informix</groupId>
+            <artifactId>informix-jdbc-complete</artifactId>
+            <version>4.50.4.1</version>
+        </dependency>
+        <dependency>
             <!--
             Include all of the production JARs without observability fixes.
             See https://www.oracle.com/database/technologies/maven-central-guide.html
@@ -306,6 +311,7 @@
                                 <tag>sap hana</tag>
                                 <tag>derby</tag>
                                 <tag>sqlite</tag>
+                                <tag>informix</tag>
                             </tags>
 
                             <confluentControlCenterIntegration>true</confluentControlCenterIntegration>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/InformixDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/InformixDatabaseDialect.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.util.Collection;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
+import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.TableId;
+
+/**
+ * A {@link DatabaseDialect} for IBM INFORMIX.
+ */
+public class InformixDatabaseDialect extends GenericDatabaseDialect {
+
+  /**
+     * The provider for {@link InformixDatabaseDialect}.
+     */
+  public static class Provider extends SubprotocolBasedProvider {
+    public Provider() {
+      super(InformixDatabaseDialect.class.getSimpleName(), "informix-sqli");
+    }
+
+    @Override
+      public DatabaseDialect create(AbstractConfig config) {
+      return new InformixDatabaseDialect(config);
+    }
+  }
+
+  /**
+     * Create a new dialect instance with the given connector configuration.
+     *
+     * @param config the connector configuration; may not be null
+     */
+  public InformixDatabaseDialect(AbstractConfig config) {
+    super(config, new IdentifierRules(".", "\"", "\""));
+  }
+
+  @Override
+    protected String currentTimestampDatabaseQuery() {
+    return "SELECT  CURRENT FROM sysmaster:informix.sysdual ";
+  }
+
+  @Override
+    protected String checkConnectionQuery() {
+    return "SELECT 1 FROM sysmaster:informix.sysdual ";
+  }
+
+  @Override
+    protected String getSqlType(SinkRecordField field) {
+    if (field.schemaName() != null) {
+      switch (field.schemaName()) {
+        case Decimal.LOGICAL_NAME:
+          return "DECIMAL(31," + field.schemaParameters().get(Decimal.SCALE_FIELD) + ")";
+        case Date.LOGICAL_NAME:
+          return "DATE";
+        case Time.LOGICAL_NAME:
+          return "TIME";
+        case Timestamp.LOGICAL_NAME:
+          return "TIMESTAMP";
+        default:
+                    // fall through to normal types
+      }
+    }
+    switch (field.schemaType()) {
+      case INT8:
+        return "SMALLINT";
+      case INT16:
+        return "SMALLINT";
+      case INT32:
+        return "INTEGER";
+      case INT64:
+        return "BIGINT";
+      case FLOAT32:
+        return "FLOAT";
+      case FLOAT64:
+        return "DOUBLE";
+      case BOOLEAN:
+        return "SMALLINT";
+      case STRING:
+        return "VARCHAR(32672)";
+      case BYTES:
+        return "BLOB(64000)";
+      default:
+        return super.getSqlType(field);
+    }
+  }
+
+  @Override
+    public String buildUpsertQueryStatement(
+        final TableId table,
+        Collection<ColumnId> keyColumns,
+        Collection<ColumnId> nonKeyColumns
+  ) {
+    // http://lpar.ath0.com/2013/08/12/upsert-in-db2/
+    final Transform<ColumnId> transform = (builder, col) -> {
+      builder.append(table)
+              .append(".")
+              .appendColumnName(col.name())
+              .append("=DAT.")
+              .appendColumnName(col.name());
+    };
+
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("merge into ");
+    builder.append(table);
+    builder.append(" using (values(");
+    builder.appendList()
+          .delimitedBy(", ")
+          .transformedBy(ExpressionBuilder.placeholderInsteadOfColumnNames("?"))
+          .of(keyColumns, nonKeyColumns);
+    builder.append(")) as DAT(");
+    builder.appendList()
+          .delimitedBy(", ")
+          .transformedBy(ExpressionBuilder.columnNames())
+          .of(keyColumns, nonKeyColumns);
+    builder.append(") on ");
+    builder.appendList()
+          .delimitedBy(" and ")
+          .transformedBy(transform)
+          .of(keyColumns);
+    if (nonKeyColumns != null && !nonKeyColumns.isEmpty()) {
+      builder.append(" when matched then update set ");
+      builder.appendList()
+              .delimitedBy(", ")
+              .transformedBy(transform)
+              .of(nonKeyColumns);
+    }
+
+    builder.append(" when not matched then insert(");
+    builder.appendList().delimitedBy(",").of(nonKeyColumns, keyColumns);
+    builder.append(") values(");
+    builder.appendList()
+          .delimitedBy(",")
+          .transformedBy(ExpressionBuilder.columnNamesWithPrefix("DAT."))
+          .of(nonKeyColumns, keyColumns);
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
+    protected String sanitizedUrl(String url) {
+    // INFORMIX has semicolon delimited property name-value pairs
+    return super.sanitizedUrl(url)
+          .replaceAll("(?i)([:;]password=)[^;]*", "$1****");
+  }
+}

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -9,3 +9,4 @@ io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SybaseDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.VerticaDatabaseDialect$Provider
+io.confluent.connect.jdbc.dialect.InformixDatabaseDialect$Provider


### PR DESCRIPTION
## Problem

Current JDBC connector doesn't support timestamp mode on informix DB

## Solution

I have added new dialect to support mode timestamp in informix source connector

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ X] Unit tests
- [ X] Integration tests
- [ X] System tests
- [ X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
adding this feature won't affect existing pipeline, I have tested this in my production environment. its running fine without any issues to the existing connector.

<!-- Are you backporting or merging to master? -->
yes
<!-- If you are reverting or rolling back, is it safe? --> 
yes
