### PR TITLE
CCDB-4454: Automatically truncate long table names to respect PostgreSQL length limits

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -15,23 +15,6 @@
 
 package io.confluent.connect.jdbc.dialect;
 
-import java.util.Map;
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Time;
-import org.apache.kafka.connect.data.Timestamp;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.util.Collection;
-
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
@@ -41,15 +24,34 @@ import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
 import io.confluent.connect.jdbc.util.IdentifierRules;
 import io.confluent.connect.jdbc.util.TableId;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * A {@link DatabaseDialect} for PostgreSQL.
  */
 public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
-  private final Logger log = LoggerFactory.getLogger(PostgreSqlDatabaseDialect.class);
+  private static final Logger log = LoggerFactory.getLogger(PostgreSqlDatabaseDialect.class);
+
+  // Visible for testing
+  volatile int maxIdentifierLength = 0;
 
   /**
    * The provider for {@link PostgreSqlDatabaseDialect}.
@@ -75,6 +77,70 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    */
   public PostgreSqlDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    Connection result = super.getConnection();
+    synchronized (this) {
+      if (maxIdentifierLength <= 0) {
+        maxIdentifierLength = computeMaxIdentifierLength(result);
+      }
+    }
+    return result;
+  }
+
+  static int computeMaxIdentifierLength(Connection connection) {
+    String warningMessage = "Unable to query database for maximum table name length; "
+        + "the connector may fail to write to tables with long names";
+    // https://stackoverflow.com/questions/27865770/how-long-can-postgresql-table-names-be/27865772#27865772
+    String nameLengthQuery = "SELECT length(repeat('1234567890', 1000)::NAME);";
+    
+    int result;
+    try (ResultSet rs = connection.createStatement().executeQuery(nameLengthQuery)) {
+      if (rs.next()) {
+        result = rs.getInt(1);
+        if (result <= 0) {
+          log.warn(
+              "Cannot accommodate maximum table name length of {} as it is not positive; "
+                  + "table name truncation will be disabled, "
+                  + "and the connector may fail to write to tables with long names",
+              result);
+          result = Integer.MAX_VALUE;
+        } else {
+          log.info(
+              "Maximum table name length for database is {} bytes",
+              result
+          );
+        }
+      } else {
+        log.warn(warningMessage);
+        result = Integer.MAX_VALUE;
+      }
+    } catch (SQLException e) {
+      log.warn(warningMessage, e);
+      result = Integer.MAX_VALUE;
+    }
+    return result;
+  }
+
+  @Override
+  public TableId parseTableIdentifier(String fqn) {
+    TableId result = super.parseTableIdentifier(fqn);
+    if (maxIdentifierLength > 0 && result.tableName().length() > maxIdentifierLength) {
+      String newTableName = result.tableName().substring(0, maxIdentifierLength);
+      log.debug(
+          "Truncating table name from {} to {} in order to respect maximum name length",
+          result.tableName(),
+          newTableName
+      );
+      result = new TableId(
+          result.catalogName(),
+          result.schemaName(),
+          newTableName
+      );
+    }
+    return result;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -15,6 +15,10 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -30,6 +34,8 @@ import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
@@ -279,5 +285,119 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
         "jdbc:postgresql://localhost/test?user=fred&password=****&ssl=true"
     );
+  }
+
+  @Test
+  public void shouldComputeMaxTableNameLength() throws Exception {
+    int expectedMaxLength = 24;
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.next()).thenReturn(true);
+    when(resultSet.getInt(1)).thenReturn(expectedMaxLength);
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenReturn(resultSet);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = PostgreSqlDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(expectedMaxLength, actualMaxLength);
+  }
+
+  @Test
+  public void shouldGracefullyHandleErrorWhenComputingMaxTableNameLength() throws Exception {
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenThrow(new SQLException("I plead the fifth"));
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = PostgreSqlDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldGracefullyHandleEmptyResultSetWhenComputingMaxTableNameLength() throws Exception {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.next()).thenReturn(false);
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenReturn(resultSet);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = PostgreSqlDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldGracefullyHandleInvalidValueWhenComputingMaxTableNameLength() throws Exception {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.next()).thenReturn(true);
+    when(resultSet.getInt(1)).thenReturn(0);
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenReturn(resultSet);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = PostgreSqlDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldTruncateTableNames() {
+
+    final String tableFqn = "some.table";
+
+    // Table name is one byte longer than it's allowed to be; should be truncated
+    dialect.maxIdentifierLength = 4;
+    TableId expectedTableId = new TableId(
+        null,
+        "some",
+        "tabl"
+    );
+    TableId actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+
+    // Table name is exactly as long as it's allowed to be; should not be truncated
+    dialect.maxIdentifierLength = 5;
+    expectedTableId = new TableId(
+        null,
+        "some",
+        "table"
+    );
+    actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+
+    // Something went wrong when computing the max length
+    dialect.maxIdentifierLength = Integer.MAX_VALUE;
+    expectedTableId = new TableId(
+        null,
+        "some",
+        "table"
+    );
+    actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+
+    // We haven't computed the max length at all yet
+    dialect.maxIdentifierLength = 0;
+    expectedTableId = new TableId(
+        null,
+        "some",
+        "table"
+    );
+    actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
   }
 }


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CCDB-4454), [GitHub issue](https://github.com/confluentinc/kafka-connect-jdbc/issues/675)

## Problem
When a table is created in PostgreSQL, if its name exceeds the maximum permitted length (see https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), it will be truncated automatically. For example, a table named "toolongtoolong" would be truncated to "too" if the maximum permitted length were 3 bytes.

Unfortunately, this truncation does not take place automatically when the connector checks to see if a table exists, so even if the connector is able to successfully create a table, if the name was truncated during that creation, the next time the connector checks to see if the table exists, it will appear as if the table is missing (since no table with the non-truncated name exists in the database).

This causes a null pointer exception in `DbStructure::amendIfNecessary`.

## Solution
Determine the maximum-permitted length of a table name (see https://stackoverflow.com/questions/27865770/how-long-can-postgresql-table-names-be/27865772#27865772), then automatically truncate table names.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Unit tests are added to verify the logic for computing the maximum table name length and performing truncation based on it.
I also reproduced the issue locally using a Dockerized PostgreSQL instance and version 10.2.5 of the connector, and verified that with these changes, the connector was able to function properly.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Merge to 5.2.x, `pint merge` forward.