### PR TITLE
PostGIS support using Debezium libaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>42.2.19</postgresql.version>
+        <debezium.version>1.5.0.Final</debezium.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>8.4.1.jre8</mssqlserver.jdbc.driver.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
@@ -122,6 +123,11 @@
             <artifactId>jtds</artifactId>
             <version>${jtds.driver.version}</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <version>${debezium.version}</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -15,18 +15,11 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.io.IOException;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
-import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.Time;
-import org.apache.kafka.connect.data.Timestamp;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,21 +28,50 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
-import io.confluent.connect.jdbc.util.ColumnDefinition;
+import javax.xml.bind.DatatypeConverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableDefinitionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
+import io.debezium.data.geometry.Geography;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Point;
+import io.debezium.time.ZonedTime;
+import io.debezium.time.ZonedTimestamp;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.junit.Test;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
+  // 'SRID=3187;POINT(174.9479 -36.7208)'::postgis.geometry
+  private static final Struct GEOMETRY_VALUE =
+          Geometry.createValue(Geometry.schema(),
+                  DatatypeConverter.parseHexBinary(
+                          "0101000020730C00001C7C613255DE6540787AA52C435C42C0"),
+                  3187);
+  // 'MULTILINESTRING((169.1321 -44.7032, 167.8974 -44.6414))'::postgis.geography
+  private static final Struct GEOGRAPHY_VALUE =
+          Geography.createValue(Geography.schema(),
+                  DatatypeConverter.parseHexBinary(
+                          "0105000020E610000001000000010200000002000000A779C7293A2465400B462575025A46C0C66D3480B7FC6440C3D32B65195246C0"),
+                  4326);
+  private static final Struct POINT_VALUE = Point.createValue(Point.builder().build(), 1, 1);
+
   @Override
   protected PostgreSqlDatabaseDialect createDialect() {
-    return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:postgresql://something"));
+    return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:postgresql://something/"));
   }
 
   @Test
@@ -95,6 +117,12 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     verifyDataTypeMapping("DATE", Date.SCHEMA);
     verifyDataTypeMapping("TIME", Time.SCHEMA);
     verifyDataTypeMapping("TIMESTAMP", Timestamp.SCHEMA);
+    verifyDataTypeMapping("TIMETZ", ZonedTime.schema());
+    verifyDataTypeMapping("TIMESTAMPTZ", ZonedTimestamp.schema());
+    verifyDataTypeMapping("GEOMETRY", Geometry.schema());
+    // Geography is also derived from Geometry
+    verifyDataTypeMapping("GEOMETRY", Geography.schema());
+    verifyDataTypeMapping("GEOMETRY", Point.schema());
   }
 
   @Test
@@ -110,6 +138,13 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Test
   public void shouldMapTimestampSchemaTypeToTimestampSqlType() {
     assertTimestampMapping("TIMESTAMP");
+  }
+
+  @Test
+  public void shouldMapGeometryTypeToPostGisTypes() {
+    assertMapping("GEOMETRY", Geometry.schema());
+    assertMapping("GEOMETRY", Geography.schema());
+    assertMapping("GEOMETRY", Point.schema());
   }
 
   @Test
@@ -421,6 +456,31 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Override
   public void bindFieldArrayUnsupported() throws SQLException {
       // Overridden simply to dummy out the test.
+  }
+
+  @Test
+  public void bindFieldZonedTimeValue() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    String value = "10:15:30+01:00";
+    super.verifyBindField(++index, ZonedTime.schema(), value).setObject(index, value, Types.OTHER);
+  }
+
+  @Test
+  public void bindFieldZonedTimestampValue() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    String value = "2021-05-01T18:00:00.030431+02:00";
+    super.verifyBindField(++index, ZonedTimestamp.schema(), value).setObject(index, value, Types.OTHER);
+  }
+
+  @Test
+  public void bindFieldPostGisValues() throws SQLException, IOException {
+    int index = ThreadLocalRandom.current().nextInt();
+    super.verifyBindField(++index, Geometry.schema(), GEOMETRY_VALUE)
+            .setBytes(index, GEOMETRY_VALUE.getBytes(Geometry.WKB_FIELD));
+    super.verifyBindField(++index, Geography.schema(), GEOGRAPHY_VALUE)
+            .setBytes(index, GEOGRAPHY_VALUE.getBytes(Geometry.WKB_FIELD));
+    super.verifyBindField(++index, Geometry.schema(), POINT_VALUE)
+            .setBytes(index, POINT_VALUE.getBytes(Geometry.WKB_FIELD));
   }
 
   @Test


### PR DESCRIPTION
## Problem
PostGIS data types were not supported by Kafka JDBC sink connector  

## Solution
Added support using the DBZ core library. 
Still the array of postgis datatypes needs to be supported.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x ] no

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
