### PR TITLE
Introduce option to enable/disable HOLDLOCK when using MERGE INTO in MS SQL Server

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -325,7 +325,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     ExpressionBuilder builder = expressionBuilder();
     builder.append("merge into ");
     builder.append(table);
-    if (this.config.getBoolean(JdbcSinkConfig.MSSQL_USE_MERGE_HOLDLOCK)) {
+    if (((JdbcSinkConfig) this.config).useHoldlockInMerge) {
       builder.append(" with (HOLDLOCK)");
     }
     builder.append(" AS target using (select ");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -324,7 +325,10 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     ExpressionBuilder builder = expressionBuilder();
     builder.append("merge into ");
     builder.append(table);
-    builder.append(" with (HOLDLOCK) AS target using (select ");
+    if (this.config.getBoolean(JdbcSinkConfig.MSSQL_USE_MERGE_HOLDLOCK)) {
+      builder.append(" with (HOLDLOCK)");
+    }
+    builder.append(" AS target using (select ");
     builder.appendList()
            .delimitedBy(", ")
            .transformedBy(ExpressionBuilder.columnNamesWithPrefix("? AS "))

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -259,6 +259,13 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   private static final EnumRecommender TABLE_TYPES_RECOMMENDER =
       EnumRecommender.in(TableType.values());
+  public static final String MSSQL_USE_MERGE_HOLDLOCK = "mssql.use.merge.holdlock";
+  private static final String MSSQL_USE_MERGE_HOLDLOCK_DEFAULT = "true";
+  private static final String MSSQL_USE_MERGE_HOLDLOCK_DOC =
+      "Whether to use HOLDLOCK when performing a MERGE INTO upsert statement "
+      + "NOTE: MS SQL Server only ";
+  private static final String MSSQL_USE_MERGE_HOLDLOCK_DISPLAY =
+      "MS SQL Server - Use HOLDLOCK in MERGE";
 
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
         // Connection
@@ -467,6 +474,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             QUOTE_SQL_IDENTIFIERS_DISPLAY,
             QUOTE_METHOD_RECOMMENDER
         )
+        .define(
+            MSSQL_USE_MERGE_HOLDLOCK,
+            ConfigDef.Type.BOOLEAN,
+            MSSQL_USE_MERGE_HOLDLOCK_DEFAULT,
+            ConfigDef.Importance.LOW,
+            MSSQL_USE_MERGE_HOLDLOCK_DOC,
+            DDL_GROUP,
+            4,
+            ConfigDef.Width.MEDIUM,
+            MSSQL_USE_MERGE_HOLDLOCK_DISPLAY
+        )
         // Retries
         .define(
             MAX_RETRIES,
@@ -513,6 +531,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String dialectName;
   public final TimeZone timeZone;
   public final EnumSet<TableType> tableTypes;
+  public final boolean useHoldlockInMerge;
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
@@ -536,6 +555,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
     String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
     timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
+    useHoldlockInMerge = getBoolean(MSSQL_USE_MERGE_HOLDLOCK);
 
     if (deleteEnabled && pkMode != PrimaryKeyMode.RECORD_KEY) {
       throw new ConfigException(

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -87,6 +87,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   }
 
   protected QuoteMethod quoteIdentfiiers;
+  protected Boolean useHoldlockInMerge;
   protected TableId tableId;
   protected ColumnId columnPK1;
   protected ColumnId columnPK2;
@@ -188,6 +189,13 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     Map<String, String> connProps = new HashMap<>();
     connProps.putAll(propertiesFromPairs(propertyPairs));
     connProps.put(JdbcSinkConfig.CONNECTION_URL, url);
+    connProps.putAll(propertiesFromPairs(propertyPairs));
+    if (quoteIdentfiiers != null) {
+      connProps.put("quote.sql.identifiers", quoteIdentfiiers.toString());
+    }
+    if (useHoldlockInMerge != null) {
+      connProps.put(JdbcSinkConfig.MSSQL_USE_MERGE_HOLDLOCK, useHoldlockInMerge.toString());
+    }
     return new JdbcSinkConfig(connProps);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -64,6 +64,19 @@ public class JdbcSinkConfigTest {
   }
 
   @Test
+  public void shouldCreateConfigWithHoldlock() {
+    createConfig();
+    assertEquals(true, config.useHoldlockInMerge);
+  }
+
+  @Test
+  public void shouldCreateConfigWithNoHoldlock() {
+    props.put("mssql.use.merge.holdlock", "false");
+    createConfig();
+    assertEquals(false, config.useHoldlockInMerge);
+  }
+
+  @Test
   public void shouldCreateConfigWithAdditionalConfigs() {
     props.put("auto.create", "true");
     props.put("pk.mode", "kafka");


### PR DESCRIPTION
## Problem

Using "with (HOLDLOCK)" when performing a MERGE INTO statement in MS SQL Server in certain cases brings up performance issues (https://sqlsunday.com/2021/05/04/how-merge-can-deadlock-you/).
The HOLDLOCK is currently hardcoded into the SQL statement of the Sink connector [here](https://github.com/confluentinc/kafka-connect-jdbc/blob/master/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java#L327) and cannot be disabled without having a custom JDBC connector.

## Solution
This PR introduces a configuration option (`mssql.use.merge.holdlock`) that allows to enable/disable the use of HOLDLOCK in the MERGE statement. The default is `true`, meaning this PR should be backwards compatible.

NOTE: the unit tests had to be updated, as the JDBCSourceConfig was used everywhere, even when testing Sink features. 

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
No plan
