### PR TITLE
Fix Sybase dialect upsert syntax

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -250,32 +250,32 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
     builder.append(table);
     builder.append(" AS target using (select ");
     builder.appendList()
-        .delimitedBy(", ")
-        .transformedBy(ExpressionBuilder.columnNamesWithPrefix("? AS "))
-        .of(keyColumns, nonKeyColumns);
+           .delimitedBy(", ")
+           .transformedBy(ExpressionBuilder.columnNamesWithPrefix("? AS "))
+           .of(keyColumns, nonKeyColumns);
     builder.append(") AS incoming on (");
     builder.appendList()
-        .delimitedBy(" and ")
-        .transformedBy(this::transformAs)
-        .of(keyColumns);
+           .delimitedBy(" and ")
+           .transformedBy(this::transformAs)
+           .of(keyColumns);
     builder.append(")");
     if (nonKeyColumns != null && !nonKeyColumns.isEmpty()) {
       builder.append(" when matched then update set ");
       builder.appendList()
-          .delimitedBy(",")
-          .transformedBy(this::transformUpdate)
-          .of(nonKeyColumns);
+             .delimitedBy(",")
+             .transformedBy(this::transformUpdate)
+             .of(nonKeyColumns);
     }
     builder.append(" when not matched then insert (");
     builder.appendList()
-        .delimitedBy(", ")
-        .transformedBy(ExpressionBuilder.columnNames())
-        .of(nonKeyColumns, keyColumns);
+           .delimitedBy(", ")
+           .transformedBy(ExpressionBuilder.columnNames())
+           .of(nonKeyColumns, keyColumns);
     builder.append(") values (");
     builder.appendList()
-        .delimitedBy(",")
-        .transformedBy(ExpressionBuilder.columnNamesWithPrefix("incoming."))
-        .of(nonKeyColumns, keyColumns);
+           .delimitedBy(",")
+           .transformedBy(ExpressionBuilder.columnNamesWithPrefix("incoming."))
+           .of(nonKeyColumns, keyColumns);
     builder.append(")");
     return builder.toString();
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -248,35 +248,35 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
     ExpressionBuilder builder = expressionBuilder();
     builder.append("merge into ");
     builder.append(table);
-    builder.append(" with (HOLDLOCK) AS target using (select ");
+    builder.append(" AS target using (select ");
     builder.appendList()
-           .delimitedBy(", ")
-           .transformedBy(ExpressionBuilder.columnNamesWithPrefix("? AS "))
-           .of(keyColumns, nonKeyColumns);
+        .delimitedBy(", ")
+        .transformedBy(ExpressionBuilder.columnNamesWithPrefix("? AS "))
+        .of(keyColumns, nonKeyColumns);
     builder.append(") AS incoming on (");
     builder.appendList()
-           .delimitedBy(" and ")
-           .transformedBy(this::transformAs)
-           .of(keyColumns);
+        .delimitedBy(" and ")
+        .transformedBy(this::transformAs)
+        .of(keyColumns);
     builder.append(")");
     if (nonKeyColumns != null && !nonKeyColumns.isEmpty()) {
       builder.append(" when matched then update set ");
       builder.appendList()
-             .delimitedBy(",")
-             .transformedBy(this::transformUpdate)
-             .of(nonKeyColumns);
+          .delimitedBy(",")
+          .transformedBy(this::transformUpdate)
+          .of(nonKeyColumns);
     }
     builder.append(" when not matched then insert (");
     builder.appendList()
-           .delimitedBy(", ")
-           .transformedBy(ExpressionBuilder.columnNames())
-           .of(nonKeyColumns, keyColumns);
+        .delimitedBy(", ")
+        .transformedBy(ExpressionBuilder.columnNames())
+        .of(nonKeyColumns, keyColumns);
     builder.append(") values (");
     builder.appendList()
-           .delimitedBy(",")
-           .transformedBy(ExpressionBuilder.columnNamesWithPrefix("incoming."))
-           .of(nonKeyColumns, keyColumns);
-    builder.append(");");
+        .delimitedBy(",")
+        .transformedBy(ExpressionBuilder.columnNamesWithPrefix("incoming."))
+        .of(nonKeyColumns, keyColumns);
+    builder.append(")");
     return builder.toString();
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -192,7 +192,7 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
   @Test
   public void shouldBuildUpsertStatement() {
     assertEquals(
-        "merge into \"myTable\" with (HOLDLOCK) AS target using (select ? AS \"id1\", ?" +
+        "merge into \"myTable\" AS target using (select ? AS \"id1\", ?" +
         " AS \"id2\", ? AS \"columnA\", ? AS \"columnB\", ? AS \"columnC\", ? AS \"columnD\")" +
         " AS incoming on (target.\"id1\"=incoming.\"id1\" and target.\"id2\"=incoming" +
         ".\"id2\") when matched then update set \"columnA\"=incoming.\"columnA\"," +
@@ -200,14 +200,14 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
         "\"columnD\"=incoming.\"columnD\" when not matched then insert (\"columnA\", " +
         "\"columnB\", \"columnC\", \"columnD\", \"id1\", \"id2\") values (incoming.\"columnA\"," +
         "incoming.\"columnB\",incoming.\"columnC\",incoming.\"columnD\",incoming.\"id1\"," +
-        "incoming.\"id2\");",
+        "incoming.\"id2\")",
         dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
     );
 
     quoteIdentfiiers = QuoteMethod.NEVER;
     dialect = createDialect();
     assertEquals(
-        "merge into myTable with (HOLDLOCK) AS target using (select ? AS id1, ?" +
+        "merge into myTable AS target using (select ? AS id1, ?" +
         " AS id2, ? AS columnA, ? AS columnB, ? AS columnC, ? AS columnD)" +
         " AS incoming on (target.id1=incoming.id1 and target.id2=incoming" +
         ".id2) when matched then update set columnA=incoming.columnA," +
@@ -215,7 +215,7 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
         "columnD=incoming.columnD when not matched then insert (columnA, " +
         "columnB, columnC, columnD, id1, id2) values (incoming.columnA," +
         "incoming.columnB,incoming.columnC,incoming.columnD,incoming.id1," +
-        "incoming.id2);",
+        "incoming.id2)",
         dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
     );
   }


### PR DESCRIPTION
## Problem
With the current merge query, user will hit the following SQL exception.
```
WARN Write of 1 records failed, remainingRetries=10 (io.confluent.connect.jdbc.sink.JdbcSinkTask:92)
java.sql.BatchUpdateException: Incorrect syntax near the keyword 'with'.
```
According to the [docs](https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc00938.1570/html/locking/locking103.htm), Sybase does support HOLDLOCK syntax directly after table name. But appending HOLDLOCK to the table name also fails in the case of merge. While the [documentation for merge command](https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc36272.1600/doc/html/san1393051041603.html) did not mention HOLDLOCK at all.

The other problem is that the driver also complains about the trailing semicolon.

## Solution
Remove HOLDLOCK from merge query.
Remove semicolon from merge query.
 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
