### PR TITLE
Informix DB Support added

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/InformixDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/InformixDatabaseDialect.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.util.Collection;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
+import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.TableId;
+
+/**
+ * A {@link DatabaseDialect} for IBM INFORMIX.
+ */
+public class InformixDatabaseDialect extends GenericDatabaseDialect {
+
+  /**
+     * The provider for {@link InformixDatabaseDialect}.
+     */
+  public static class Provider extends SubprotocolBasedProvider {
+    public Provider() {
+      super(InformixDatabaseDialect.class.getSimpleName(), "informix-sqli");
+    }
+
+    @Override
+      public DatabaseDialect create(AbstractConfig config) {
+      return new InformixDatabaseDialect(config);
+    }
+  }
+
+  /**
+     * Create a new dialect instance with the given connector configuration.
+     *
+     * @param config the connector configuration; may not be null
+     */
+  public InformixDatabaseDialect(AbstractConfig config) {
+    super(config, new IdentifierRules(".",null,null));
+  }
+
+  @Override
+    protected String currentTimestampDatabaseQuery() {
+    return "SELECT  CURRENT FROM sysmaster:informix.sysdual ";
+  }
+
+  @Override
+    protected String checkConnectionQuery() {
+    return "SELECT 1 FROM sysmaster:informix.sysdual ";
+  }
+
+  @Override
+    protected String getSqlType(SinkRecordField field) {
+    if (field.schemaName() != null) {
+      switch (field.schemaName()) {
+        case Decimal.LOGICAL_NAME:
+          return "DECIMAL(31," + field.schemaParameters().get(Decimal.SCALE_FIELD) + ")";
+        case Date.LOGICAL_NAME:
+          return "DATE";
+        case Time.LOGICAL_NAME:
+          return "TIME";
+        case Timestamp.LOGICAL_NAME:
+          return "TIMESTAMP";
+        default:
+                    // fall through to normal types
+      }
+    }
+    switch (field.schemaType()) {
+      case INT8:
+        return "SMALLINT";
+      case INT16:
+        return "SMALLINT";
+      case INT32:
+        return "INTEGER";
+      case INT64:
+        return "BIGINT";
+      case FLOAT32:
+        return "FLOAT";
+      case FLOAT64:
+        return "DOUBLE";
+      case BOOLEAN:
+        return "SMALLINT";
+      case STRING:
+        return "VARCHAR(32672)";
+      case BYTES:
+        return "BLOB(64000)";
+      default:
+        return super.getSqlType(field);
+    }
+  }
+
+  @Override
+    public String buildUpsertQueryStatement(
+        final TableId table,
+        Collection<ColumnId> keyColumns,
+        Collection<ColumnId> nonKeyColumns
+  ) {
+    // http://lpar.ath0.com/2013/08/12/upsert-in-db2/
+    final Transform<ColumnId> transform = (builder, col) -> {
+      builder.append(table)
+              .append(".")
+              .appendColumnName(col.name())
+              .append("=DAT.")
+              .appendColumnName(col.name());
+    };
+
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("merge into ");
+    builder.append(table);
+    builder.append(" using (values(");
+    builder.appendList()
+          .delimitedBy(", ")
+          .transformedBy(ExpressionBuilder.placeholderInsteadOfColumnNames("?"))
+          .of(keyColumns, nonKeyColumns);
+    builder.append(")) as DAT(");
+    builder.appendList()
+          .delimitedBy(", ")
+          .transformedBy(ExpressionBuilder.columnNames())
+          .of(keyColumns, nonKeyColumns);
+    builder.append(") on ");
+    builder.appendList()
+          .delimitedBy(" and ")
+          .transformedBy(transform)
+          .of(keyColumns);
+    if (nonKeyColumns != null && !nonKeyColumns.isEmpty()) {
+      builder.append(" when matched then update set ");
+      builder.appendList()
+              .delimitedBy(", ")
+              .transformedBy(transform)
+              .of(nonKeyColumns);
+    }
+
+    builder.append(" when not matched then insert(");
+    builder.appendList().delimitedBy(",").of(nonKeyColumns, keyColumns);
+    builder.append(") values(");
+    builder.appendList()
+          .delimitedBy(",")
+          .transformedBy(ExpressionBuilder.columnNamesWithPrefix("DAT."))
+          .of(nonKeyColumns, keyColumns);
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
+    protected String sanitizedUrl(String url) {
+    // INFORMIX has semicolon delimited property name-value pairs
+    return super.sanitizedUrl(url)
+          .replaceAll("(?i)([:;]password=)[^;]*", "$1****");
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -63,6 +63,7 @@ public class JdbcSourceTask extends SourceTask {
   private Time time;
   private JdbcSourceTaskConfig config;
   private DatabaseDialect dialect;
+  public  static String diaName = "";
   private CachedConnectionProvider cachedConnectionProvider;
   private PriorityQueue<TableQuerier> tableQueue = new PriorityQueue<TableQuerier>();
   private final AtomicBoolean running = new AtomicBoolean(false);
@@ -100,7 +101,7 @@ public class JdbcSourceTask extends SourceTask {
       dialect = DatabaseDialects.findBestFor(url, config);
     }
     log.info("Using JDBC dialect {}", dialect.name());
-
+    diaName = dialect.name();
     cachedConnectionProvider = connectionProvider(maxConnAttempts, retryBackoff);
 
     List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -37,11 +37,14 @@ import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 
+
 public class TimestampIncrementingCriteria {
+  JdbcSourceTask tn;
 
   /**
    * The values that can be used in a statement's WHERE clause.
    */
+
   public interface CriteriaValues {
 
     /**
@@ -280,7 +283,11 @@ public class TimestampIncrementingCriteria {
 
   protected String coalesceTimestampColumns(ExpressionBuilder builder) {
     if (timestampColumns.size() == 1) {
-      builder.append(timestampColumns.get(0));
+      if (tn.diaName.equals("Informix")) {
+        builder.append(timestampColumns.get(0).toString().replaceAll("\"",""));
+      } else {
+        builder.append(timestampColumns.get(0));
+      }
     } else {
       builder.append("COALESCE(");
       builder.appendList().delimitedBy(",").of(timestampColumns);

--- a/src/main/java/io/confluent/connect/jdbc/util/ExpressionBuilder.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/ExpressionBuilder.java
@@ -294,12 +294,18 @@ public class ExpressionBuilder {
     return this;
   }
 
+  public ExpressionBuilder appendIdentifierDelimiter(String delim) {
+    sb.append(delim.trim());
+    return this;
+  }
+
   /**
    * Always append to this builder's expression the leading quote character(s) defined by this
    * builder's {@link IdentifierRules}.
    *
    * @return this builder to enable methods to be chained; never null
    */
+
   public ExpressionBuilder appendLeadingQuote() {
     return appendLeadingQuote(QuoteMethod.ALWAYS);
   }
@@ -398,6 +404,13 @@ public class ExpressionBuilder {
     return this;
   }
 
+  public ExpressionBuilder appendIdentifierwithoutqutes(
+      String name
+  ) {
+    sb.append(name.trim());
+    return this;
+  }
+
   /**
    * Append to this builder's expression the specified Column identifier, possibly surrounded by
    * the leading and trailing quotes based upon {@link #setQuoteIdentifiers(QuoteMethod)}.
@@ -421,6 +434,11 @@ public class ExpressionBuilder {
     appendLeadingQuote(quote);
     sb.append(name);
     appendTrailingQuote(quote);
+    return this;
+  }
+
+  public ExpressionBuilder appendTableNamewithoutquotes(String name) {
+    sb.append(name.trim());
     return this;
   }
 
@@ -621,6 +639,7 @@ public class ExpressionBuilder {
   }
 
   public String toString() {
+
     return sb.toString();
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/TableId.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableId.java
@@ -18,13 +18,24 @@ package io.confluent.connect.jdbc.util;
 import java.util.Objects;
 
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Expressable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.confluent.connect.jdbc.source.JdbcSourceTask;
 
-public class TableId implements Comparable<TableId>, Expressable {
+
+
+public class TableId implements Comparable<TableId>, Expressable  {
+
+  private static final Logger log = LoggerFactory.getLogger(
+      TableId.class
+  );
 
   private final String catalogName;
   private final String schemaName;
   private final String tableName;
   private final int hash;
+
+  JdbcSourceTask tn;
 
   public TableId(
       String catalogName,
@@ -58,16 +69,33 @@ public class TableId implements Comparable<TableId>, Expressable {
   public void appendTo(
       ExpressionBuilder builder,
       QuoteMethod useQuotes
+
   ) {
     if (catalogName != null) {
-      builder.appendIdentifier(catalogName, useQuotes);
-      builder.appendIdentifierDelimiter();
+      if (tn.diaName.equals("Informix")) {
+        builder.appendIdentifierwithoutqutes(catalogName);
+        builder.appendIdentifierDelimiter(":");
+      } else {
+        builder.appendIdentifier(catalogName, useQuotes);
+        builder.appendIdentifierDelimiter();
+      }
     }
     if (schemaName != null) {
-      builder.appendIdentifier(schemaName, useQuotes);
-      builder.appendIdentifierDelimiter();
+      if (tn.diaName.equals("Informix")) {
+        builder.appendIdentifierwithoutqutes(schemaName);
+        builder.appendIdentifierDelimiter(".");
+      } else {
+        builder.appendIdentifier(schemaName, useQuotes);
+        builder.appendIdentifierDelimiter();
+
+      }
     }
-    builder.appendTableName(tableName, useQuotes);
+    if (tn.diaName.equals("Informix")) {
+      builder.appendTableNamewithoutquotes(tableName);
+    } else {
+      builder.appendTableName(tableName, useQuotes);
+    }
+
   }
 
   @Override
@@ -130,5 +158,6 @@ public class TableId implements Comparable<TableId>, Expressable {
   @Override
   public String toString() {
     return ExpressionBuilder.create().append(this).toString();
+
   }
 }

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -9,3 +9,4 @@ io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SybaseDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.VerticaDatabaseDialect$Provider
+io.confluent.connect.jdbc.dialect.InformixDatabaseDialect$Provider


### PR DESCRIPTION
## Problem
In Informix DB, kafka-connect-jdbc qenerated query for view should have different delimiter(colon & dot) like (select * from database_name:Schema_name.Table_name), In other DB its always dotted delimiter. Along with Informix dialect, this issue also taken cared

## Solution
Informix Dialect support and table_type: table and view support is added


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
