### PR TITLE
CCDB-4190: Commit after DDL

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1189,6 +1189,17 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         statement.executeUpdate(ddlStatement);
       }
     }
+    try {
+      connection.commit();
+    } catch (Exception e) {
+      try {
+        connection.rollback();
+      } catch (SQLException sqle) {
+        e.addSuppressed(sqle);
+      } finally {
+        throw e;
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
## Problem
`GenericDatabaseDialect::applyDdlStatements` just does a `statement.executeUpdate` on the ddl statements to execute them, without explicitly calling `commit` to ensure they are committed. At the same time, the `CachedConnectionProvider` acquired from `JdbcDbWriter::connectionProvider` explicitly disables autocommit on the connection. The combination of this means that DDL changes may not be COMMITed to the DB before our next query.

## Solution
Explicitly call `commit` on the connection to commit the DDL changes. From the `Connection::setAutoCommit` javadoc:
>  If a connection is in auto-commit mode, then all its SQL statements will be executed and committed as individual transactions. Otherwise, its SQL statements are grouped into transactions that are terminated by a call to either the method commit or the method rollback.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
New unittests were added to verify the new behavior

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Bug fix to be brought back to versions starting from `10.0.x`