### PR TITLE
CCDB-4470: Handle case mismatch between user-specified and table-provided timestamp column names

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/LRUCache.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LRUCache.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@SuppressWarnings("serial")
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+
+  private final int maxEntries;
+
+  public LRUCache(int maxEntries) {
+    super(16, 0.75f, true);
+    this.maxEntries = maxEntries;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K, V> entry) {
+    return size() > maxEntries;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/LruCache.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LruCache.java
@@ -19,11 +19,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 @SuppressWarnings("serial")
-public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
 
   private final int maxEntries;
 
-  public LRUCache(int maxEntries) {
+  public LruCache(int maxEntries) {
     super(16, 0.75f, true);
     this.maxEntries = maxEntries;
   }


### PR DESCRIPTION
## Problem
Copied from [Jira](https://confluentinc.atlassian.net/browse/CCDB-4470):

When run in timestamp or timestamp+incrementing mode against a given table, the JDBC connector will:

1. Issue a SELECT query that uses the user-supplied timestamp column name in a WHERE clause via JDBC and track the ResultSet for that query
2. Use the ResultSetMetadata from that query's ResultSet to construct a Kafka Connect schema for the source records that will be produced for that query
3. Iterate over each row in the ResultSet and, for each row, construct a Kafka Connect Struct that will be used as the value for the source record corresponding to that row
4. Extract the values for each timestamp column from that struct using the user-supplied timestamp column names

This can cause issues when the logic of the `SELECT` query is case-insensitive with regards to the timestamp columns' names (i.e., `SELECT ... FROM ... WHERE tsColumn > 3` has the same behavior as `SELECT ... FROM ... WHERE tsCOLUMN > 3`), since the call to `Struct::get` in the `TimestampIncrementingCriteria` class in step 4 is always case-sensitive and the column names returned in the `ResultSetMetadata` in step 2 are also always case-sensitive.

For example, if a user configures the connector with a timestamp column name of `createdOn`, but the actual name of the column in the table is `createdon`, if the database's query logic is case-insensitive, the connector will fail with an error like this:

```
org.apache.kafka.connect.errors.DataException: CreatedOn is not a valid field name
	at org.apache.kafka.connect.data.Struct.lookupField(Struct.java:254)
	at org.apache.kafka.connect.data.Struct.get(Struct.java:74)
	at io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.extractOffsetTimestamp(TimestampIncrementingCriteria.java:221)
	at io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.extractValues(TimestampIncrementingCriteria.java:191)
	at io.confluent.connect.jdbc.source.TimestampIncrementingTableQuerier.extractRecord(TimestampIncrementingTableQuerier.java:217)
	at io.confluent.connect.jdbc.source.JdbcSourceTask.poll(JdbcSourceTask.java:376)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.poll(WorkerSourceTask.java:294)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:257)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:198)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:253)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:831)
```

## Solution
When the user-specified timestamp column cannot be found exactly as-is in the list of columns read from the table, fall back and search for columns that match case-insensitively. If one such column is found, use that one instead. If no column is found, fail the connector with a `DataException`. If multiple such columns are found, also fail the connector with a `DataException`, and provide instructions for how to proceed.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Several new unit tests are added.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
If approved, merge to 5.2.x and `pint merge` forward.