### PR TITLE
MINOR: fix the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 common {
   slackChannel = '#connect-warn'
+  nodeLabel = 'docker-oraclejdk8'
   upstreamProjects = 'confluentinc/common'
   pintMerge = true
 }


### PR DESCRIPTION
## Problem
All `5.0.x`+ builds failing with 
```
01:33:34  [2021-09-04 08:33:34,264] ERROR mysql: /tmp/MariaDB4j/base/bin/mysql: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory (ch.vorburger.exec.ManagedProcess:71)
```

## Solution
Root cause is https://github.com/confluentinc/jenkins-common/pull/373/files changing the default jenkins node to `docker-debian-10-jdk8` , which likely does not have `libncurses` package installed. Change it back to previous label we were using - `docker-oraclejdk8`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
Other connectors either already have specified nodeLabel `docker-oraclejdk8` or are fine building with the new `docker-debian-10-jdk8` image.

## Test Strategy
Rely on PR builder to run in Jenkins

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
