### PR TITLE
MINOR: Fix checkstyle by updating Apache license header to Community License

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -1,18 +1,17 @@
-/**
- * Copyright 2015 Confluent Inc.
+/*
+ * Copyright 2018 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
 package io.confluent.connect.jdbc.source;
 


### PR DESCRIPTION
Signed-off-by: Greg Harris <gregh@confluent.io>

## Problem

Our build is failing due to checkstyle:
```
[ERROR] /src/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java:3: Empty line should be followed by <p> tag on the next line. [JavadocParagraph]
[ERROR] /src/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java:7: Empty line should be followed by <p> tag on the next line. [JavadocParagraph]
[ERROR] /src/kafka-connect-jdbc/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java:9: Empty line should be followed by <p> tag on the next line. [JavadocParagraph]
```

## Solution

Update the license header in this file to match the JdbcSourceTask, which is not a javadoc (and is Confluent Community instead of Apache 2.0)


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
