### PR TITLE
FF-5018: JDBC Source Connector needs to provide column precision for DECIMAL (NUMERIC) data types

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1096,7 +1096,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         glog.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
         SchemaBuilder fieldBuilder = Decimal.builder(scale);
-        // fieldBuilder.parameter("connect.decimal.precision", Integer.toString(precision));
+        fieldBuilder.parameter("connect.decimal.precision", Integer.toString(precision));
         if (optional) {
           fieldBuilder.optional();
         }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -108,6 +108,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   // The maximum precision that can be achieved in a signed 64-bit integer is 2^63 ~= 9.223372e+18
   private static final int MAX_INTEGER_TYPE_PRECISION = 18;
 
+  private static final String PRECISION_FIELD = "connect.decimal.precision";
+
   /**
    * The provider for {@link GenericDatabaseDialect}.
    */
@@ -1096,7 +1098,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         glog.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
         SchemaBuilder fieldBuilder = Decimal.builder(scale);
-        fieldBuilder.parameter("connect.decimal.precision", Integer.toString(precision));
+        fieldBuilder.parameter(PRECISION_FIELD, Integer.toString(precision));
         if (optional) {
           fieldBuilder.optional();
         }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1096,7 +1096,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         glog.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
         SchemaBuilder fieldBuilder = Decimal.builder(scale);
-        fieldBuilder.parameter("connect.decimal.precision", Integer.toString(precision));
+        // fieldBuilder.parameter("connect.decimal.precision", Integer.toString(precision));
         if (optional) {
           fieldBuilder.optional();
         }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1096,6 +1096,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         glog.debug("DECIMAL with precision: '{}' and scale: '{}'", precision, scale);
         scale = decimalScale(columnDefn);
         SchemaBuilder fieldBuilder = Decimal.builder(scale);
+        fieldBuilder.parameter("connect.decimal.precision", Integer.toString(precision));
         if (optional) {
           fieldBuilder.optional();
         }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTypeTest.java
@@ -113,7 +113,6 @@ public abstract class BaseDialectTypeTest<T extends GenericDatabaseDialect> {
     Field field = fields.get(0);
     assertEquals(expectedType, field.schema().type());
 
-
     // Set up the ResultSet
     when(resultSet.getBigDecimal(1, scale)).thenReturn(BIG_DECIMAL);
     when(resultSet.getBigDecimal(1, -scale)).thenReturn(BIG_DECIMAL);

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -230,6 +230,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testDecimal() throws Exception {
+    // Populate precision on schema
     SchemaBuilder schemaBuilder = Decimal.builder(2);
     schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 
@@ -240,6 +241,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testNullableDecimal() throws Exception {
+    // Populate precision on schema
     SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
     schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -237,8 +237,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
         false,
         new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
         schemaBuilder.build(),
-        new BigDecimal(new BigInteger("12345"),
-  2));
+        new BigDecimal(new BigInteger("12345"), 2));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -19,6 +19,7 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
@@ -229,18 +230,25 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testDecimal() throws Exception {
+    SchemaBuilder schemaBuilder = Decimal.builder(2);
+    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-                   Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
+                  schemaBuilder.build(),new BigDecimal(new BigInteger("12345"), 2));
   }
 
   @Test
   public void testNullableDecimal() throws Exception {
+    SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
+    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-                   Decimal.builder(2).optional().build(),
+                   schemaBuilder.build(),
                    new BigDecimal(new BigInteger("12345"), 2));
