### PR TITLE
CCDB-4141: Prevent data loss in timestamp mode

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -217,13 +217,12 @@ public class JdbcSourceTask extends SourceTask {
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
         tableQueue.add(
-            new TimestampIncrementingTableQuerier(
+            new TimestampTableQuerier(
                 dialect,
                 queryMode,
                 tableOrQuery,
                 topicPrefix,
                 timestampColumns,
-                null,
                 offset,
                 timestampDelayInterval,
                 timeZone

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -111,7 +111,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     closeStatementQuietly();
     releaseLocksQuietly();
     // TODO: Can we cache this and quickly check that it's identical for the next query
-    // instead of constructing from scratch since it's almost always the same
+    //     instead of constructing from scratch since it's almost always the same
     schemaMapping = null;
     lastUpdate = now;
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -49,7 +49,7 @@ public class TimestampIncrementingCriteria {
      * @return the beginning timestamp; may be null
      * @throws SQLException if there is a problem accessing the value
      */
-    Timestamp beginTimetampValue() throws SQLException;
+    Timestamp beginTimestampValue() throws SQLException;
 
     /**
      * Get the end of the time period.
@@ -57,7 +57,7 @@ public class TimestampIncrementingCriteria {
      * @return the ending timestamp; never null
      * @throws SQLException if there is a problem accessing the value
      */
-    Timestamp endTimetampValue() throws SQLException;
+    Timestamp endTimestampValue() throws SQLException;
 
     /**
      * Get the last incremented value seen.
@@ -135,8 +135,8 @@ public class TimestampIncrementingCriteria {
       PreparedStatement stmt,
       CriteriaValues values
   ) throws SQLException {
-    Timestamp beginTime = values.beginTimetampValue();
-    Timestamp endTime = values.endTimetampValue();
+    Timestamp beginTime = values.beginTimestampValue();
+    Timestamp endTime = values.endTimestampValue();
     Long incOffset = values.lastIncrementedValue();
     stmt.setTimestamp(1, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setTimestamp(2, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
@@ -162,8 +162,8 @@ public class TimestampIncrementingCriteria {
       PreparedStatement stmt,
       CriteriaValues values
   ) throws SQLException {
-    Timestamp beginTime = values.beginTimetampValue();
-    Timestamp endTime = values.endTimetampValue();
+    Timestamp beginTime = values.beginTimestampValue();
+    Timestamp endTime = values.endTimestampValue();
     stmt.setTimestamp(1, beginTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     stmt.setTimestamp(2, endTime, DateTimeUtils.getTimeZoneCalendar(timeZone));
     log.debug("Executing prepared statement with timestamp value = {} end time = {}",
@@ -294,7 +294,7 @@ public class TimestampIncrementingCriteria {
     // get only the row with id = 23:
     //  timestamp 1234, id 22 <- last
     //  timestamp 1234, id 23
-    // The second check only uses the timestamp >= last timestamp. This covers everything new,
+    // The second check only uses the timestamp > last timestamp. This covers everything new,
     // even if it is an update of the existing row. If we previously had:
     //  timestamp 1234, id 22 <- last
     // and then these rows were written:

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffset.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class TimestampIncrementingOffset {
   private static final Logger log = LoggerFactory.getLogger(JdbcSourceTask.class);
@@ -51,6 +52,10 @@ public class TimestampIncrementingOffset {
 
   public Timestamp getTimestampOffset() {
     return timestampOffset != null ? timestampOffset : new Timestamp(0L);
+  }
+
+  public boolean hasTimestampOffset() {
+    return timestampOffset != null;
   }
 
   public Map<String, Object> toMap() {
@@ -96,15 +101,8 @@ public class TimestampIncrementingOffset {
 
     TimestampIncrementingOffset that = (TimestampIncrementingOffset) o;
 
-    if (incrementingOffset != null
-        ? !incrementingOffset.equals(that.incrementingOffset)
-        : that.incrementingOffset != null) {
-      return false;
-    }
-    return timestampOffset != null
-           ? timestampOffset.equals(that.timestampOffset)
-           : that.timestampOffset == null;
-
+    return Objects.equals(incrementingOffset, that.incrementingOffset)
+        && Objects.equals(timestampOffset, that.timestampOffset);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -45,18 +45,18 @@ import io.confluent.connect.jdbc.util.ExpressionBuilder;
 /**
  * <p>
  *   TimestampIncrementingTableQuerier performs incremental loading of data using two mechanisms: a
- *   timestamp column provides monotonically incrementing values that can be used to detect new or
- *   modified rows and a strictly incrementing (e.g. auto increment) column allows detecting new
+ *   timestamp column provides monotonically-incrementing values that can be used to detect new or
+ *   modified rows and a strictly-incrementing (e.g. auto increment) column allows detecting new
  *   rows or combined with the timestamp provide a unique identifier for each update to the row.
  * </p>
  * <p>
  *   At least one of the two columns must be specified (or left as "" for the incrementing column
  *   to indicate use of an auto-increment column). If both columns are provided, they are both
  *   used to ensure only new or updated rows are reported and to totally order updates so
- *   recovery can occur no matter when offsets were committed. If only the incrementing fields is
- *   provided, new rows will be detected but not updates. If only the timestamp field is
+ *   recovery can occur no matter when offsets were committed. If only an incrementing field is
+ *   provided, new rows will be detected but not updates. If only timestamp fields are
  *   provided, both new and updated rows will be detected, but stream offsets will not be unique
- *   so failures may cause duplicates or losses.
+ *   so failures may cause duplicates.
  * </p>
  */
 public class TimestampIncrementingTableQuerier extends TableQuerier implements CriteriaValues {
@@ -64,14 +64,14 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       TimestampIncrementingTableQuerier.class
   );
 
-  private final List<String> timestampColumnNames;
+  protected final List<String> timestampColumnNames;
+  protected TimestampIncrementingOffset offset;
+  protected TimestampIncrementingCriteria criteria;
+  protected final Map<String, String> partition;
+  protected final String topic;
   private final List<ColumnId> timestampColumns;
   private String incrementingColumnName;
-  private long timestampDelay;
-  private TimestampIncrementingOffset offset;
-  private TimestampIncrementingCriteria criteria;
-  private final Map<String, String> partition;
-  private final String topic;
+  private final long timestampDelay;
   private final TimeZone timeZone;
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
@@ -83,7 +83,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     super(dialect, mode, name, topicPrefix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
-                                ? timestampColumnNames : Collections.<String>emptyList();
+        ? timestampColumnNames : Collections.emptyList();
     this.timestampDelay = timestampDelay;
     this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
 
@@ -97,7 +97,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     switch (mode) {
       case TABLE:
         String tableName = tableId.tableName();
-        topic = topicPrefix + tableName;// backward compatible
+        topic = topicPrefix + tableName; // backward compatible
         partition = OffsetProtocols.sourcePartitionForProtocolV1(tableId);
         break;
       case QUERY:
@@ -199,12 +199,12 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   }
 
   @Override
-  public Timestamp beginTimetampValue() {
+  public Timestamp beginTimestampValue() {
     return offset.getTimestampOffset();
   }
 
   @Override
-  public Timestamp endTimetampValue()  throws SQLException {
+  public Timestamp endTimestampValue()  throws SQLException {
     final long currentDbTime = dialect.currentTimeOnDB(
         stmt.getConnection(),
         DateTimeUtils.getTimeZoneCalendar(timeZone)

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -48,9 +48,7 @@ import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
  * committed.
  */
 public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
-  private static final Logger log = LoggerFactory.getLogger(
-      TimestampIncrementingTableQuerier.class
-  );
+  private static final Logger log = LoggerFactory.getLogger(TimestampTableQuerier.class);
 
   private boolean exhaustedResultSet;
   private PendingRecord nextRecord;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -38,9 +38,9 @@ import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
 
 /**
  * A specialized subclass of the {@link TimestampIncrementingTableQuerier} that only advances the
- * to-be-committed timestamp offset for its records after all either all rows have been read from
- * the current table query, or all rows with the to-be-committed timestamp have been read
- * successfully (and the next row has a timestamp that is strictly greater than it).
+ * to-be-committed timestamp offset for its records after either all rows have been read from the
+ * current table query, or all rows with the to-be-committed timestamp have been read successfully
+ * (and the next row has a timestamp that is strictly greater than it).
  * This prevents data loss in cases where the table has multiple rows with identical timestamps and
  * the connector is shut down in the middle of reading these rows. However, if the connector is
  * configured with additional query logic (such as a suffix containing a LIMIT clause), data loss

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.source;
+
+import java.util.TimeZone;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
+
+/**
+ * A specialized subclass of the {@link TimestampIncrementingTableQuerier} that only advances the
+ * to-be-committed timestamp offset for its records after all either all rows have been read from
+ * the current table query, or all rows with the to-be-committed timestamp have been read
+ * successfully (and the next row has a timestamp that is strictly greater than it).
+ * This prevents data loss in cases where the table has multiple rows with identical timestamps and
+ * the connector is shut down in the middle of reading these rows. However, if the connector is
+ * configured with additional query logic (such as a suffix containing a LIMIT clause), data loss
+ * may still occur, since the timestamp offset for the last row of each query is unconditionally
+ * committed.
+ */
+public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
+  private static final Logger log = LoggerFactory.getLogger(
+      TimestampIncrementingTableQuerier.class
+  );
+
+  private boolean exhaustedResultSet;
+  private PendingRecord nextRecord;
+  private Timestamp latestCommittableTimestamp;
+
+  public TimestampTableQuerier(
+      DatabaseDialect dialect,
+      QueryMode mode,
+      String name,
+      String topicPrefix,
+      List<String> timestampColumnNames,
+      Map<String, Object> offsetMap,
+      Long timestampDelay,
+      TimeZone timeZone
+  ) {
+    super(
+        dialect,
+        mode,
+        name,
+        topicPrefix,
+        timestampColumnNames,
+        null,
+        offsetMap,
+        timestampDelay,
+        timeZone
+    );
+
+    this.latestCommittableTimestamp = this.offset.getTimestampOffset();
+    this.exhaustedResultSet = false;
+    this.nextRecord = null;
+  }
+
+  @Override
+  public boolean next() throws SQLException {
+    if (exhaustedResultSet && nextRecord == null) {
+      // We've reached the end of the result set and returned our cached record; nothing left until
+      // we execute a new query
+      return false;
+    }
+
+    if (nextRecord == null) {
+      // We haven't read any rows from the table yet; happens when this method is invoked for the
+      // first time after a new query is executed
+      if (resultSet.next()) {
+        // At least one row is available; cache it immediately
+        nextRecord = doExtractRecord();
+      } else {
+        // No rows were available from the result set; make note that we've exhausted it, and
+        // indicate to the caller that no more rows are available until a new query is executed
+        exhaustedResultSet = true;
+        return false;
+      }
+    }
+
+    if (!resultSet.next()) {
+      exhaustedResultSet = true;
+    }
+    // Even if we've exhausted the result set, our cached record is still available
+    return true;
+  }
+
+  @Override
+  protected ResultSet executeQuery() throws SQLException {
+    ResultSet result = super.executeQuery();
+    exhaustedResultSet = false;
+    return result;
+  }
+
+  @Override
+  public SourceRecord extractRecord() {
+    if (nextRecord == null) {
+      throw new IllegalStateException("No more records are available");
+    }
+    PendingRecord currentRecord = nextRecord;
+    nextRecord = exhaustedResultSet ? null : doExtractRecord();
+    if (nextRecord == null
+        || canCommitTimestamp(currentRecord.timestamp(), nextRecord.timestamp())) {
+      latestCommittableTimestamp = currentRecord.timestamp();
+    }
+    return currentRecord.record(latestCommittableTimestamp);
+  }
+
+  private PendingRecord doExtractRecord() {
+    Struct record = new Struct(schemaMapping.schema());
+    for (FieldSetter setter : schemaMapping.fieldSetters()) {
+      try {
+        setter.setField(record, resultSet);
+      } catch (IOException e) {
+        log.warn("Error mapping fields into Connect record", e);
+        throw new ConnectException(e);
+      } catch (SQLException e) {
+        log.warn("SQL error mapping fields into Connect record", e);
+        throw new DataException(e);
+      }
+    }
+    this.offset = criteria.extractValues(schemaMapping.schema(), record, offset);
+    Timestamp timestamp = offset.hasTimestampOffset() ? offset.getTimestampOffset() : null;
+    return new PendingRecord(partition, timestamp, topic, record.schema(), record);
+  }
+
+  private boolean canCommitTimestamp(Timestamp current, Timestamp next) {
+    return current == null || next == null || current.before(next);
+  }
+
+  @Override
+  public String toString() {
+    return "TimestampTableQuerier{"
+        + "table=" + tableId
+        + ", query='" + query + '\''
+        + ", topicPrefix='" + topicPrefix + '\''
+        + ", timestampColumns=" + timestampColumnNames
+        + '}';
+  }
+
+  private static class PendingRecord {
+    private final Map<String, String> partition;
+    private final Timestamp timestamp;
+    private final String topic;
+    private final Schema valueSchema;
+    private final Object value;
+
+    public PendingRecord(
+        Map<String, String> partition,
+        Timestamp timestamp,
+        String topic,
+        Schema valueSchema,
+        Object value
+    ) {
+      this.partition = partition;
+      this.timestamp = timestamp;
+      this.topic = topic;
+      this.valueSchema = valueSchema;
+      this.value = value;
+    }
+
+    /**
+     * @return the timestamp value for the row that generated this record
+     */
+    public Timestamp timestamp() {
+      return timestamp;
+    }
+
+    /**
+     * @param offsetTimestamp the timestamp to use for the record's offset; may be null
+     * @return a {@link SourceRecord} whose source offset contains the provided timestamp
+     */
+    public SourceRecord record(Timestamp offsetTimestamp) {
+      TimestampIncrementingOffset offset = new TimestampIncrementingOffset(offsetTimestamp, null);
+      return new SourceRecord(
+          partition, offset.toMap(), topic, valueSchema, value
+      );
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingOffsetTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TimestampIncrementingOffsetTest {
   private final Timestamp ts = new Timestamp(100L);
@@ -78,6 +80,14 @@ public class TimestampIncrementingOffsetTest {
     assertEquals(zero, incOnly.getTimestampOffset());
     assertEquals(ts, tsInc.getTimestampOffset());
     assertEquals(nanos, nanosOffset.getTimestampOffset());
+  }
+
+  @Test
+  public void testHasTimestampOffset() {
+    assertFalse(unset.hasTimestampOffset());
+    assertFalse(incOnly.hasTimestampOffset());
+    assertTrue(tsOnly.hasTimestampOffset());
+    assertTrue(tsInc.hasTimestampOffset());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -181,9 +181,7 @@ public class TimestampIncrementingTableQuerierTest {
 
     querier.maybeStartQuery(db);
 
-    // We just commit timestamp offsets immediately in this mode since the incrementing column
-    // provides an additional layer of granularity; as long as there aren't two updates to the same
-    // row that take place with the same timestamp, no data loss should occur
+    // We commit offsets immediately in this mode
     assertNextRecord(querier, firstNewOffset);
     assertNextRecord(querier, firstNewOffset);
     assertNextRecord(querier, secondNewOffset);

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.api.easymock.annotation.MockNice;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.easymock.PowerMock.expectLastCall;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SchemaMapping.class)
+public class TimestampIncrementingTableQuerierTest {
+
+  private static final Timestamp INITIAL_TS = new Timestamp(71);
+  private static final long INITIAL_INC = 4761;
+  private static final List<String> TIMESTAMP_COLUMNS = Arrays.asList("ts1", "ts2");
+  private static final String INCREMENTING_COLUMN = "inc";
+
+  @Mock
+  private PreparedStatement stmt;
+  @Mock
+  private ResultSet resultSet;
+  @Mock
+  private Connection db;
+  @MockNice
+  private ExpressionBuilder expressionBuilder;
+  @Mock
+  private TimestampIncrementingCriteria criteria;
+  @Mock
+  private SchemaMapping schemaMapping;
+  private DatabaseDialect dialect;
+
+  @Before
+  public void setUp() {
+    dialect = mock(DatabaseDialect.class);
+    mockStatic(SchemaMapping.class);
+  }
+
+  private TimestampIncrementingTableQuerier querier(
+      TimestampIncrementingOffset initialOffset,
+      boolean timestampMode
+  ) {
+    final String tableName = "table";
+    expect(dialect.parseTableIdentifier(tableName)).andReturn(new TableId("", "", tableName));
+
+    // Have to replay the dialect here since it's used to the table ID in the querier's constructor
+    replay(dialect);
+
+    return new TimestampIncrementingTableQuerier(
+        dialect,
+        TableQuerier.QueryMode.TABLE,
+        tableName,
+        "",
+        timestampMode ? TIMESTAMP_COLUMNS : null,
+        INCREMENTING_COLUMN,
+        initialOffset.toMap(),
+        10211197100L, // Timestamp delay
+        TimeZone.getTimeZone("UTC")
+    );
+  }
+
+  private Schema schema() {
+    SchemaBuilder result =SchemaBuilder.struct();
+    result.field(INCREMENTING_COLUMN, Schema.INT64_SCHEMA);
+    TIMESTAMP_COLUMNS.forEach(
+        col -> result.field(col, org.apache.kafka.connect.data.Timestamp.builder().build())
+    );
+    return result.build();
+  }
+
+  private void expectNewQuery() throws Exception {
+    expect(dialect.createPreparedStatement(eq(db), anyObject())).andReturn(stmt);
+    expect(dialect.expressionBuilder()).andReturn(expressionBuilder);
+    expect(dialect.criteriaFor(anyObject(), anyObject())).andReturn(criteria);
+    criteria.whereClause(expressionBuilder);
+    expectLastCall();
+    criteria.setQueryParameters(eq(stmt), anyObject());
+    expectLastCall();
+    expect(stmt.executeQuery()).andReturn(resultSet);
+    expect(resultSet.getMetaData()).andReturn(null);
+    expect(SchemaMapping.create(anyObject(), anyObject(), anyObject())).andReturn(schemaMapping);
+  }
+
+  @Test
+  public void testEmptyResultSet() throws Exception {
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(offset(INITIAL_TS, INITIAL_INC), false);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testTimestampAndIncrementingMode() throws Exception {
+    Timestamp firstNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    TimestampIncrementingOffset firstNewOffset = offset(firstNewTimestamp, INITIAL_INC + 1);
+    TimestampIncrementingOffset secondNewOffset = offset(new Timestamp(INITIAL_TS.getTime() + 2), INITIAL_INC + 2);
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(offset(INITIAL_TS, INITIAL_INC), false);
+    expectRecord(firstNewOffset);
+    expectRecord(firstNewOffset);
+    expectRecord(secondNewOffset);
+    expectRecord(secondNewOffset);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // We just commit timestamp offsets immediately in this mode since the incrementing column
+    // provides an additional layer of granularity; as long as there aren't two updates to the same
+    // row that take place with the same timestamp, no data loss should occur
+    assertNextRecord(querier, firstNewOffset);
+    assertNextRecord(querier, firstNewOffset);
+    assertNextRecord(querier, secondNewOffset);
+    assertNextRecord(querier, secondNewOffset);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testIncrementingMode() throws Exception {
+    TimestampIncrementingOffset firstNewOffset = offset(INITIAL_INC + 1);
+    TimestampIncrementingOffset secondNewOffset = offset(INITIAL_INC + 2);
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(offset(INITIAL_INC), true);
+    expectRecord(firstNewOffset);
+    expectRecord(firstNewOffset);
+    expectRecord(secondNewOffset);
+    expectRecord(secondNewOffset);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // We just commit timestamp offsets immediately in this mode since the incrementing column
+    // provides an additional layer of granularity; as long as there aren't two updates to the same
+    // row that take place with the same timestamp, no data loss should occur
+    assertNextRecord(querier, firstNewOffset);
+    assertNextRecord(querier, firstNewOffset);
+    assertNextRecord(querier, secondNewOffset);
+    assertNextRecord(querier, secondNewOffset);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testMultipleSingleRecordResultSets() throws Exception {
+    TimestampIncrementingOffset initialOffset = offset(INITIAL_TS, INITIAL_INC);
+    expectNewQuery();
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(initialOffset, true);
+    expectRecord(initialOffset);
+    expect(resultSet.next()).andReturn(false);
+    expectReset();
+    expectRecord(initialOffset);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    assertNextRecord(querier, initialOffset);
+
+    assertFalse(querier.next());
+
+    querier.reset(0);
+    querier.maybeStartQuery(db);
+
+    assertNextRecord(querier, initialOffset);
+
+    assertFalse(querier.next());
+  }
+
+  private void assertNextRecord(
+      TimestampIncrementingTableQuerier querier, TimestampIncrementingOffset offset
+  ) throws Exception {
+    assertTrue(querier.next());
+    assertEquals(offset.toMap(), querier.extractRecord().sourceOffset());
+  }
+
+  private void expectRecord(TimestampIncrementingOffset offset) throws Exception {
+    expect(schemaMapping.schema()).andReturn(schema()).times(2);
+    expect(resultSet.next()).andReturn(true);
+    expect(schemaMapping.fieldSetters()).andReturn(Collections.emptyList());
+    expect(criteria.extractValues(anyObject(), anyObject(), anyObject())).andReturn(offset);
+  }
+
+  private void expectReset() throws Exception {
+    resultSet.close();
+    expectLastCall();
+    stmt.close();
+    expectLastCall();
+    db.commit();
+    expectLastCall();
+  }
+
+  private static TimestampIncrementingOffset offset(Long inc) {
+    return new TimestampIncrementingOffset(null, inc);
+  }
+
+  private static TimestampIncrementingOffset offset(Timestamp ts, Long inc) {
+    return new TimestampIncrementingOffset(ts, inc);
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.api.easymock.annotation.MockNice;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.easymock.PowerMock.expectLastCall;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SchemaMapping.class)
+public class TimestampTableQuerierTest {
+
+  private static final Timestamp INITIAL_TS = new Timestamp(71);
+  private static final long INITIAL_INC = 4761;
+  private static final List<String> TIMESTAMP_COLUMNS = Arrays.asList("ts1", "ts2");
+  private static final String INCREMENTING_COLUMN = "inc";
+
+  @Mock
+  private PreparedStatement stmt;
+  @Mock
+  private ResultSet resultSet;
+  @Mock
+  private Connection db;
+  @MockNice
+  private ExpressionBuilder expressionBuilder;
+  @Mock
+  private TimestampIncrementingCriteria criteria;
+  @Mock
+  private SchemaMapping schemaMapping;
+  private DatabaseDialect dialect;
+
+  @Before
+  public void setUp() {
+    dialect = mock(DatabaseDialect.class);
+    mockStatic(SchemaMapping.class);
+  }
+
+  private TimestampIncrementingTableQuerier querier(Timestamp initialTimestampOffset) {
+    final String tableName = "table";
+    expect(dialect.parseTableIdentifier(tableName)).andReturn(new TableId("", "", tableName));
+
+    // Have to replay the dialect here since it's used to the table ID in the querier's constructor
+    replay(dialect);
+
+    return new TimestampTableQuerier(
+        dialect,
+        TableQuerier.QueryMode.TABLE,
+        tableName,
+        "",
+        TIMESTAMP_COLUMNS,
+        new TimestampIncrementingOffset(initialTimestampOffset, null).toMap(),
+        10211197100L, // Timestamp delay
+        TimeZone.getTimeZone("UTC")
+    );
+  }
+
+  private Schema schema() {
+    SchemaBuilder result =SchemaBuilder.struct();
+    result.field(INCREMENTING_COLUMN, Schema.INT64_SCHEMA);
+    TIMESTAMP_COLUMNS.forEach(
+        col -> result.field(col, org.apache.kafka.connect.data.Timestamp.builder().build())
+    );
+    return result.build();
+  }
+
+  private void expectNewQuery() throws Exception {
+    expect(dialect.createPreparedStatement(eq(db), anyObject())).andReturn(stmt);
+    expect(dialect.expressionBuilder()).andReturn(expressionBuilder);
+    expect(dialect.criteriaFor(anyObject(), anyObject())).andReturn(criteria);
+    criteria.whereClause(expressionBuilder);
+    expectLastCall();
+    criteria.setQueryParameters(eq(stmt), anyObject());
+    expectLastCall();
+    expect(stmt.executeQuery()).andReturn(resultSet);
+    expect(resultSet.getMetaData()).andReturn(null);
+    expect(SchemaMapping.create(anyObject(), anyObject(), anyObject())).andReturn(schemaMapping);
+  }
+
+  @Test
+  public void testEmptyResultSet() throws Exception {
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testSingleRecordInResultSet() throws Exception {
+    Timestamp newTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(newTimestamp);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    assertNextRecord(querier, newTimestamp);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testTwoRecordsWithSameTimestampInResultSet() throws Exception {
+    Timestamp newTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(newTimestamp);
+    expectRecord(newTimestamp);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // This isn't the last record in the result set with the new timestamp, so we can't commit an
+    // offset that includes that timestamp yet
+    assertNextRecord(querier, INITIAL_TS);
+
+    // Now we can commit an offset with that timestamp, since this is the last record in the result
+    // set
+    assertNextRecord(querier, newTimestamp);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testTwoRecordsWithSameTimestampFollowedByRecordWithNewTimestampInResultSet() throws Exception {
+    Timestamp firstNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    Timestamp secondNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 2);
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(firstNewTimestamp);
+    expectRecord(firstNewTimestamp);
+    expectRecord(secondNewTimestamp);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // This isn't the last record in the result set with the new timestamp, so we can't commit an
+    // offset that includes that timestamp yet
+    assertNextRecord(querier, INITIAL_TS);
+
+    // Now we can commit an offset with that timestamp, since this is the last record in the result
+    // set
+    assertNextRecord(querier, firstNewTimestamp);
+
+    // And again, now we can commit an offset with the second new timestamp as we've exhausted the
+    // batch
+    assertNextRecord(querier, secondNewTimestamp);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testTwoRecordsWithSameTimestampFollowedByTwoRecordsWithNewTimestampInResultSet() throws Exception {
+    Timestamp firstNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    Timestamp secondNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 2);
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(firstNewTimestamp);
+    expectRecord(firstNewTimestamp);
+    expectRecord(secondNewTimestamp);
+    expectRecord(secondNewTimestamp);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // This isn't the last record in the result set with the new timestamp, so we can't commit an
+    // offset that includes that timestamp yet
+    assertNextRecord(querier, INITIAL_TS);
+
+    // Now we can commit an offset with that timestamp, since this is the last record in the result
+    // set
+    assertNextRecord(querier, firstNewTimestamp);
+
+    // Again, have to reuse the timestamp since there's another record waiting that has the same
+    // timestamp as the one we're about to query
+    assertNextRecord(querier, firstNewTimestamp);
+
+    // And again, now we can commit an offset with the second new timestamp as we've exhausted the
+    // batch
+    assertNextRecord(querier, secondNewTimestamp);
+
+    assertFalse(querier.next());
+  }
+
+  @Test
+  public void testMultipleSingleRecordResultSets() throws Exception {
+    expectNewQuery();
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(INITIAL_TS);
+    expect(resultSet.next()).andReturn(false);
+    expectReset();
+    expectRecord(INITIAL_TS);
+    expect(resultSet.next()).andReturn(false);
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // We have to commit for the last record in the batch
+    assertNextRecord(querier, INITIAL_TS);
+
+    assertFalse(querier.next());
+
+    querier.reset(0);
+    querier.maybeStartQuery(db);
+
+    // We have to commit for the last record in the batch
+    assertNextRecord(querier, INITIAL_TS);
+
+    assertFalse(querier.next());
+  }
+
+  private void assertNextRecord(
+      TimestampIncrementingTableQuerier querier, Timestamp expectedTimestampOffset
+  ) throws Exception {
+    assertTrue(querier.next());
+    SourceRecord record = querier.extractRecord();
+    TimestampIncrementingOffset actualOffset =TimestampIncrementingOffset.fromMap(record.sourceOffset()); 
+    assertEquals(expectedTimestampOffset, actualOffset.getTimestampOffset());
+  }
+
+  private void expectRecord(Timestamp timestamp) throws Exception {
+    expect(schemaMapping.schema()).andReturn(schema()).times(2);
+    expect(resultSet.next()).andReturn(true);
+    expect(schemaMapping.fieldSetters()).andReturn(Collections.emptyList());
+    TimestampIncrementingOffset offset = new TimestampIncrementingOffset(timestamp, null);
+    expect(criteria.extractValues(anyObject(), anyObject(), anyObject())).andReturn(offset);
+  }
+
+  private void expectReset() throws Exception {
+    resultSet.close();
+    expectLastCall();
+    stmt.close();
+    expectLastCall();
+    db.commit();
+    expectLastCall();
+  }
+
+  private static TimestampIncrementingOffset offset(Timestamp ts) {
+    return offset(ts, null);
+  }
+
+  private static TimestampIncrementingOffset offset(Timestamp ts, Long inc) {
+    return new TimestampIncrementingOffset(ts, inc);
+  }
+}


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CCDB-4141)

## Problem
Data loss can occur in timestamp mode when there are multiple rows with the same timestamp if the connector is shut down after reading at least one such row but before reading all of them.

## Solution
Take a more conservative approach with the timestamps we use for the source offsets in records produced by the connector. These timestamps will now only advance once the connector has either:
- Read every row from the current query that uses a given timestamp
OR
- Read every row from the current query

For example, if the connector's current timestamp is T0 and it then reads five rows from the current query with timestamps T1, T1, T2, T2, and T3, the records it produces will have timestamps of T0, T1, T1, T2, and T3, respectively. Put visually:

| Timestamp in row | Timestamp in record offset | Note |
| - | - | - |
| T1 | T0 | Not the last row with T1; use our previous offset, T0 |
| T1 | T1 | This is the last row with T1; we can safely commit a source offset with that timestamp now |
| T2 | T1 | Not the last row with T2; use our previous offset, T1 |
| T2 | T2 | This is the last row with T2; we can safely commit a source offset with that timestamp now |
| T3 | T3 | This is the last row in the query; we'll commit that timestamp |

Note that it may be unsafe to unconditionally commit an offset for the timestamp of the last row in the query in some cases; for example, if the user has configured the connector to use a `LIMIT` clause with its query, then there may be more rows to read from the table with the timestamp present in the last row that were not returned in the current query. This eventuality is permitted for four reasons:
- The `query.suffix` property is relatively new and it's unclear how popular this feature is; speaking from personal experience, not that many users appear to be relying on it
- Limiting the number of rows each query returns with timestamp mode in current versions of the connector can already lead to data loss in cases where there are multiple rows with the same timestamp, so this change is not a regression in behavior
- The alternative is that the connector would always be at least one row behind while reading from the table, which may be frustrating for users with slowly-evolving tables
- If the query ever returned a set of rows that all shared the same timestamp, the connector could enter an infinite loop and never move beyond those rows

Some final remarks:
- It's still vital to use a high enough `timestamp.delay.interval.ms` value when running the connector in timestamp mode in order to ensure that all rows with a given timestamp are available in the table by the time the connector reads the very _first_ row with that timestamp. This is already the case with the connector as it exists today.
- No change is necessary for timestamp+incrementing mode.
- Some small hygienic improvements are made in the code base that are not necessary for the PR. Just wanted to leave things better than they were found.
- Once [KIP-618](https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors) is implemented, this mode would be a perfect candidate for connector-defined transaction boundaries, which could be used to ensure that rows that share a timestamp are produced atomically and prevent duplicates if a task dies in the middle of producing a collection of such rows.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
A couple new unit tests are added for the `TimestampIncrementingTableQuerier` and newly-introduced `TimestampQuerier` test. The former should be a reasonable guard against regressions; the latter helps verify that the logic introduced here is valid.

I've also cherry-picked this locally onto master and verified that all unit and integration tests pass with it as well; there were a few minor failures that had to addressed first, but they can all be chalked up to a bad merge.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Merge to 5.0.x, let Jenkins automatically `pint merge` forward, issue follow-up PRs to handle any test or build failures caused by bad (but not failed) merges.