### PR TITLE
CCDB-4476: Prevent blocking on database connection in JdbcSourceConnector::taskConfigs

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -145,7 +145,13 @@ public class JdbcSourceConnector extends SourceConnector {
       return taskConfigs;
     } else {
       List<TableId> currentTables = tableMonitorThread.tables();
-      if (currentTables.isEmpty()) {
+      if (currentTables == null) {
+        taskConfigs = Collections.emptyList();
+        log.info(
+            "No tasks will be run because the connector has not been able to read "
+                + "the list of tables from the database yet"
+        );
+      } else if (currentTables.isEmpty()) {
         taskConfigs = Collections.emptyList();
         log.warn("No tasks will be run because no tables were found");
       } else {

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -28,9 +28,11 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
@@ -45,10 +47,9 @@ public class TableMonitorThread extends Thread {
   private final ConnectorContext context;
   private final CountDownLatch shutdownLatch;
   private final long pollMs;
-  private Set<String> whitelist;
-  private Set<String> blacklist;
-  private List<TableId> tables;
-  private Map<String, List<TableId>> duplicates;
+  private final Set<String> whitelist;
+  private final Set<String> blacklist;
+  private final AtomicReference<List<TableId>> tables;
 
   public TableMonitorThread(DatabaseDialect dialect,
       ConnectionProvider connectionProvider,
@@ -64,8 +65,7 @@ public class TableMonitorThread extends Thread {
     this.pollMs = pollMs;
     this.whitelist = whitelist;
     this.blacklist = blacklist;
-    this.tables = null;
-
+    this.tables = new AtomicReference<>();
   }
 
   @Override
@@ -77,8 +77,7 @@ public class TableMonitorThread extends Thread {
           context.requestTaskReconfiguration();
         }
       } catch (Exception e) {
-        context.raiseError(e);
-        throw e;
+        throw fail(e);
       }
 
       try {
@@ -93,22 +92,37 @@ public class TableMonitorThread extends Thread {
     }
   }
 
-  public synchronized List<TableId> tables() {
-    //TODO: Timeout should probably be user-configurable or class-level constant
-    final long timeout = 10000L;
-    long started = System.currentTimeMillis();
-    long now = started;
-    while (tables == null && now - started < timeout) {
-      try {
-        wait(timeout - (now - started));
-      } catch (InterruptedException e) {
-        // Ignore
-      }
-      now = System.currentTimeMillis();
+  /**
+   * @return the latest set of tables from the database that should be read by the connector, or
+   *         {@link null} if the connector has not been able to read any tables from the database
+   *         successfully yet
+   */
+  public List<TableId> tables() {
+    List<TableId> tablesSnapshot = tables.get();
+    if (tablesSnapshot == null) {
+      return null;
     }
-    if (tables == null) {
-      throw new ConnectException("Tables could not be updated quickly enough.");
+
+    Map<String, List<TableId>> duplicates = tablesSnapshot.stream()
+        .collect(Collectors.groupingBy(TableId::tableName))
+        .entrySet().stream()
+        .filter(entry -> entry.getValue().size() > 1)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (tablesSnapshot.isEmpty()) {
+      log.debug(
+          "Based on the supplied filtering rules, there are no matching tables to read from"
+      );
+    } else {
+      log.debug(
+          "Based on the supplied filtering rules, the tables available to read from include: {}",
+          dialect.expressionBuilder()
+              .appendList()
+              .delimitedBy(",")
+              .of(tablesSnapshot)
+      );
     }
+
     if (!duplicates.isEmpty()) {
       String configText;
       if (whitelist != null) {
@@ -125,9 +139,10 @@ public class TableMonitorThread extends Thread {
           + "JDBC Source connector fails to start when it detects duplicate table name "
           + "configurations. Update the connector's " + configText + " config to include exactly "
           + "one table in each of the tables listed below.\n\t";
-      throw new ConnectException(msg + duplicates.values());
+      RuntimeException exception = new ConnectException(msg + duplicates.values());
+      throw fail(exception);
     }
-    return tables;
+    return tablesSnapshot;
   }
 
   public void shutdown() {
@@ -135,11 +150,11 @@ public class TableMonitorThread extends Thread {
     shutdownLatch.countDown();
   }
 
-  private synchronized boolean updateTables() {
-    final List<TableId> tables;
+  private boolean updateTables() {
+    final List<TableId> allTables;
     try {
-      tables = dialect.tableIds(connectionProvider.getConnection());
-      log.debug("Got the following tables: {}", tables);
+      allTables = dialect.tableIds(connectionProvider.getConnection());
+      log.debug("Got the following tables: {}", allTables);
     } catch (SQLException e) {
       log.error(
           "Error while trying to get updated table list, ignoring and waiting for next table poll"
@@ -150,9 +165,9 @@ public class TableMonitorThread extends Thread {
       return false;
     }
 
-    final List<TableId> filteredTables = new ArrayList<>(tables.size());
+    final List<TableId> filteredTables = new ArrayList<>(allTables.size());
     if (whitelist != null) {
-      for (TableId table : tables) {
+      for (TableId table : allTables) {
         String fqn1 = dialect.expressionBuilder().append(table, QuoteMethod.NEVER).toString();
         String fqn2 = dialect.expressionBuilder().append(table, QuoteMethod.ALWAYS).toString();
         if (whitelist.contains(fqn1) || whitelist.contains(fqn2)
@@ -161,7 +176,7 @@ public class TableMonitorThread extends Thread {
         }
       }
     } else if (blacklist != null) {
-      for (TableId table : tables) {
+      for (TableId table : allTables) {
         String fqn1 = dialect.expressionBuilder().append(table, QuoteMethod.NEVER).toString();
         String fqn2 = dialect.expressionBuilder().append(table, QuoteMethod.ALWAYS).toString();
         if (!(blacklist.contains(fqn1) || blacklist.contains(fqn2)
@@ -170,39 +185,28 @@ public class TableMonitorThread extends Thread {
         }
       }
     } else {
-      filteredTables.addAll(tables);
+      filteredTables.addAll(allTables);
     }
 
-    if (!filteredTables.equals(this.tables)) {
-      Map<String, List<TableId>> duplicates = filteredTables.stream()
-          .collect(Collectors.groupingBy(TableId::tableName))
-          .entrySet().stream()
-          .filter(entry -> entry.getValue().size() > 1)
-          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-      this.duplicates = duplicates;
-      final List<TableId> previousTables = this.tables;
-      this.tables = filteredTables;
+    List<TableId> priorTablesSnapshot = tables.getAndSet(filteredTables);
+    return !Objects.equals(priorTablesSnapshot, filteredTables);
+  }
 
-      if (filteredTables.isEmpty()) {
-        log.debug(
-            "Based on the supplied filtering rules, there are no matching tables to read from"
-        );
-      } else {
-        log.debug(
-            "Based on the supplied filtering rules, the tables available to read from include: {}",
-            dialect.expressionBuilder()
-                .appendList()
-                .delimitedBy(",")
-                .of(filteredTables)
-        );
-      }
+  /**
+   * Fail the connector with an unrecoverable error and stop the table monitoring thread
+   * @param t the cause of the failure
+   * @return a {@link RuntimeException} that can be thrown from the calling method, for convenience
+   */
+  private RuntimeException fail(Throwable t) {
+    String message = "Encountered an unrecoverable rrorwhile reading tables from the database ";
+    log.error(message, t);
 
-      notifyAll();
-      // Only return true if the table list wasn't previously null, i.e. if this was not the
-      // first table lookup
-      return previousTables != null;
-    }
+    RuntimeException exception = new ConnectException(message, t);
+    context.raiseError(exception);
 
-    return false;
+    // Preemptively shut down the monitoring thread
+    // so that we don't keep trying to read from the database
+    shutdownLatch.countDown();
+    return exception;
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -198,7 +198,7 @@ public class TableMonitorThread extends Thread {
    * @return a {@link RuntimeException} that can be thrown from the calling method, for convenience
    */
   private RuntimeException fail(Throwable t) {
-    String message = "Encountered an unrecoverable rrorwhile reading tables from the database ";
+    String message = "Encountered an unrecoverable error while reading tables from the database";
     log.error(message, t);
 
     RuntimeException exception = new ConnectException(message, t);

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc;
 
+import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
 import org.easymock.Mock;
@@ -34,6 +35,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.source.EmbeddedDerby;
@@ -59,6 +62,8 @@ public class JdbcSourceConnectorTest {
 
   @Mock
   private DatabaseDialect dialect;
+  @Mock
+  private ConnectorContext connectorContext;
 
   @Before
   public void setup() {
@@ -148,7 +153,22 @@ public class JdbcSourceConnectorTest {
     // Tests simplest case where we have exactly 1 table and also ensures we return fewer tasks
     // if there aren't enough tables for the max # of tasks
     db.createTable("test", "id", "INT NOT NULL");
+
+    CountDownLatch taskReconfigurationLatch = new CountDownLatch(1);
+    connectorContext.requestTaskReconfiguration();
+    EasyMock.expectLastCall().andAnswer(() -> {
+      taskReconfigurationLatch.countDown();
+      return null;
+    });
+    EasyMock.replay(connectorContext);
+    connector.initialize(connectorContext);
+
     connector.start(connProps);
+    assertTrue(
+        "Connector should have request task reconfiguration after reading tables from the database",
+        taskReconfigurationLatch.await(10, TimeUnit.SECONDS)
+    );
+
     List<Map<String, String>> configs = connector.taskConfigs(10);
     assertEquals(1, configs.size());
     assertTaskConfigsHaveParentConfigs(configs);
@@ -164,7 +184,22 @@ public class JdbcSourceConnectorTest {
     db.createTable("test2", "id", "INT NOT NULL");
     db.createTable("test3", "id", "INT NOT NULL");
     db.createTable("test4", "id", "INT NOT NULL");
+
+    CountDownLatch taskReconfigurationLatch = new CountDownLatch(1);
+    connectorContext.requestTaskReconfiguration();
+    EasyMock.expectLastCall().andAnswer(() -> {
+      taskReconfigurationLatch.countDown();
+      return null;
+    });
+    EasyMock.replay(connectorContext);
+    connector.initialize(connectorContext);
+
     connector.start(connProps);
+    assertTrue(
+        "Connector should have request task reconfiguration after reading tables from the database",
+        taskReconfigurationLatch.await(10, TimeUnit.SECONDS)
+    );
+
     List<Map<String, String>> configs = connector.taskConfigs(3);
     assertEquals(3, configs.size());
     assertTaskConfigsHaveParentConfigs(configs);


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CCDB-4476), [GitHub issue](https://github.com/confluentinc/kafka-connect-jdbc/issues/1142)

## Problem
The connector can block in its `taskConfigs` method while [invoking `tableMonitorThread::tables`](https://github.com/confluentinc/kafka-connect-jdbc/blob/26cc0b1e309f15f368fbf6d2cd6c8665770c1608/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java#L149), which is [synchronized](https://github.com/confluentinc/kafka-connect-jdbc/blob/26cc0b1e309f15f368fbf6d2cd6c8665770c1608/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java#L96) and therefore blocks on the completion of any pending calls to the [also-synchronized `updateTables` method](https://github.com/confluentinc/kafka-connect-jdbc/blob/26cc0b1e309f15f368fbf6d2cd6c8665770c1608/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java#L138). This method (`updateTables`) may block for a long or even indefinite time as it interacts with the database and may hang on network connectivity issues, deadlock, etc.

With https://github.com/apache/kafka/pull/8069, we made Connect workers more resilient to connectors that would hang during invocations of methods like start, stop, and validate; the impact was lowered from blocking the worker's herder thread (which would cause some REST requests to time out and the worker to eventually fall out of the cluster) to just causing a thread to be allocated to that connector while it remained blocked. With https://github.com/apache/kafka/pull/9669, we fixed a similar issue where the worker's herder thread would block on invocations of `SourceTask::stop` (all other task interactions (except for `version`) such as `start`, `poll`, `put` were already performed safely without risk of blocking the worker's herder thread).

However, some connector methods (which were deemed less likely to hang) have not been safeguarded in this fashion yet, including `taskConfigs`.

As a result, if a JDBC source connector blocks during an invocation of `taskConfigs` (due to a block in the table monitoring thread), the entire worker's herder thread becomes blocked, which causes most REST requests to fail and for the worker to fall out of the cluster and have its tasks and connectors reassigned (even though they will still be running on the current worker as well).

## Solution
Modify the table monitoring thread logic to remove all `synchronized` blocks and instead employ a snapshot-based approach. When `TableMonitorThread::tables` is invoked, no attempt is made to block for any currently-in-progress reads of the database's list of tables to complete, and only the latest complete set of tables is utilized. If no table read has succeeded yet, an `INFO`-level log message is emitted and the connector generates an empty set of task configs. If a table read has succeeded but there are no eligible tables to read from (after applying any user-supplied whitelist/blacklist rules), the connector also generates an empty set of task configs, but emits a `WARN`-level log message as well.

Additionally, calls are added to [`ConnectorContext::raiseError`](https://kafka.apache.org/30/javadoc/org/apache/kafka/connect/connector/ConnectorContext.html#raiseError(java.lang.Exception)) when the table monitor thread encounters unrecoverable errors (i.e., duplicate table names and unexpected failures). This signals to Connect that no further calls to `taskConfigs` should be made (see the logic in the [`DistributedHerder`](https://github.com/apache/kafka/blob/e1dba7af57ec69eb2bbf5a8f4d009502139f0e24/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java#L1552-L1555) and [`StandaloneHerder`](https://github.com/apache/kafka/blob/e1dba7af57ec69eb2bbf5a8f4d009502139f0e24/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java#L393-L396) classes), which is better than the current behavior, where the connector throws an exception from `taskConfigs` and the Connect worker responds by waiting for 250 milliseconds and then invoking the method again until it finally succeeds.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Existing unit tests are augmented to account for this new logic, and a new case is added that explicitly verifies that `TableMonitorThread::tables` does not block even when an in-progress call to `updateTables` is blocked.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Merge to 5.2.x, `pint merge` forward. Will likely publish new independent releases on the 10.0.x, 10.1.x, and 10.2.x branches once https://github.com/confluentinc/kafka-connect-jdbc/pull/1144 and https://github.com/confluentinc/kafka-connect-jdbc/pull/1143 are either rejected or merged as well.