-    typeConversion("DECIMAL(5,2)", true, null, Decimal.builder(2).optional().build(),
+    typeConversion("DECIMAL(5,2)", true, null,
+                   schemaBuilder.build(),
                    null);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -230,9 +230,8 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testDecimal() throws Exception {
-    SchemaBuilder schemaBuilder = Decimal.builder(2)
-        .parameter("connect.decimal.precision", Integer.toString(5))
-        .optional();
+    SchemaBuilder schemaBuilder = Decimal.builder(2);
+    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
@@ -241,9 +240,8 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testNullableDecimal() throws Exception {
-    SchemaBuilder schemaBuilder = Decimal.builder(2)
-        .parameter("connect.decimal.precision", Integer.toString(5))
-        .optional();
+    SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
+    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -240,7 +240,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-                  Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
+                   Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
   }
 
   @Test
@@ -251,7 +251,7 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-                    Decimal.builder(2).optional().build(),
+                   Decimal.builder(2).optional().build(),
                    new BigDecimal(new BigInteger("12345"), 2));
     typeConversion("DECIMAL(5,2)", true, null, Decimal.builder(2).optional().build(),
                    null);

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -230,8 +230,9 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testDecimal() throws Exception {
-    SchemaBuilder schemaBuilder = Decimal.builder(2);
-    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+    SchemaBuilder schemaBuilder = Decimal.builder(2)
+        .parameter("connect.decimal.precision", Integer.toString(5))
+        .optional();
 
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
@@ -240,8 +241,9 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testNullableDecimal() throws Exception {
-    SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
-    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+    SchemaBuilder schemaBuilder = Decimal.builder(2)
+        .parameter("connect.decimal.precision", Integer.toString(5))
+        .optional();
 
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -19,7 +19,7 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
+//import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
@@ -231,27 +231,38 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
   @Test
   public void testDecimal() throws Exception {
     // Populate precision on schema
-    SchemaBuilder schemaBuilder = Decimal.builder(2);
-    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+    // SchemaBuilder schemaBuilder = Decimal.builder(2);
+    // schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+
+    // typeConversion("DECIMAL(5,2)", false,
+    //    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
+    //    schemaBuilder.build(),new BigDecimal(new BigInteger("12345"), 2));
 
     typeConversion("DECIMAL(5,2)", false,
                    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-                  schemaBuilder.build(),new BigDecimal(new BigInteger("12345"), 2));
+                  Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
   }
 
   @Test
   public void testNullableDecimal() throws Exception {
     // Populate precision on schema
-    SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
-    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+    // SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
+    // schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 
     typeConversion("DECIMAL(5,2)", true,
                    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-                   schemaBuilder.build(),
+                    Decimal.builder(2).optional().build(),
                    new BigDecimal(new BigInteger("12345"), 2));
-    typeConversion("DECIMAL(5,2)", true, null,
-                   schemaBuilder.build(),
+    typeConversion("DECIMAL(5,2)", true, null, Decimal.builder(2).optional().build(),
                    null);
+
+    // typeConversion("DECIMAL(5,2)", true,
+    //    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
+    //    schemaBuilder.build(),
+    //    new BigDecimal(new BigInteger("12345"), 2));
+    // typeConversion("DECIMAL(5,2)", true, null,
+    //    schemaBuilder.build(),
+    //    null);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskConversionTest.java
@@ -19,7 +19,7 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-//import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
@@ -230,39 +230,29 @@ public class JdbcSourceTaskConversionTest extends JdbcSourceTaskTestBase {
 
   @Test
   public void testDecimal() throws Exception {
-    // Populate precision on schema
-    // SchemaBuilder schemaBuilder = Decimal.builder(2);
-    // schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+    SchemaBuilder schemaBuilder = Decimal.builder(2);
+    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 
-    // typeConversion("DECIMAL(5,2)", false,
-    //    new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-    //    schemaBuilder.build(),new BigDecimal(new BigInteger("12345"), 2));
-
-    typeConversion("DECIMAL(5,2)", false,
-                   new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
-                   Decimal.schema(2),new BigDecimal(new BigInteger("12345"), 2));
+    typeConversion("DECIMAL(5,2)",
+        false,
+        new EmbeddedDerby.Literal("CAST (123.45 AS DECIMAL(5,2))"),
+        schemaBuilder.build(),
+        new BigDecimal(new BigInteger("12345"),
+  2));
   }
 
   @Test
   public void testNullableDecimal() throws Exception {
-    // Populate precision on schema
-    // SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
-    // schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
+    SchemaBuilder schemaBuilder = Decimal.builder(2).optional();
+    schemaBuilder.parameter("connect.decimal.precision", Integer.toString(5));
 
     typeConversion("DECIMAL(5,2)", true,
-                   new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-                   Decimal.builder(2).optional().build(),
-                   new BigDecimal(new BigInteger("12345"), 2));
-    typeConversion("DECIMAL(5,2)", true, null, Decimal.builder(2).optional().build(),
-                   null);
-
-    // typeConversion("DECIMAL(5,2)", true,
-    //    new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
-    //    schemaBuilder.build(),
-    //    new BigDecimal(new BigInteger("12345"), 2));
-    // typeConversion("DECIMAL(5,2)", true, null,
-    //    schemaBuilder.build(),
-    //    null);
+        new EmbeddedDerby.Literal("CAST(123.45 AS DECIMAL(5,2))"),
+        schemaBuilder.build(),
+        new BigDecimal(new BigInteger("12345"), 2));
+    typeConversion("DECIMAL(5,2)", true, null,
+        schemaBuilder.build(),
+        null);
   }
 
   @Test


### PR DESCRIPTION
## Problem

We currently have precision available to us, but we don't add it to the Connect Schema.  This one-line change adds the precision.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
