### PR TITLE
CCDB-3981: Add a null check for get after auto create for JDBC connector

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,13 +7,13 @@
 <suppressions>
 
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|DbStructure).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(BufferedRecords|DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>
+              files="(BufferedRecords|DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect|DbStructure).java"/>
 
     <suppress checks="JavaNCSS"
               files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -111,10 +111,12 @@ public class DbStructure {
 
     final TableDefinition tableDefn = tableDefns.get(connection, tableId);
     if (tableDefn == null) {
-      throw new ConnectException(
-          "Unable to auto create table " + tableId
-              + " . DDL statement for auto creation was successful"
-                  + " but table does not exist in database."
+      throw new SQLException(
+          "Table with id " + tableId +  "does not exist in database."
+              + " Since we've either already auto-created the table or confirmed"
+              + " it existed before this point, it must mean this user does not"
+              + " have the permission to read the column data for this table"
+              + " (assuming the database is ACID compliant)."
       );
     }
 
@@ -188,11 +190,15 @@ public class DbStructure {
 
     if (tableDefns.refresh(connection, tableId) == null) {
       // Refresh should not make the table null.
-      throw new ConnectException(
-              "Unable to auto create or update table. Ddl statements to create or update"
-                  + " the table was successful but table does not exist. Table id" + tableId
+      throw new SQLException(
+        "Table with id " + tableId +  "does not exist in database."
+                + " Since we've either already auto-created the table or confirmed"
+                + " it existed before this point, it must mean this user does not"
+                + " have the permission to read the column data for this table"
+                + " (assuming the database is ACID compliant)."
       );
     }
+
     return true;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -110,6 +110,13 @@ public class DbStructure {
     //   We also don't check if the data types for columns that do line-up are compatible.
 
     final TableDefinition tableDefn = tableDefns.get(connection, tableId);
+    if (tableDefn == null) {
+      throw new ConnectException(
+          "Unable to auto create table " + tableId
+              + " . DDL statement for auto creation was successful"
+                  + " but table does not exist in database."
+      );
+    }
 
     // FIXME: SQLite JDBC driver seems to not always return the PK column names?
     //    if (!tableMetadata.getPrimaryKeyColumnNames().equals(fieldsMetadata.keyFieldNames)) {
@@ -179,7 +186,13 @@ public class DbStructure {
       );
     }
 
-    tableDefns.refresh(connection, tableId);
+    if (tableDefns.refresh(connection, tableId) == null) {
+      // Refresh should not make the table null.
+      throw new ConnectException(
+              "Unable to auto create or update table. Ddl statements to create or update"
+                  + " the table was successful but table does not exist. Table id" + tableId
+      );
+    }
     return true;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -115,8 +115,7 @@ public class DbStructure {
           "Table with id " + tableId +  "does not exist in database."
               + " Since we've either already auto-created the table or confirmed"
               + " it existed before this point, it must mean this user does not"
-              + " have the permission to read the column data for this table"
-              + " (assuming the database is ACID compliant)."
+              + " have the permission to read the column data for this table."
       );
     }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -193,8 +193,7 @@ public class DbStructure {
         "Table with id " + tableId +  "does not exist in database."
                 + " Since we've either already auto-created the table or confirmed"
                 + " it existed before this point, it must mean this user does not"
-                + " have the permission to read the column data for this table"
-                + " (assuming the database is ACID compliant)."
+                + " have the permission to read the column data for this table."
       );
     }
 


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

## Problem
There is a possibility for an NPE to happen if the DDL statements happen without an exception, but describe/get table returns null in the database.  Generally RDS guarantees DDLs are consistent with the get but we've encountered a database where this happens. 

 
## Solution
Add more null checks before and after `amendIfNecessary ` 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Pint merge up