### PR TITLE
CC-14541 : Exclude zk and netty from packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,21 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- common pom defines them in dependency management and hence they're pulled in compile scope.
+        Explicitly define them as test to prevent from them form being packaged. -->
+        <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+            <version>${zkclient.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Problem

Vulnerabilities with below versions as reported by twist lock

org.apache.zookeeper_zookeeper 3.4.13-- Please upgrade to the latest version listed in the following CVEs 
io.netty_netty 3.10.6.Final-- Please upgrade to the latest version listed in the following CVEs 

## Solution

Explicitly mark the ZK dependencies as `test`. common pom defines them in dependency management and hence they are marked as `compile` by maven and included in the final package. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
