### PR TITLE
Include the TableAlterOrCreateException in creatOrAmend path for sink…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -78,7 +78,7 @@ public class BufferedRecords {
     this.recordValidator = RecordValidator.create(config);
   }
 
-  public List<SinkRecord> add(SinkRecord record) throws SQLException {
+  public List<SinkRecord> add(SinkRecord record) throws SQLException, TableAlterOrCreateException {
     recordValidator.validate(record);
     final List<SinkRecord> flushed = new ArrayList<>();
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -60,7 +60,7 @@ public class DbStructure {
       final Connection connection,
       final TableId tableId,
       final FieldsMetadata fieldsMetadata
-  ) throws SQLException {
+  ) throws SQLException, TableAlterOrCreateException {
     if (tableDefns.get(connection, tableId) == null) {
       // Table does not yet exist, so attempt to create it ...
       try {
@@ -75,6 +75,9 @@ public class DbStructure {
         } catch (SQLException e) {
           throw sqle;
         }
+      } catch (TableAlterOrCreateException te) {
+        log.warn(te.getMessage());
+        throw te;
       }
     }
     return amendIfNecessary(config, connection, tableId, fieldsMetadata, config.maxRetries);
@@ -109,7 +112,7 @@ public class DbStructure {
       final Connection connection,
       final TableId tableId,
       final FieldsMetadata fieldsMetadata
-  ) throws SQLException {
+  ) throws SQLException, TableAlterOrCreateException {
     if (!config.autoCreate) {
       throw new TableAlterOrCreateException(
           String.format("Table %s is missing and auto-creation is disabled", tableId)

--- a/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/DbStructureTest.java
@@ -67,6 +67,24 @@ public class DbStructureTest {
   }
 
   @Test (expected = TableAlterOrCreateException.class)
+  public void testCreateOrAlterNoAutoEvolve() throws Exception {
+    when(dbDialect.tableExists(any(), any())).thenReturn(false);
+
+    SinkRecordField sinkRecordField = new SinkRecordField(
+        Schema.OPTIONAL_INT32_SCHEMA,
+        "test",
+        false
+    );
+
+    fieldsMetadata = new FieldsMetadata(
+        Collections.emptySet(),
+        Collections.singleton(sinkRecordField.name()),
+        Collections.singletonMap(sinkRecordField.name(), sinkRecordField));
+
+    structure.createOrAmendIfNecessary(config, connection, tableId, fieldsMetadata);
+  }
+
+  @Test (expected = TableAlterOrCreateException.class)
   public void testAlterNoAutoEvolve() throws Exception {
     TableDefinition tableDefinition = mock(TableDefinition.class);
     when(dbDialect.tableExists(any(), any())).thenReturn(true);


### PR DESCRIPTION
… connectors

## Problem
Caused by: java.lang.NullPointerException: Cannot invoke "io.confluent.connect.jdbc.util.TableDefinition.columnNames()" because "tableDefn" is null
	at io.confluent.connect.jdbc.sink.DbStructure.amendIfNecessary(DbStructure.java:151)
	at io.confluent.connect.jdbc.sink.DbStructure.createOrAmendIfNecessary(DbStructure.java:80)
	at io.confluent.connect.jdbc.sink.BufferedRecords.add(BufferedRecords.java:123)
	at io.confluent.connect.jdbc.sink.JdbcDbWriter.write(JdbcDbWriter.java:74)
	at io.confluent.connect.jdbc.sink.JdbcSinkTask.put(JdbcSinkTask.java:84)

## Solution
This is because TableAlterOrCreateException is unhandled and is silently ignored. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no


## Test Strategy
Test with unit tests. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
