### PR TITLE
Fix the JDBC data loss issue, by updating the internal offset value

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -109,7 +109,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
 
   public abstract SourceRecord extractRecord() throws SQLException;
 
-  public void reset(long now) {
+  public void reset(long now, boolean resetOffset) {
     closeResultSetQuietly();
     closeStatementQuietly();
     releaseLocksQuietly();

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -155,6 +155,12 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
   }
 
   @Override
+  public void reset(long now, boolean resetOffset) {
+    this.nextRecord = null;
+    super.reset(now, resetOffset);
+  }
+
+  @Override
   public String toString() {
     return "TimestampTableQuerier{"
         + "table=" + tableId

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -213,7 +213,7 @@ public class TimestampIncrementingTableQuerierTest {
 
     assertFalse(querier.next());
 
-    querier.reset(0);
+    querier.reset(0, true);
     querier.maybeStartQuery(db);
 
     assertNextRecord(querier, initialOffset);

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
@@ -263,13 +263,67 @@ public class TimestampTableQuerierTest {
 
     assertFalse(querier.next());
 
-    querier.reset(0);
+    querier.reset(0, true);
     querier.maybeStartQuery(db);
 
     // We have to commit for the last record in the batch
     assertNextRecord(querier, INITIAL_TS);
 
     assertFalse(querier.next());
+  }
+
+  @Test
+  public void testMultipleDoubleRecordResultSetsOffsetReset() throws Exception {
+    Timestamp firstNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    expectNewQuery();
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(INITIAL_TS);
+    expectRecord(firstNewTimestamp);
+    expect(resultSet.next()).andReturn(false);
+    expectReset();
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // We have to commit for the last record in the batch
+    assertNextRecord(querier, INITIAL_TS);
+    assertNextRecord(querier, firstNewTimestamp);
+
+    assertFalse(querier.next());
+
+    querier.reset(0, true);
+    querier.maybeStartQuery(db);
+
+    assertEquals(querier.offset.getTimestampOffset(), INITIAL_TS);
+  }
+
+  @Test
+  public void testMultipleDoubleRecordResultSetsNoOffsetReset() throws Exception {
+    Timestamp firstNewTimestamp = new Timestamp(INITIAL_TS.getTime() + 1);
+    expectNewQuery();
+    expectNewQuery();
+    TimestampIncrementingTableQuerier querier = querier(INITIAL_TS);
+    expectRecord(INITIAL_TS);
+    expectRecord(firstNewTimestamp);
+    expect(resultSet.next()).andReturn(false);
+    expectReset();
+
+    replayAll();
+
+    querier.maybeStartQuery(db);
+
+    // We have to commit for the last record in the batch
+    assertNextRecord(querier, INITIAL_TS);
+    assertNextRecord(querier, firstNewTimestamp);
+
+    assertFalse(querier.next());
+
+    querier.reset(0, false);
+    querier.maybeStartQuery(db);
+
+    assertEquals(querier.offset.getTimestampOffset(), firstNewTimestamp);
   }
 
   private void assertNextRecord(


### PR DESCRIPTION
## Problem
The connector experiences data loss when it sees JDBC connection timeouts. This has particularly happened when `querier.next()`  is called midway through a batch. 
The error is

```
2021-10-01 17:13:04,414 ERROR (io.confluent.connect.jdbc.source.JdbcSourceTask:419) null - SQL exception while running query for table: <xxxx> 
java.sql.SQLRecoverableException: Closed Connection: next
at oracle.jdbc.driver.InsensitiveScrollableResultSet.ensureOpen(InsensitiveScrollableResultSet.java:110)
at oracle.jdbc.driver.InsensitiveScrollableResultSet.next(InsensitiveScrollableResultSet.java:404)
at io.confluent.connect.jdbc.source.TimestampTableQuerier.next(TimestampTableQuerier.java:107)
at io.confluent.connect.jdbc.source.JdbcSourceTask.poll(JdbcSourceTask.java:383)
```
The problem is because we cleanup the resultSet, stmt and release the locks. None of the records processed from the entire ResultSet is committed. But there are two important state objects that are not cleaned up properly in `TimestampTableQuerier` class, the `nextRecord` and `offset`

These values store state from the previous queries ResultSet and affect the offset committing logic.

## Solution
The solution is to update an internal `committedOffset` everytime after a successful `poll()` run. A failure in `poll()` would reset all the state variables. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
- Unit tests
- Manual tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. --> Release a new minor version
<!-- Are you backporting or merging to master? --> Merging to Master 
<!-- If you are reverting or rolling back, is it safe? --> NA
