### PR TITLE
Change pom repository reference value to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Similar to https://github.com/confluentinc/common/pull/341, change the pom's repository value to `https` as now required by default with newer versions of maven (3.8.1+, ref: https://issues.apache.org/jira/browse/MNG-7118).