### PR TITLE
(WIP): FF-5703: Support semantic types for Timestamps (string or epoch nanoseconds as long) DO NOT MERGE

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,13 +7,13 @@
 <suppressions>
 
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask|Conversions|NanoTimestamp).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(BufferedRecords|DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>
+              files="(BufferedRecords|DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect|Conversions).java"/>
 
     <suppress checks="JavaNCSS"
               files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>

--- a/src/main/java/io/confluent/connect/jdbc/data/Conversions.java
+++ b/src/main/java/io/confluent/connect/jdbc/data/Conversions.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.data;
+
+// import java.time.Duration;
+// import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+// import java.time.LocalTime;
+// import java.time.OffsetDateTime;
+// import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+
+// Ref: https://github.com/debezium/debezium/blob/master/debezium-core/src/main/java/io/debezium/time/Conversions.java
+
+final class Conversions {
+
+  static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
+  static final long MICROSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toMicros(1);
+  static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
+  static final long NANOSECONDS_PER_MICROSECOND = TimeUnit.MICROSECONDS.toNanos(1);
+  static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+  static final long NANOSECONDS_PER_DAY = TimeUnit.DAYS.toNanos(1);
+  static final long SECONDS_PER_DAY = TimeUnit.DAYS.toSeconds(1);
+  static final long MICROSECONDS_PER_DAY = TimeUnit.DAYS.toMicros(1);
+  static final LocalDate EPOCH = LocalDate.ofEpochDay(0);
+
+  private Conversions() {
+  }
+
+  @SuppressWarnings("deprecation")
+  // Todo: determine if we need all of this, or just the Timestamp > LocalDateTime conversion
+  protected static LocalDateTime toLocalDateTime(Object obj) {
+    if (obj == null) {
+      return null;
+    }
+    // if (obj instanceof OffsetDateTime) {
+    //   return ((OffsetDateTime) obj).toLocalDateTime();
+    // }
+    // if (obj instanceof Instant) {
+    //   return ((Instant) obj).atOffset(ZoneOffset.UTC).toLocalDateTime();
+    // }
+    // if (obj instanceof LocalDateTime) {
+    //   return (LocalDateTime) obj;
+    // }
+    // if (obj instanceof LocalDate) {
+    //   LocalDate date = (LocalDate) obj;
+    //   return LocalDateTime.of(date, LocalTime.MIDNIGHT);
+    // }
+    // if (obj instanceof LocalTime) {
+    //   LocalTime time = (LocalTime) obj;
+    //   return LocalDateTime.of(EPOCH, time);
+    // }
+    // if (obj instanceof java.sql.Date) {
+    //   java.sql.Date sqlDate = (java.sql.Date) obj;
+    //   LocalDate date = sqlDate.toLocalDate();
+    //   return LocalDateTime.of(date, LocalTime.MIDNIGHT);
+    // }
+    // if (obj instanceof java.sql.Time) {
+    //   LocalTime localTime = toLocalTime(obj);
+    //   return LocalDateTime.of(EPOCH, localTime);
+    // }
+    if (obj instanceof java.sql.Timestamp) {
+      java.sql.Timestamp timestamp = (java.sql.Timestamp) obj;
+      return LocalDateTime.of(timestamp.getYear() + 1900,
+                              timestamp.getMonth() + 1,
+                              timestamp.getDate(),
+                              timestamp.getHours(),
+                              timestamp.getMinutes(),
+                              timestamp.getSeconds(),
+                              timestamp.getNanos());
+    }
+    // if (obj instanceof java.util.Date) {
+    //   java.util.Date date = (java.util.Date) obj;
+    //   long millis = (int) (date.getTime() % Conversions.MILLISECONDS_PER_SECOND);
+    //   if (millis < 0) {
+    //     millis = Conversions.MILLISECONDS_PER_SECOND + millis;
+    //   }
+    //   int nanosOfSecond = (int) (millis * Conversions.NANOSECONDS_PER_MILLISECOND);
+    //   return LocalDateTime.of(date.getYear() + 1900,
+    //     date.getMonth() + 1,
+    //     date.getDate(),
+    //     date.getHours(),
+    //     date.getMinutes(),
+    //     date.getSeconds(),
+    //     nanosOfSecond);
+    // }
+    throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value '" 
+      + obj + "' of type " + obj.getClass().getName());
+  }
+  
+
+  static long toEpochNanos(LocalDateTime timestamp) {
+    long nanoInDay = timestamp.toLocalTime().toNanoOfDay();
+    long nanosOfDay = toEpochNanos(timestamp.toLocalDate());
+    return nanosOfDay + nanoInDay;
+  }
+
+  /**
+   * Get the number of nanoseconds past epoch of the given {@link LocalDate}.
+   * 
+   * @param date the Java date value
+   * @return the epoch nanoseconds
+   */
+  static long toEpochNanos(LocalDate date) {
+    long epochDay = date.toEpochDay();
+    return epochDay * Conversions.NANOSECONDS_PER_DAY;
+  }
+
+  // static String toEpochNanosString(LocalDate date) {
+
+  // }
+}

