### PR TITLE
Add topic.suffix config prop for JDBC Source

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,5 +22,5 @@
               files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect).java"/>
+              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|JdbcSourceConnectorConfig|TimestampIncrementingTableQuerier).java"/>
 </suppressions>

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -40,13 +40,14 @@ public class BulkTableQuerier extends TableQuerier {
   private static final Logger log = LoggerFactory.getLogger(BulkTableQuerier.class);
 
   public BulkTableQuerier(
-      DatabaseDialect dialect,
-      QueryMode mode,
-      String name,
-      String topicPrefix,
-      String suffix
+          DatabaseDialect dialect,
+          QueryMode mode,
+          String name,
+          String topicPrefix,
+          String topicSuffix,
+          String suffix
   ) {
-    super(dialect, mode, name, topicPrefix, suffix);
+    super(dialect, mode, name, topicPrefix, topicSuffix, suffix);
   }
 
   @Override
@@ -100,7 +101,7 @@ public class BulkTableQuerier extends TableQuerier {
       case TABLE:
         String name = tableId.tableName(); // backwards compatible
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.TABLE_NAME_KEY, name);
-        topic = topicPrefix + name;
+        topic = topicPrefix + name + topicSuffix;
         break;
       case QUERY:
         partition = Collections.singletonMap(JdbcSourceConnectorConstants.QUERY_NAME_KEY,
@@ -116,8 +117,11 @@ public class BulkTableQuerier extends TableQuerier {
 
   @Override
   public String toString() {
-    return "BulkTableQuerier{" + "table='" + tableId + '\'' + ", query='" + query + '\''
-           + ", topicPrefix='" + topicPrefix + '\'' + '}';
+    return "BulkTableQuerier{"
+           + "table='" + tableId + '\''
+           + ", topicPrefix='" + topicPrefix + '\''
+           + ", topicSuffix='" + topicSuffix + '\''
+           + ", query=" + query
+           + '}';
   }
-
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -201,6 +201,7 @@ public class JdbcSourceTask extends SourceTask {
       offset = computeInitialOffset(tableOrQuery, offset, timeZone);
 
       String topicPrefix = config.topicPrefix();
+      String topicSuffix = config.topicSuffix();
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(
@@ -208,7 +209,8 @@ public class JdbcSourceTask extends SourceTask {
                 dialect, 
                 queryMode, 
                 tableOrQuery, 
-                topicPrefix, 
+                topicPrefix,
+                topicSuffix,
                 suffix
             )
         );
@@ -219,6 +221,7 @@ public class JdbcSourceTask extends SourceTask {
                 queryMode,
                 tableOrQuery,
                 topicPrefix,
+                topicSuffix,
                 null,
                 incrementingColumn,
                 offset,
@@ -234,6 +237,7 @@ public class JdbcSourceTask extends SourceTask {
                 queryMode,
                 tableOrQuery,
                 topicPrefix,
+                topicSuffix,
                 timestampColumns,
                 offset,
                 timestampDelayInterval,
@@ -248,6 +252,7 @@ public class JdbcSourceTask extends SourceTask {
                 queryMode,
                 tableOrQuery,
                 topicPrefix,
+                topicSuffix,
                 timestampColumns,
                 incrementingColumn,
                 offset,

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -45,6 +45,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected final QueryMode mode;
   protected final String query;
   protected final String topicPrefix;
+  protected final String topicSuffix;
   protected final TableId tableId;
   protected final String suffix;
 
@@ -58,14 +59,15 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   private String loggedQueryString;
 
   public TableQuerier(
-      DatabaseDialect dialect,
-      QueryMode mode,
-      String nameOrQuery,
-      String topicPrefix,
-      String suffix
+          DatabaseDialect dialect,
+          QueryMode mode,
+          String nameOrQuery,
+          String topicPrefix,
+          String topicSuffix, String suffix
   ) {
     this.dialect = dialect;
     this.mode = mode;
+    this.topicSuffix = topicSuffix;
     this.tableId = mode.equals(QueryMode.TABLE) ? dialect.parseTableIdentifier(nameOrQuery) : null;
     this.query = mode.equals(QueryMode.QUERY) ? nameOrQuery : null;
     this.topicPrefix = topicPrefix;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -76,11 +76,12 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
                                            String topicPrefix,
+                                           String topicSuffix,
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
                                            TimeZone timeZone, String suffix) {
-    super(dialect, mode, name, topicPrefix, suffix);
+    super(dialect, mode, name, topicPrefix, topicSuffix, suffix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
         ? timestampColumnNames : Collections.emptyList();
@@ -97,7 +98,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     switch (mode) {
       case TABLE:
         String tableName = tableId.tableName();
-        topic = topicPrefix + tableName; // backward compatible
+        topic = topicPrefix + tableName + topicSuffix; // backward compatible
         partition = OffsetProtocols.sourcePartitionForProtocolV1(tableId);
         break;
       case QUERY:

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -54,21 +54,23 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
   private Timestamp latestCommittableTimestamp;
 
   public TimestampTableQuerier(
-      DatabaseDialect dialect,
-      QueryMode mode,
-      String name,
-      String topicPrefix,
-      List<String> timestampColumnNames,
-      Map<String, Object> offsetMap,
-      Long timestampDelay,
-      TimeZone timeZone,
-      String suffix
+          DatabaseDialect dialect,
+          QueryMode mode,
+          String name,
+          String topicPrefix,
+          String topicSuffix,
+          List<String> timestampColumnNames,
+          Map<String, Object> offsetMap,
+          Long timestampDelay,
+          TimeZone timeZone,
+          String suffix
   ) {
     super(
         dialect,
         mode,
         name,
         topicPrefix,
+        topicSuffix,
         timestampColumnNames,
         null,
         offsetMap,
@@ -160,6 +162,7 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
         + "table=" + tableId
         + ", query='" + query + '\''
         + ", topicPrefix='" + topicPrefix + '\''
+        + ", topicSuffix='" + topicSuffix + '\''
         + ", timestampColumns=" + timestampColumnNames
         + '}';
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskTestBase.java
@@ -64,6 +64,7 @@ public class JdbcSourceTaskTestBase {
       = new EmbeddedDerby.TableName(JOIN_TABLE_NAME);
 
   protected static final String TOPIC_PREFIX = "test-";
+  protected static final String TOPIC_SUFFIX = "-test";
 
   protected Time time;
   @Mock
@@ -118,6 +119,7 @@ public class JdbcSourceTaskTestBase {
     props.put(JdbcSourceTaskConfig.TABLES_CONFIG, SINGLE_TABLE_NAME + "," + SECOND_TABLE_NAME);
     props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     props.put(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG, TOPIC_PREFIX);
+    props.put(JdbcSourceTaskConfig.TOPIC_SUFFIX_CONFIG, TOPIC_SUFFIX);
     return props;
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
@@ -64,7 +64,8 @@ public class TableQuerierTest {
                                                     databaseDialectMock, 
                                                     QueryMode.TABLE, 
                                                     TABLE_NAME, 
-                                                    null, 
+                                                    null,
+                                                    null,
                                                     null,
                                                     INCREMENTING_COLUMN_NAME, 
                                                     null,
@@ -84,8 +85,9 @@ public class TableQuerierTest {
                                                     databaseDialectMock, 
                                                     QueryMode.QUERY, 
                                                     QUERY, 
-                                                    null, 
-                                                    null, 
+                                                    null,
+                                                    null,
+                                                    null,
                                                     INCREMENTING_COLUMN_NAME, 
                                                     null, 
                                                     TIMESTAMP_DELAY, 
@@ -104,7 +106,8 @@ public class TableQuerierTest {
                                    databaseDialectMock,
                                    QueryMode.TABLE, 
                                    TABLE_NAME, 
-                                   null, 
+                                   null,
+                                   null,
                                    SUFFIX
                                );
       
@@ -119,7 +122,8 @@ public class TableQuerierTest {
                                    databaseDialectMock, 
                                    QueryMode.QUERY,
                                    QUERY, 
-                                   null, 
+                                   null,
+                                   null,
                                    SUFFIX
                                );
       
@@ -134,7 +138,8 @@ public class TableQuerierTest {
                                    databaseDialectMock, 
                                    QueryMode.QUERY, 
                                    QUERY, 
-                                   null, 
+                                   null,
+                                   null,
                                    "" /* default value */
                                );
       

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -94,6 +94,7 @@ public class TimestampIncrementingTableQuerierTest {
         TableQuerier.QueryMode.TABLE,
         tableName,
         "",
+        "",
         timestampMode ? TIMESTAMP_COLUMNS : null,
         INCREMENTING_COLUMN,
         initialOffset.toMap(),

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
@@ -92,6 +92,7 @@ public class TimestampTableQuerierTest {
         TableQuerier.QueryMode.TABLE,
         tableName,
         "",
+        "",
         TIMESTAMP_COLUMNS,
         new TimestampIncrementingOffset(initialTimestampOffset, null).toMap(),
         10211197100L, // Timestamp delay


### PR DESCRIPTION
## Problem
Currently there's a `topic.prefix ` config prop, but there's not corresponding suffix option, and useful addition for things like topic versioning and general naming conventions

## Solution

A new topic.suffix config option has been added that allows users to specify a suffix to be added to all topics. If using a custom query and `topic.prefix` is specifying a full topic name, this option is ignored.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
