### PR TITLE
fix: db.timezone invalid timezone identifier error

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TimeZoneValidator.java
@@ -28,7 +28,7 @@ public class TimeZoneValidator implements ConfigDef.Validator {
   @Override
   public void ensureValid(String name, Object value) {
     if (value != null) {
-      if (!Arrays.asList(TimeZone.getAvailableIDs()).contains(value.toString())) {
+      if (!Arrays.asList(TimeZone.getAvailableIDs()).contains(value.getID())) {
         throw new ConfigException(name, value, "Invalid time zone identifier");
       }
     }


### PR DESCRIPTION
## Problem
connect crashes with ```invalid time zone identiferi``` exception thrown when ```db.timezone``` parameter is specified in sink properties

## Solution
List of available timezones and given timezone comparision uses different datatypes. This bug fix fixes this issue.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
This is a bug fix