--- a/src/main/java/io/confluent/connect/jdbc/data/Conversions.java
+++ b/src/main/java/io/confluent/connect/jdbc/data/Conversions.java
@@ -43,6 +43,7 @@ final class Conversions {
 
   @SuppressWarnings("deprecation")
   // Todo: determine if we need all of this, or just the Timestamp > LocalDateTime conversion
+  // Also todo: see if we can reduce the number of conversions here
   protected static LocalDateTime toLocalDateTime(Object obj) {
     if (obj == null) {
       return null;

--- a/src/main/java/io/confluent/connect/jdbc/data/NanoTimestamp.java
+++ b/src/main/java/io/confluent/connect/jdbc/data/NanoTimestamp.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.data;
+
+import java.time.LocalDateTime;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Utility class for managing nano timestamp representations
+ * 
+ */
+public class NanoTimestamp {
+  public static final String SCHEMA_NAME = "io.confluent.connect.jdbc.data.NanoTimestamp";
+
+  public static SchemaBuilder builder() {
+    return SchemaBuilder.int64()
+                        .name(SCHEMA_NAME)
+                        .version(1);
+  }
+
+  public static Schema schema() {
+    return builder().build();
+  }
+
+  public static long toEpochNanos(Object value) {
+    LocalDateTime dateTime = Conversions.toLocalDateTime(value);
+    return Conversions.toEpochNanos(dateTime);
+  }
+
+  private NanoTimestamp() {
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/data/NanoTimestampString.java
+++ b/src/main/java/io/confluent/connect/jdbc/data/NanoTimestampString.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.data;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Utility class for managing nano timestamp representations
+ * 
+ */
+public class NanoTimestampString {
+  public static final String SCHEMA_NAME = "io.confluent.connect.jdbc.data.NanoTimestampString";
+  private static DateTimeFormatter formatter = 
+      DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+
+  public static SchemaBuilder builder() {
+    return SchemaBuilder.string()
+                        .name(SCHEMA_NAME)
+                        .version(1);
+  }
+
+  public static Schema schema() {
+    return builder().build();
+  }
+
+  // public static long toEpochNanos(Object value) {
+  //   LocalDateTime dateTime = Conversions.toLocalDateTime(value);
+  //   return Conversions.toEpochNanos(dateTime);
+  // }
+
+  public static String toNanoString(Object value) {
+    LocalDateTime dateTime = Conversions.toLocalDateTime(value);
+    return dateTime.format(formatter);
+  } 
+
+  private NanoTimestampString() {
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -91,6 +91,9 @@ import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.TableType;
 
+import io.confluent.connect.jdbc.data.NanoTimestamp;
+import io.confluent.connect.jdbc.data.NanoTimestampString;
+
 /**
  * A {@link DatabaseDialect} implementation that provides functionality based upon JDBC and SQL.
  *
@@ -1154,12 +1157,30 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
       // Timestamp is a date + time
       case Types.TIMESTAMP: {
-        SchemaBuilder tsSchemaBuilder = org.apache.kafka.connect.data.Timestamp.builder();
-        if (optional) {
-          tsSchemaBuilder.optional();
+        if (0 == 1) {
+          // Placeholder: flag for INT64
+          SchemaBuilder ntSchemaBuilder = NanoTimestamp.builder();
+          if (optional) {
+            ntSchemaBuilder.optional();
+          }
+          builder.field(fieldName, ntSchemaBuilder.build());
+          break;
+        } else if (0 == 0) {
+          // Placeholder: flag for STRING
+          SchemaBuilder ntsSchemaBuilder = NanoTimestampString.builder();
+          if (optional) {
+            ntsSchemaBuilder.optional();
+          }
+          builder.field(fieldName, ntsSchemaBuilder.build());
+          break;
+        } else {
+          SchemaBuilder tsSchemaBuilder = org.apache.kafka.connect.data.Timestamp.builder();
+          if (optional) {
+            tsSchemaBuilder.optional();
+          }
+          builder.field(fieldName, tsSchemaBuilder.build());
+          break;
         }
-        builder.field(fieldName, tsSchemaBuilder.build());
-        break;
       }
 
       case Types.ARRAY:
@@ -1385,7 +1406,19 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
       // Timestamp is a date + time
       case Types.TIMESTAMP: {
-        return rs -> rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
+        if (0 == 1) {
+          return rs -> {
+            Timestamp ts = rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
+            return NanoTimestamp.toEpochNanos(ts);
+          };
+        } else if (2 == 2) {
+          return rs -> {
+            Timestamp ts = rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
+            return NanoTimestampString.toNanoString(ts);
+          };
+        } else {
+          return rs -> rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
+        }
       }
 
       // Datalink is basically a URL -> string

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -131,6 +131,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   private static final EnumRecommender NUMERIC_MAPPING_RECOMMENDER =
       EnumRecommender.in(NumericMapping.values());
 
+  public static final String TIMESTAMP_MAPPING_CONFIG = "timestamp.mapping";
+  public static final String TIMESTAMP_MAPPING_UNSPECIFIED = "";
+  public static final String TIMESTAMP_MAPPING_NANOS = "nanos";
+  public static final String TIMESTAMP_MAPPING_NANOS_STRING = "nanos_string";
+  private static final String TIMESTAMP_MAPPING_DOC =
+      "Mode used to map SQL TIMESTAMP values to Kafka Connect types.  By default this is "
+      + "empty, and the connector automatically";
+  private static final String TIMESTAMP_MAPPING_DISPLAY = "Timestamp Mapping Format";
+
+
   public static final String DIALECT_NAME_CONFIG = "dialect.name";
   private static final String DIALECT_NAME_DISPLAY = "Database Dialect";
   public static final String DIALECT_NAME_DEFAULT = "";
@@ -435,6 +445,21 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         Width.SHORT,
         NUMERIC_MAPPING_DISPLAY,
         NUMERIC_MAPPING_RECOMMENDER
+    ).define(
+        TIMESTAMP_MAPPING_CONFIG,
+        Type.STRING,
+        TIMESTAMP_MAPPING_UNSPECIFIED,
+        ConfigDef.ValidString.in(
+          TIMESTAMP_MAPPING_UNSPECIFIED,
+          TIMESTAMP_MAPPING_NANOS,
+          TIMESTAMP_MAPPING_NANOS_STRING
+        ),
+        Importance.LOW,
+        TIMESTAMP_MAPPING_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.LONG,
+        TIMESTAMP_MAPPING_DISPLAY
     ).define(
         DIALECT_NAME_CONFIG,
         Type.STRING,


### PR DESCRIPTION
## Problem

Customers have requirements for more-than-millsecond granularity for timestamps (specifically in Oracle, but also generally).

## Solution

This WIP PR introduces flaggable behavior, which interprets timestamps as strings or longs (nanos since epoch)

Still need to implement the actual flag, and make sure this doesn't break the timestamp incrementer.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
