### PR TITLE
Refactor Array handling in Postgres

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1916,6 +1916,10 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return url.replaceAll("(?i)([?&]([^=&]*)password([^=&]*)=)[^&]*", "$1****");
   }
 
+  protected Connection peekConnection() {
+    return connections.peek();
+  }
+
   @Override
   public String identifier() {
     return name() + " database " + sanitizedUrl(jdbcUrl);


### PR DESCRIPTION
## Problem
Current solution of handling arrays in Postgres dialect does not work correctly when trying to parse a `numeric` array. The following exception is thrown:

```
org.postgresql.util.PSQLException: Cannot cast an instance of [Ljava.lang.Double; to type Types.ARRAY
```

## Solution
The solution is to use `java.sql.Array` in order to handle these arrays correctly when constructing the `PreparedStatement`.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
-

## Test Strategy
CI & has been tested manually in our PoC of CDC over Postgres DBs (source & sink) and works perfectly.

##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
I leave this up to you! 
