### PR TITLE
Revert "MINOR: call `setCharacterStream` API with length (#1130)"

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -141,15 +141,14 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     }
 
     if (schema.type() == Type.STRING) {
-      String strValue = (String) value;
       if (colDef.type() == Types.CLOB) {
-        statement.setCharacterStream(index, new StringReader(strValue), strValue.length());
+        statement.setCharacterStream(index, new StringReader((String) value));
         return true;
       } else if (colDef.type() == Types.NCLOB) {
-        statement.setNCharacterStream(index, new StringReader(strValue), strValue.length());
+        statement.setNCharacterStream(index, new StringReader((String) value));
         return true;
       } else if (colDef.type() == Types.NVARCHAR || colDef.type() == Types.NCHAR) {
-        statement.setNString(index, strValue);
+        statement.setNString(index, (String) value);
         return true;
       } else {
         return super.maybeBindPrimitive(statement, index, schema, value);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -56,10 +56,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Override
   @Test
   public void bindFieldStringValue() throws SQLException {
-    String value = "yep";
     int index = ThreadLocalRandom.current().nextInt();
-    verifyBindField(++index, Schema.STRING_SCHEMA, value)
-        .setCharacterStream(eq(index), any(StringReader.class), eq(value.length()));
+    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setCharacterStream(eq(index), any(StringReader.class));
   }
 
   @Override
@@ -345,8 +343,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     verify(stmtNvarchar, times(1)).setNString(index, value);
 
     dialect.bindField(stmtClob, index, schema, value, colDefClob);
-    verify(stmtClob, times(1))
-        .setCharacterStream(eq(index), any(StringReader.class), eq(value.length()));
+    verify(stmtClob, times(1)).setCharacterStream(eq(index), any(StringReader.class));
   }
 
   @Test


### PR DESCRIPTION
This reverts commit b33ed0572430457dcaa9054c2009589a59847442.

## Problem
IT added in https://github.com/confluentinc/kafka-connect-jdbc/pull/1147 has reproduced a regression introduced by #1130

## Solution
Revert this PR

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
