### PR TITLE
CCDB-4247: Close resources correctly on stop

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -318,12 +318,12 @@ public class JdbcSourceTask extends SourceTask {
   public void stop() throws ConnectException {
     log.info("Stopping JDBC source task");
 
+    // In earlier versions of Kafka, stop() was not called from the task thread. In this case, all
+    // resources are closed at the end of 'poll()' when no longer running or if there is an error.
+    running.set(false);
+
     if (taskThreadId.longValue() == Thread.currentThread().getId()) {
       shutdown();
-    } else {
-      running.set(false);
-      // All resources are closed at the end of 'poll()' when no longer running or
-      // if there is an error
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -106,6 +106,9 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
     try {
       task.stop();
+      synchronized (lock) {
+          lock.wait();
+      }
       running.set(false);
     } finally {
       executor.shutdown();

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -75,6 +75,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
+    mockCachedConnectionProvider.close();
 
     PowerMock.expectLastCall();
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -23,14 +23,16 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -61,7 +63,60 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   }
 
   @Test
-  public void testStartStop() {
+  public void testStartStopDifferentThreads() throws Exception {
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT");
+
+    // Minimal start/stop functionality
+    task = new JdbcSourceTask(time) {
+      @Override
+      protected CachedConnectionProvider connectionProvider(
+          int maxConnAttempts,
+          long retryBackoff
+      ) {
+        return mockCachedConnectionProvider;
+      }
+    };
+
+    // Should request a connection, then should close it on stop()
+    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection()).anyTimes();
+    mockCachedConnectionProvider.close();
+
+    PowerMock.expectLastCall();
+
+    PowerMock.replayAll();
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Object lock = new Object();
+    AtomicBoolean running = new AtomicBoolean(true);
+
+    executor.submit(() -> {
+      task.start(singleTableConfig());
+      while (running.get()) {
+        task.poll();
+
+        synchronized (lock) {
+          lock.notifyAll();
+        }
+      }
+      return null;
+    });
+
+    synchronized (lock) {
+      lock.wait();
+    }
+
+    try {
+      task.stop();
+      running.set(false);
+    } finally {
+      executor.shutdown();
+    }
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void testStartStopSameThread() {
     // Minimal start/stop functionality
     task = new JdbcSourceTask(time) {
       @Override

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -28,7 +28,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;


### PR DESCRIPTION
## Problem
Since KAFKA-10792 fixed the source task `stop()` to be called on the task thread, the previous assumption that `stop()` will be called in a separate thread is no longer correct. Instead, the shutdown steps should be done in the `stop()` method directly. This method will be called by framework on the same task thread as `poll()` , once `poll()` relinquishes control back to framework.

## Solution
Detect whether `stop()` is called from task thread. If so, do shutdown immediately.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Unit test expectation was updated

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Since KAFKA-10792 was taken back to `2.5` , we similarly take this change back to `5.5.x` . 