### PR TITLE
Fixing ClassCastException when field is not a Timestamp

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -218,11 +218,12 @@ public class TimestampIncrementingCriteria {
       Struct record
   ) {
     for (ColumnId timestampColumn : timestampColumns) {
-      Timestamp ts = (Timestamp) record.get(timestampColumn.name());
-      if (ts != null) {
-        return ts;
+      if (record.get(timestampColumn.name()) instanceof Timestamp) {
+        return (Timestamp) record.get(timestampColumn.name());
       }
     }
+    log.warn("None of the fields [{}] entered are of timestamp type.",
+            timestampColumns.stream().map(ColumnId::name).collect(Collectors.joining(",")));
     return null;
   }
 


### PR DESCRIPTION
## Problem

In `kafka-connect-jdbc` when we choose the **mode** parameter `timestamp` or `timestamp+increment` and the field setted in **timestamp.column.name** is not a Timestamp field (e.g. String), at line 221 of `TimestampIncrementingCriteria.java` the cast causes ClassCastException.

`java.lang.ClassCastException: class java.lang.String cannot be cast to class java.sql.Timestamp (java.lang.String is in module java.base of loader ‘bootstrap’; java.sql.Timestamp is in module java.sql of loader ‘platform’)`

This issue was reported here: https://github.com/confluentinc/kafka-connect-jdbc/issues/1071

## Solution

I added a class type verification before to try cast value and I take the opportunity to simplify the method using return without if condition.

This solution is a little bit different than that: https://github.com/confluentinc/kafka-connect-jdbc/pull/1007
In my proposal, I prefer to warn the user using log or throws an exception to make it more visible instead of fixing it without users knowing.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Set the mode parameter to `timestamp` or `timestamp+increment` and put on `timestamp.column.name` a field VARCHAR (e.g. updated_at with value is "2021-01-02 03:04:05.123456"), this solution won't throws `ClassCastException` and it will return `null`

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
