### PR TITLE
MINOR: call `setCharacterStream` API with length

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -141,14 +141,15 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     }
 
     if (schema.type() == Type.STRING) {
+      String strValue = (String) value;
       if (colDef.type() == Types.CLOB) {
-        statement.setCharacterStream(index, new StringReader((String) value));
+        statement.setCharacterStream(index, new StringReader(strValue), strValue.length());
         return true;
       } else if (colDef.type() == Types.NCLOB) {
-        statement.setNCharacterStream(index, new StringReader((String) value));
+        statement.setNCharacterStream(index, new StringReader(strValue), strValue.length());
         return true;
       } else if (colDef.type() == Types.NVARCHAR || colDef.type() == Types.NCHAR) {
-        statement.setNString(index, (String) value);
+        statement.setNString(index, strValue);
         return true;
       } else {
         return super.maybeBindPrimitive(statement, index, schema, value);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -56,8 +56,10 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Override
   @Test
   public void bindFieldStringValue() throws SQLException {
+    String value = "yep";
     int index = ThreadLocalRandom.current().nextInt();
-    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setCharacterStream(eq(index), any(StringReader.class));
+    verifyBindField(++index, Schema.STRING_SCHEMA, value)
+        .setCharacterStream(eq(index), any(StringReader.class), eq(value.length()));
   }
 
   @Override
@@ -343,7 +345,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     verify(stmtNvarchar, times(1)).setNString(index, value);
 
     dialect.bindField(stmtClob, index, schema, value, colDefClob);
-    verify(stmtClob, times(1)).setCharacterStream(eq(index), any(StringReader.class));
+    verify(stmtClob, times(1))
+        .setCharacterStream(eq(index), any(StringReader.class), eq(value.length()));
   }
 
   @Test


### PR DESCRIPTION
## Problem
Performance regression when writing short strings into CLOB type columns

## Solution
Call the `setCharacterStream` and `setNCharacterStream` variants that take the length of the stream as argument. These variants can use the length to determine the most efficient binding to use. From javadoc:
> Consult your JDBC driver documentation to determine if it might be more efficient to use a version of setCharacterStream which takes a length parameter.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Unit tests were updated. Manually verified performance regression fixed.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backport fix all the way back to `5.0.x` when #1004 introduced this logic.