### PR TITLE
Change PreparedStatement.setString to setObject to work around Kudu's…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1663,7 +1663,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         statement.setBoolean(index, (Boolean) value);
         break;
       case STRING:
-        statement.setString(index, (String) value);
+        statement.setObject(index, value);
         break;
       case BYTES:
         final byte[] bytes;

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -451,7 +451,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
   @Test
   public void bindFieldStringValue() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
-    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setObject(index, "yep");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -335,7 +335,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     when(colDefClob.type()).thenReturn(Types.CLOB);
 
     dialect.bindField(stmtVarchar, index, schema, value, colDefVarchar);
-    verify(stmtVarchar, times(1)).setString(index, value);
+    verify(stmtVarchar, times(1)).setObject(index, value);
 
     dialect.bindField(stmtNchar, index, schema, value, colDefNchar);
     verify(stmtNchar, times(1)).setNString(index, value);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -345,7 +345,7 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     verifyBindField(++index, Schema.FLOAT64_SCHEMA, 42d).setDouble(index, 42d);
     verifyBindField(++index, Schema.BYTES_SCHEMA, new byte[]{42}).setBytes(index, new byte[]{42});
     verifyBindField(++index, Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{42})).setBytes(index, new byte[]{42});
-    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setString(index, "yep");
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setObject(index, "yep");
     verifyBindField(++index, Decimal.schema(0), new BigDecimal("1.5").setScale(0, BigDecimal.ROUND_HALF_EVEN)).setBigDecimal(index, new BigDecimal(2));
     Calendar utcCalendar = DateTimeUtils.getTimeZoneCalendar(TimeZone.getTimeZone(ZoneOffset.UTC));
     verifyBindField(

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -187,8 +187,8 @@ public class PreparedStatementBinderTest {
     // key field first
     verify(statement, times(1)).setLong(index++, valueStruct.getInt64("long"));
     // rest in order of schema def
-    verify(statement, times(1)).setString(index++, valueStruct.getString("firstName"));
-    verify(statement, times(1)).setString(index++, valueStruct.getString("lastName"));
+    verify(statement, times(1)).setObject(index++, valueStruct.getString("firstName"));
+    verify(statement, times(1)).setObject(index++, valueStruct.getString("lastName"));
     verify(statement, times(1)).setInt(index++, valueStruct.getInt32("age"));
     verify(statement, times(1)).setBoolean(index++, valueStruct.getBoolean("bool"));
     verify(statement, times(1)).setShort(index++, valueStruct.getInt16("short"));
@@ -261,7 +261,7 @@ public class PreparedStatementBinderTest {
       // key field first
       verify(statement, times(1)).setLong(index++, valueStruct.getInt64("long"));
       // rest in order of schema def
-      verify(statement, times(1)).setString(index++, valueStruct.getString("firstName"));
+      verify(statement, times(1)).setObject(index++, valueStruct.getString("firstName"));
     }
 
     @Test
@@ -311,7 +311,7 @@ public class PreparedStatementBinderTest {
       int index = 1;
 
       // non key first
-      verify(statement, times(1)).setString(index++, valueStruct.getString("firstName"));
+      verify(statement, times(1)).setObject(index++, valueStruct.getString("firstName"));
       // last the keys
       verify(statement, times(1)).setLong(index++, valueStruct.getInt64("long"));
     }


### PR DESCRIPTION
… 500 character limit for strings

## Problem
The Impala JDBC driver does not support inserting strings >500 characters with PreparedStatement.setString, causing a customer's KuduSinkConnector to fail

## Solution
PreparedStatement.setObject has the same functionality as setString but does not have the 500 character limit. The only caveat is it may misinterpret strings as other datatypes if there is any confusion

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
