### PR TITLE
Fix the JDBC data loss issue, by updating the internal offset value

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -335,7 +335,7 @@ public class JdbcSourceTask extends SourceTask {
         if (!hadNext) {
           // If we finished processing the results from the current query, we can reset and send
           // the querier to the tail of the queue
-          resetAndRequeueHead(querier);
+          resetAndRequeueHead(querier, false);
         }
 
         if (results.isEmpty()) {
@@ -358,10 +358,10 @@ public class JdbcSourceTask extends SourceTask {
         return results;
       } catch (SQLException sqle) {
         log.error("Failed to run query for table {}: {}", querier.toString(), sqle);
-        resetAndRequeueHead(querier);
+        resetAndRequeueHead(querier, true);
         return null;
       } catch (Throwable t) {
-        resetAndRequeueHead(querier);
+        resetAndRequeueHead(querier, true);
         // This task has failed, so close any resources (may be reopened if needed) before throwing
         closeResources();
         throw t;
@@ -371,17 +371,17 @@ public class JdbcSourceTask extends SourceTask {
     // Only in case of shutdown
     final TableQuerier querier = tableQueue.peek();
     if (querier != null) {
-      resetAndRequeueHead(querier);
+      resetAndRequeueHead(querier, true);
     }
     closeResources();
     return null;
   }
 
-  private void resetAndRequeueHead(TableQuerier expectedHead) {
+  private void resetAndRequeueHead(TableQuerier expectedHead, boolean resetOffset) {
     log.debug("Resetting querier {}", expectedHead.toString());
     TableQuerier removedQuerier = tableQueue.poll();
     assert removedQuerier == expectedHead;
-    expectedHead.reset(time.milliseconds());
+    expectedHead.reset(time.milliseconds(), resetOffset);
     tableQueue.add(expectedHead);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -105,7 +105,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
 
   public abstract SourceRecord extractRecord() throws SQLException;
 
-  public void reset(long now) {
+  public void reset(long now, boolean resetOffset) {
     closeResultSetQuietly();
     closeStatementQuietly();
     releaseLocksQuietly();

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -65,6 +65,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   );
 
   protected final List<String> timestampColumnNames;
+  protected TimestampIncrementingOffset committedOffset;
   protected TimestampIncrementingOffset offset;
   protected TimestampIncrementingCriteria criteria;
   protected final Map<String, String> partition;
@@ -85,7 +86,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     this.timestampColumnNames = timestampColumnNames != null
         ? timestampColumnNames : Collections.emptyList();
     this.timestampDelay = timestampDelay;
-    this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
+    this.committedOffset = this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
 
     this.timestampColumns = new ArrayList<>();
     for (String timestampColumn : this.timestampColumnNames) {
@@ -160,6 +161,11 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       dialect.validateSpecificColumnTypes(metadata, timestampColumns);
       schemaMapping = SchemaMapping.create(schemaName, metadata, dialect);
     }
+
+    // This is called everytime during poll() before extracting records,
+    // to ensure that the previous run succeeded, allowing us to move the committedOffset forward.
+    // This action is a no-op for the first poll()
+    this.committedOffset = this.offset;
   }
 
   private void findDefaultAutoIncrementingColumn(Connection db) throws SQLException {
@@ -214,6 +220,16 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     }
     offset = criteria.extractValues(schemaMapping.schema(), record, offset);
     return new SourceRecord(partition, offset.toMap(), topic, record.schema(), record);
+  }
+
+  @Override
+  public void reset(long now, boolean resetOffset) {
+    // the task is being reset, any uncommitted offset needs to be reset as well
+    // use the previous committedOffset to set the running offset
+    if (resetOffset) {
+      this.offset = this.committedOffset;
+    }
+    super.reset(now, resetOffset);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -153,6 +153,12 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
   }
 
   @Override
+  public void reset(long now, boolean resetOffset) {
+    this.nextRecord = null;
+    super.reset(now, resetOffset);
+  }
+
+  @Override
   public String toString() {
     return "TimestampTableQuerier{"
         + "table=" + tableId

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -212,7 +212,7 @@ public class TimestampIncrementingTableQuerierTest {
 
     assertFalse(querier.next());
 
-    querier.reset(0);
+    querier.reset(0, true);
     querier.maybeStartQuery(db);
 
     assertNextRecord(querier, initialOffset);


### PR DESCRIPTION
## Problem
The connector experiences data loss when it sees JDBC connection timeouts. This has particularly happened when `querier.next()`  is called midway through a batch. 
The error is

```
2021-10-01 17:13:04,414 ERROR (io.confluent.connect.jdbc.source.JdbcSourceTask:419) null - SQL exception while running query for table: <xxxx> 
java.sql.SQLRecoverableException: Closed Connection: next
at oracle.jdbc.driver.InsensitiveScrollableResultSet.ensureOpen(InsensitiveScrollableResultSet.java:110)
at oracle.jdbc.driver.InsensitiveScrollableResultSet.next(InsensitiveScrollableResultSet.java:404)
at io.confluent.connect.jdbc.source.TimestampTableQuerier.next(TimestampTableQuerier.java:107)
at io.confluent.connect.jdbc.source.JdbcSourceTask.poll(JdbcSourceTask.java:383)
```
The problem is because we cleanup the resultSet, stmt and release the locks. None of the records processed from the entire ResultSet is committed. But there are two important state objects that are not cleaned up properly in `TimestampTableQuerier` class, the `nextRecord` and `offset`

These values store state from the previous queries ResultSet and affect the offset committing logic.

## Solution
The solution is to update an internal `committedOffset` everytime after a successful `poll()` run. A failure in `poll()` would reset all the state variables. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
- Unit tests
- Manual tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. --> Release a new minor version
<!-- Are you backporting or merging to master? --> Merging to Master 
<!-- If you are reverting or rolling back, is it safe? --> NA
