### PR TITLE
CCDB-4340 - Add support for the new Timestamp granularity features in the jdbc source connector

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,5 +22,5 @@
               files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect).java"/>
+              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|TimestampIncrementingTableQuerier).java"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <testcontainers.version>1.16.2</testcontainers.version>
     </properties>
 
     <repositories>
@@ -229,7 +230,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.0-rc2</version>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1391,7 +1391,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       case Types.TIMESTAMP: {
         return rs -> {
           Timestamp timestamp = rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
-          return tsGranularity.convert.apply(timestamp);
+          return tsGranularity.fromTimestamp.apply(timestamp);
         };
       }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -187,6 +187,21 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "Use -1 to use the current time. If not specified, all data will be retrieved.";
   public static final String TIMESTAMP_INITIAL_DISPLAY = "Unix time value of initial timestamp";
 
+  public static final String TIMESTAMP_GRANULARITY_CONNECT_LOGICAL = "connect-logical";
+  public static final String TIMESTAMP_GRANULARITY_LONG_NANOS = "nanos-long";
+  public static final String TIMESTAMP_GRANULARITY_STRING_NANOS = "nanos-string";
+  public static final String TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME = "iso-datetime-string";
+  public static final String TIMESTAMP_GRANULARITY_CONFIG = "timestamp.granularity";
+  public static final String TIMESTAMP_GRANULARITY_DOC =
+      "Define the granularity of the Timestamp column. Options include: \n"
+          + "  * connect-logical (default): represents timestamp values using Kafka Connect's "
+          + "built-in representations "
+          + "  * nanos-long: represents timestamp values as nanos since epoch"
+          + "  * nanos-string: represents timestamp values as nanos since epoch in string"
+          + "  * iso-datetime-string: uses the iso format 'yyyy-MM-dd'T'HH:mm:ss.n'";
+  public static final String TIMESTAMP_GRANULARITY_DISPLAY = "Timestamp granularity for "
+      + "timestamp columns";
+
   public static final String TABLE_POLL_INTERVAL_MS_CONFIG = "table.poll.interval.ms";
   private static final String TABLE_POLL_INTERVAL_MS_DOC =
       "Frequency in ms to poll for new or removed tables, which may result in updated task "
@@ -643,7 +658,23 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         CONNECTOR_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        DB_TIMEZONE_CONFIG_DISPLAY);
+        DB_TIMEZONE_CONFIG_DISPLAY
+    ).define(
+        TIMESTAMP_GRANULARITY_CONFIG,
+        Type.STRING,
+        TIMESTAMP_GRANULARITY_CONNECT_LOGICAL,
+        ConfigDef.ValidString.in(
+            TIMESTAMP_GRANULARITY_CONNECT_LOGICAL,
+            TIMESTAMP_GRANULARITY_LONG_NANOS,
+            TIMESTAMP_GRANULARITY_STRING_NANOS,
+            TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME
+        ),
+        Importance.MEDIUM,
+        TIMESTAMP_GRANULARITY_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TIMESTAMP_GRANULARITY_DISPLAY);
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -190,7 +190,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String TIMESTAMP_GRANULARITY_CONNECT_LOGICAL = "connect-logical";
   public static final String TIMESTAMP_GRANULARITY_LONG_NANOS = "nanos-long";
   public static final String TIMESTAMP_GRANULARITY_STRING_NANOS = "nanos-string";
-  public static final String TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME = "nanos-iso-datetime-string";
+  public static final String TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME =
+      "nanos-iso-datetime-string";
   public static final String TIMESTAMP_GRANULARITY_CONFIG = "timestamp.granularity";
   public static final String TIMESTAMP_GRANULARITY_DOC =
       "Define the granularity of the Timestamp column. Options include: \n"

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -199,7 +199,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "built-in representations "
           + "  * nanos-long: represents timestamp values as nanos since epoch"
           + "  * nanos-string: represents timestamp values as nanos since epoch in string"
-          + "  * iso-datetime-string: uses the iso format 'yyyy-MM-dd'T'HH:mm:ss.n'";
+          + "  * nanos-iso-datetime-string: uses the iso format 'yyyy-MM-dd'T'HH:mm:ss.n'";
   public static final String TIMESTAMP_GRANULARITY_DISPLAY = "Timestamp granularity for "
       + "timestamp columns";
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -190,7 +190,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String TIMESTAMP_GRANULARITY_CONNECT_LOGICAL = "connect-logical";
   public static final String TIMESTAMP_GRANULARITY_LONG_NANOS = "nanos-long";
   public static final String TIMESTAMP_GRANULARITY_STRING_NANOS = "nanos-string";
-  public static final String TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME = "iso-datetime-string";
+  public static final String TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME = "nanos-iso-datetime-string";
   public static final String TIMESTAMP_GRANULARITY_CONFIG = "timestamp.granularity";
   public static final String TIMESTAMP_GRANULARITY_DOC =
       "Define the granularity of the Timestamp column. Options include: \n"

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -201,6 +201,8 @@ public class JdbcSourceTask extends SourceTask {
       offset = computeInitialOffset(tableOrQuery, offset, timeZone);
 
       String topicPrefix = config.topicPrefix();
+      String timestampGranularity
+          = config.getString(JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONFIG);
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(
@@ -224,7 +226,8 @@ public class JdbcSourceTask extends SourceTask {
                 offset,
                 timestampDelayInterval,
                 timeZone,
-                suffix
+                suffix,
+                timestampGranularity
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -238,7 +241,8 @@ public class JdbcSourceTask extends SourceTask {
                 offset,
                 timestampDelayInterval,
                 timeZone,
-                suffix
+                suffix,
+                timestampGranularity
             )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -253,7 +257,8 @@ public class JdbcSourceTask extends SourceTask {
                 offset,
                 timestampDelayInterval,
                 timeZone,
-                suffix
+                suffix,
+                timestampGranularity
             )
         );
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -201,8 +201,8 @@ public class JdbcSourceTask extends SourceTask {
       offset = computeInitialOffset(tableOrQuery, offset, timeZone);
 
       String topicPrefix = config.topicPrefix();
-      String timestampGranularity
-          = config.getString(JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONFIG);
+      JdbcSourceConnectorConfig.TimestampGranularity timestampGranularity
+          = JdbcSourceConnectorConfig.TimestampGranularity.get(config);
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -186,7 +186,7 @@ public class TimestampIncrementingCriteria {
    * @param schema the record's schema; never null
    * @param record the record's struct; never null
    * @param previousOffset a previous timestamp offset if the table has timestamp columns
-   * @param timestampGranularity defines the configured grrityanualrity of the timestamp field
+   * @param timestampGranularity defines the configured granularity of the timestamp field
    * @return the timestamp for this row; may not be null
    */
   public TimestampIncrementingOffset extractValues(
@@ -230,16 +230,9 @@ public class TimestampIncrementingCriteria {
   ) {
     caseAdjustedTimestampColumns.computeIfAbsent(schema, this::findCaseSensitiveTimestampColumns);
     for (String timestampColumn : caseAdjustedTimestampColumns.get(schema)) {
-      try {
-        Timestamp ts = timestampGranularity.toTimestamp.apply(record.get(timestampColumn));
-        if (ts != null) {
-          return ts;
-        }
-      } catch (NumberFormatException  e) {
-        throw new ConnectException(
-            "Invalid value for timestamp column with nanos-string granularity: "
-                + record.get(timestampColumn)
-                + e.getMessage());
+      Timestamp ts = timestampGranularity.toTimestamp.apply(record.get(timestampColumn));
+      if (ts != null) {
+        return ts;
       }
     }
     return null;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -70,6 +70,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   protected TimestampIncrementingCriteria criteria;
   protected final Map<String, String> partition;
   protected final String topic;
+  protected final String timestampGranularity;
   private final List<ColumnId> timestampColumns;
   private String incrementingColumnName;
   private final long timestampDelay;
@@ -80,7 +81,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
-                                           TimeZone timeZone, String suffix) {
+                                           TimeZone timeZone, String suffix,
+                                           String timestampGranularity) {
     super(dialect, mode, name, topicPrefix, suffix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
@@ -111,6 +113,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     }
 
     this.timeZone = timeZone;
+    this.timestampGranularity = timestampGranularity;
   }
 
   /**
@@ -220,7 +223,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
         throw new DataException(e);
       }
     }
-    offset = criteria.extractValues(schemaMapping.schema(), record, offset);
+    offset = criteria.extractValues(schemaMapping.schema(), record, offset, timestampGranularity);
     return new SourceRecord(partition, offset.toMap(), topic, record.schema(), record);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TimestampGranularity;
 import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
 import io.confluent.connect.jdbc.source.TimestampIncrementingCriteria.CriteriaValues;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
@@ -70,7 +71,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   protected TimestampIncrementingCriteria criteria;
   protected final Map<String, String> partition;
   protected final String topic;
-  protected final String timestampGranularity;
+  protected final TimestampGranularity timestampGranularity;
   private final List<ColumnId> timestampColumns;
   private String incrementingColumnName;
   private final long timestampDelay;
@@ -82,7 +83,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
                                            TimeZone timeZone, String suffix,
-                                           String timestampGranularity) {
+                                           TimestampGranularity timestampGranularity) {
     super(dialect, mode, name, topicPrefix, suffix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -62,7 +62,8 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
       Map<String, Object> offsetMap,
       Long timestampDelay,
       TimeZone timeZone,
-      String suffix
+      String suffix,
+      String timestampGranularity
   ) {
     super(
         dialect,
@@ -74,7 +75,8 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
         offsetMap,
         timestampDelay,
         timeZone,
-        suffix
+        suffix,
+        timestampGranularity
     );
 
     this.latestCommittableTimestamp = this.offset.getTimestampOffset();
@@ -145,7 +147,8 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
         throw new DataException(e);
       }
     }
-    this.offset = criteria.extractValues(schemaMapping.schema(), record, offset);
+    this.offset = criteria.extractValues(schemaMapping.schema(), record, offset,
+        timestampGranularity);
     Timestamp timestamp = offset.hasTimestampOffset() ? offset.getTimestampOffset() : null;
     return new PendingRecord(partition, timestamp, topic, record.schema(), record);
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TimestampGranularity;
 import io.confluent.connect.jdbc.source.SchemaMapping.FieldSetter;
 
 /**
@@ -63,7 +64,7 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
       Long timestampDelay,
       TimeZone timeZone,
       String suffix,
-      String timestampGranularity
+      TimestampGranularity timestampGranularity
   ) {
     super(
         dialect,

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -15,15 +15,25 @@
 
 package io.confluent.connect.jdbc.util;
 
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 public class DateTimeUtils {
+
+  static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
+  static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
+  static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+  static final DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.n");
 
   private static final ThreadLocal<Map<TimeZone, Calendar>> TIMEZONE_CALENDARS =
       ThreadLocal.withInitial(HashMap::new);
@@ -63,6 +73,59 @@ public class DateTimeUtils {
       sdf.setTimeZone(aTimeZone);
       return sdf;
     }).format(date);
+  }
+
+  /**
+   * Get the number of nanoseconds past epoch of the given {@link Timestamp}.
+   *
+   * @param timestamp the Java timestamp value
+   * @return the epoch nanoseconds
+   */
+  public static long toEpochNanos(Timestamp timestamp) {
+    return TimeUnit.SECONDS.toNanos(timestamp.getTime() / MILLISECONDS_PER_SECOND)
+        + TimeUnit.NANOSECONDS.toNanos(timestamp.getNanos());
+  }
+
+  /**
+   * Get the iso date-time string with nano precision for the given {@link Timestamp}.
+   *
+   * @param timestamp the Java timestamp value
+   * @return the string iso date time
+   */
+  public static String toIsoDateTimeString(Timestamp timestamp) {
+    return timestamp.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
+  }
+
+  /**
+   * Get {@link Timestamp} from epoch with nano precision
+   *
+   * @param nanos epoch nanos in long
+   * @return the equivalent java sql Timestamp
+   */
+  public static Timestamp toTimestamp(long nanos) {
+    Timestamp ts = new Timestamp(nanos / NANOSECONDS_PER_MILLISECOND);
+    ts.setNanos((int)(nanos % NANOSECONDS_PER_SECOND));
+    return ts;
+  }
+
+  /**
+   * Get {@link Timestamp} from epoch with nano precision
+   *
+   * @param nanos epoch nanos in string
+   * @return the equivalent java sql Timestamp
+   */
+  public static Timestamp toTimestamp(String nanos) throws NumberFormatException {
+    return toTimestamp(Long.parseLong(nanos));
+  }
+
+  /**
+   * Get {@link Timestamp} from epoch with nano precision
+   *
+   * @param isoDateTime iso dateTime format "yyyy-MM-dd'T'HH:mm:ss.n"
+   * @return the equivalent java sql Timestamp
+   */
+  public static Timestamp toTimestampFromIsoDateTime(String isoDateTime) {
+    return Timestamp.valueOf(LocalDateTime.parse(isoDateTime, ISO_DATE_TIME_NANOS_FORMAT));
   }
 
   private DateTimeUtils() {

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/OracleDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/OracleDatatypeIT.java
@@ -1,0 +1,273 @@
+package io.confluent.connect.jdbc.sink.integration;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.ThrowingFunction;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.integration.BaseConnectorIT;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(IntegrationTest.class)
+public class OracleDatatypeIT extends BaseConnectorIT {
+    @SuppressWarnings( "deprecation" )
+    @Rule
+    public OracleContainer oracle = new OracleContainer();
+
+    Connection connection;
+    private JsonConverter jsonConverter;
+    private Map<String, String> props;
+    private String tableName;
+
+    @Before
+    public void setup() throws SQLException {
+        startConnect();
+
+        jsonConverter = jsonConverter();
+        props = baseSinkProps();
+
+        tableName = "TEST";
+        props.put(JdbcSinkConfig.CONNECTION_URL, oracle.getJdbcUrl());
+        props.put(JdbcSinkConfig.CONNECTION_USER, oracle.getUsername());
+        props.put(JdbcSinkConfig.CONNECTION_PASSWORD, oracle.getPassword());
+        props.put(JdbcSinkConfig.PK_MODE, "record_value");
+        props.put(JdbcSinkConfig.PK_FIELDS, "KEY");
+        props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+        props.put(JdbcSinkConfig.MAX_RETRIES, "0");
+        props.put("topics", tableName);
+
+        // create topic in Kafka
+        connect.kafka().createTopic(tableName, 1);
+
+        connection = DriverManager.getConnection(oracle.getJdbcUrl(),
+            oracle.getUsername(), oracle.getPassword());
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        connection.close();
+
+        stopConnect();
+    }
+
+    @Test
+    public void testPrimitiveAndLogicalTypesInsert() throws Exception {
+        createPrimitiveAndLogicalTypesTable();
+
+        testPrimitiveAndLogicalTypes("insert");
+    }
+
+    @Test
+    public void testPrimitiveAndLogicalTypesUpsert() throws Exception {
+        createPrimitiveAndLogicalTypesTable();
+
+        testPrimitiveAndLogicalTypes("upsert");
+    }
+
+    @Test
+    public void testPrimitiveAndLogicalTypesUpdate() throws Exception {
+        createPrimitiveAndLogicalTypesTable();
+
+        try (Statement s = connection.createStatement()) {
+            s.execute("INSERT INTO " + tableName + " VALUES (0, 0, 0, 0, 0, 0, 0, '0', EMPTY_BLOB(), DATE '2022-01-01', DATE '2022-01-01', TIMESTAMP '2022-01-01 09:26:50.12', 0, 1)");
+        }
+
+        testPrimitiveAndLogicalTypes("update");
+    }
+
+    private void createPrimitiveAndLogicalTypesTable() throws SQLException {
+        try (Statement s = connection.createStatement()) {
+            s.execute("CREATE TABLE " + tableName + "("
+                + "\"boolean\" NUMBER(1,0),"
+                + "\"int8\" NUMBER, "
+                + "\"int16\" NUMBER, "
+                + "\"int32\" NUMBER, "
+                + "\"int64\" NUMBER, "
+                + "\"float32\" NUMBER, "
+                + "\"float64\" NUMBER, "
+                + "\"string\" VARCHAR2(100), "
+                + "\"bytes\" BLOB, "
+                + "\"date\" DATE, "
+                + "\"time\" DATE, "
+                + "\"timestamp\" TIMESTAMP, "
+                + "\"decimal\" NUMBER, "
+                + "KEY NUMBER NOT NULL, PRIMARY KEY (KEY)"
+                + ")");
+        }
+    }
+
+    private void testPrimitiveAndLogicalTypes(String insertMode) throws Exception {
+        props.put(JdbcSinkConfig.INSERT_MODE, insertMode);
+
+        final Schema schema = SchemaBuilder.struct()
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int8", Schema.INT8_SCHEMA)
+            .field("int16", Schema.INT16_SCHEMA)
+            .field("int32", Schema.INT32_SCHEMA)
+            .field("int64", Schema.INT64_SCHEMA)
+            .field("float32", Schema.FLOAT32_SCHEMA)
+            .field("float64", Schema.FLOAT64_SCHEMA)
+            .field("string", Schema.STRING_SCHEMA)
+            .field("bytes", Schema.BYTES_SCHEMA)
+            .field("date", Date.SCHEMA)
+            .field("time", Time.SCHEMA)
+            .field("timestamp", Timestamp.SCHEMA)
+            .field("decimal", Decimal.schema(0))
+            .field("KEY", Schema.INT32_SCHEMA)
+            .build();
+
+        java.util.Date date = new java.util.Date(0);
+        java.util.Date time = new java.util.Date(0);
+        java.util.Date timestamp = new java.util.Date();
+        BigDecimal decimal = new BigDecimal(2022);
+
+        final Struct value = new Struct(schema)
+            .put("boolean", false)
+            .put("int8", (byte) 1)
+            .put("int16", (short) 2)
+            .put("int32", 3)
+            .put("int64", 4L)
+            .put("float32", (float) 5.0)
+            .put("float64", (double) 6.0)
+            .put("string", "7")
+            .put("bytes", "8".getBytes(StandardCharsets.UTF_8))
+            .put("date", date)
+            .put("time", time)
+            .put("timestamp", timestamp)
+            .put("decimal", decimal)
+            .put("KEY", 1);
+
+        assertProduced(schema, value, (rs) -> {
+            assertFalse(rs.getBoolean(1));
+            assertEquals((byte) 1, rs.getByte(2));
+            assertEquals((short) 2, rs.getShort(3));
+            assertEquals(3, rs.getInt(4));
+            assertEquals(4L, rs.getLong(5));
+            assertEquals((float) 5.0, rs.getFloat(6), 0.01);
+            assertEquals((double) 6.0, rs.getDouble(7), 0.01);
+            assertEquals("7", rs.getString(8));
+            assertEquals("8", new String(rs.getBytes(9)));
+            assertEquals(date, rs.getDate(10,
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("UTC")))));
+            assertEquals(time, rs.getTime(11,
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("UTC")))));
+            assertEquals(timestamp, rs.getTimestamp(12,
+                Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("UTC")))));
+            assertEquals(decimal, rs.getBigDecimal(13));
+            return null;
+        });
+    }
+
+    @Test
+    public void testShortAndLongStringInsert() throws Exception {
+        createShortAndLongStringTable();
+        testShortAndLongString("insert");
+    }
+
+    @Test
+    public void testShortAndLongStringUpsert() throws Exception {
+        createShortAndLongStringTable();
+
+        testShortAndLongString("upsert");
+    }
+
+    @Test
+    public void testShortAndLongStringUpdate() throws Exception {
+        createShortAndLongStringTable();
+
+        try (Statement s = connection.createStatement()) {
+            s.execute("INSERT INTO " + tableName + " VALUES ('', EMPTY_CLOB(), 1)");
+        }
+
+        testShortAndLongString("update");
+    }
+
+    private void createShortAndLongStringTable() throws SQLException {
+        try (Statement s = connection.createStatement()) {
+            s.execute("CREATE TABLE " + tableName + "("
+                + "\"shortString\" VARCHAR2(100),"
+                + "\"longString\" CLOB, "
+                + "KEY NUMBER NOT NULL, PRIMARY KEY (KEY)"
+                + ")");
+        }
+    }
+
+    @SuppressWarnings( "deprecation" )
+    private void testShortAndLongString(String insertMode) throws Exception {
+        props.put(JdbcSinkConfig.INSERT_MODE, insertMode);
+
+        final String shortString = "shortString";
+        final String longString = org.apache.commons.lang3.RandomStringUtils
+            .randomAlphanumeric(40001);
+
+        final Schema schema = SchemaBuilder.struct()
+            .field("shortString", Schema.STRING_SCHEMA)
+            .field("longString", Schema.STRING_SCHEMA)
+            .field("KEY", Schema.INT32_SCHEMA)
+            .build();
+        final Struct value = new Struct(schema)
+            .put("shortString", shortString)
+            .put("longString", longString)
+            .put("KEY", 1);
+        assertProduced(schema, value, (rs) -> {
+            assertEquals(shortString, rs.getString(1));
+            assertEquals(longString, rs.getString(2));
+            return null;
+        });
+    }
+
+    private void assertProduced(
+        Schema schema, Struct value, ThrowingFunction<ResultSet, Void> assertion) throws Exception {
+
+        connect.configureConnector("jdbc-sink-connector", props);
+        waitForConnectorToStart("jdbc-sink-connector", 1);
+
+        produceRecord(schema, value);
+
+        waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName),
+            1, 1,
+            TimeUnit.MINUTES.toMillis(3));
+
+        try (Statement s = connection.createStatement()) {
+            ResultSet rs = s.executeQuery(
+                "SELECT * FROM " + tableName + " ORDER BY KEY DESC FETCH FIRST 1 ROWS ONLY");
+            assertTrue(rs.next());
+            assertion.apply(rs);
+        }
+    }
+
+    private void produceRecord(Schema schema, Struct struct) {
+        String kafkaValue = new String(jsonConverter.fromConnectData(tableName, schema, struct));
+        connect.kafka().produce(tableName, null, kafkaValue);
+    }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
@@ -71,7 +71,7 @@ public class TableQuerierTest {
                                                     TIMESTAMP_DELAY,
                                                     null,
                                                     SUFFIX,
-                                                    JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
+                                                    JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
                                                 );
       
     querier.createPreparedStatement(connectionMock);
@@ -92,7 +92,7 @@ public class TableQuerierTest {
                                                     TIMESTAMP_DELAY, 
                                                     null, 
                                                     SUFFIX,
-                                                    JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
+                                                    JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
                                                 );
       
     querier.createPreparedStatement(connectionMock);

--- a/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
@@ -70,7 +70,8 @@ public class TableQuerierTest {
                                                     null,
                                                     TIMESTAMP_DELAY,
                                                     null,
-                                                    SUFFIX
+                                                    SUFFIX,
+                                                    JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
                                                 );
       
     querier.createPreparedStatement(connectionMock);
@@ -90,7 +91,8 @@ public class TableQuerierTest {
                                                     null, 
                                                     TIMESTAMP_DELAY, 
                                                     null, 
-                                                    SUFFIX
+                                                    SUFFIX,
+                                                    JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
                                                 );
       
     querier.createPreparedStatement(connectionMock);

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -35,6 +35,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TimestampGranularity;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.IdentifierRules;
@@ -80,7 +81,7 @@ public class TimestampIncrementingCriteriaTest {
       java.sql.Timestamp expectedT,
       Schema schema,
       Struct record,
-      String timestampGranularity) {
+      TimestampGranularity timestampGranularity) {
     TimestampIncrementingCriteria criteria;
     if (schema.field(INCREMENTING_COLUMN.name()) != null) {
       if (schema.field(TS1_COLUMN.name()) != null) {
@@ -103,14 +104,14 @@ public class TimestampIncrementingCriteriaTest {
   public void extractIntOffset() throws SQLException {
     schema = SchemaBuilder.struct().field("id", SchemaBuilder.INT32_SCHEMA).build();
     record = new Struct(schema).put("id", 42);
-    assertExtractedOffset(42L, TS0, schema, record, "");
+    assertExtractedOffset(42L, TS0, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
   public void extractLongOffset() throws SQLException {
     schema = SchemaBuilder.struct().field("id", SchemaBuilder.INT64_SCHEMA).build();
     record = new Struct(schema).put("id", 42L);
-    assertExtractedOffset(42L, TS0, schema, record, "");
+    assertExtractedOffset(42L, TS0, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -118,7 +119,7 @@ public class TimestampIncrementingCriteriaTest {
     final Schema decimalSchema = Decimal.schema(0);
     schema = SchemaBuilder.struct().field("id", decimalSchema).build();
     record = new Struct(schema).put("id", new BigDecimal(42));
-    assertExtractedOffset(42L, TS0, schema, record, "");
+    assertExtractedOffset(42L, TS0, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test(expected = ConnectException.class)
@@ -126,7 +127,7 @@ public class TimestampIncrementingCriteriaTest {
     final Schema decimalSchema = Decimal.schema(0);
     schema = SchemaBuilder.struct().field("id", decimalSchema).build();
     record = new Struct(schema).put("id", new BigDecimal(Long.MAX_VALUE).add(new BigDecimal(1)));
-    assertExtractedOffset(42L, TS0, schema, record, "");
+    assertExtractedOffset(42L, TS0, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test(expected = ConnectException.class)
@@ -134,7 +135,7 @@ public class TimestampIncrementingCriteriaTest {
     final Schema decimalSchema = Decimal.schema(2);
     schema = SchemaBuilder.struct().field("id", decimalSchema).build();
     record = new Struct(schema).put("id", new BigDecimal("42.42"));
-    assertExtractedOffset(42L, TS0, schema, record, "");
+    assertExtractedOffset(42L, TS0, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -148,7 +149,7 @@ public class TimestampIncrementingCriteriaTest {
         .put("id", 42)
         .put(TS1_COLUMN.name(), TS1);
     assertExtractedOffset(42L, TS1, schema, record,
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL);
+        TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test(expected = DataException.class)
@@ -159,7 +160,7 @@ public class TimestampIncrementingCriteriaTest {
             .field(TS2_COLUMN.name(), Timestamp.SCHEMA)
             .build();
     record = new Struct(schema).put("real-id", 42);
-    criteriaIncTs.extractValues(schema, record, null, "");
+    criteriaIncTs.extractValues(schema, record, null, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -171,7 +172,7 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema)
         .put(TS1_COLUMN.name(), TS1)
         .put(TS2_COLUMN.name(), TS2);
-    assertExtractedOffset(-1, TS1, schema, record, "");
+    assertExtractedOffset(-1, TS1, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -184,7 +185,7 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS1_COLUMN.name(), TS1)
         .put(TS2_COLUMN.name(), TS2);
     assertExtractedOffset(-1, TS1, schema, record,
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL);
+        TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -197,7 +198,7 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS1_COLUMN.name(), DateTimeUtils.toEpochNanos(TS1))
         .put(TS2_COLUMN.name(), DateTimeUtils.toEpochNanos(TS2));
     assertExtractedOffset(-1, TS1, schema, record,
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_LONG_NANOS);
+        TimestampGranularity.NANOS_LONG);
   }
 
   @Test
@@ -210,7 +211,7 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS1_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochNanos(TS1)))
         .put(TS2_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochNanos(TS2)));
     assertExtractedOffset(-1, TS1, schema, record,
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_STRING_NANOS);
+        TimestampGranularity.NANOS_STRING);
   }
 
   @Test
@@ -223,7 +224,7 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS1))
         .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2));
     assertExtractedOffset(-1, TS1, schema, record,
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_STRING_ISO_DATETIME);
+        TimestampGranularity.NANOS_ISO_DATETIME_STRING);
   }
 
   @Test(expected = ConnectException.class)
@@ -236,7 +237,7 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS1))
         .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2));
     assertExtractedOffset(-1, TS1, schema, record,
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_STRING_NANOS);
+        TimestampGranularity.NANOS_STRING);
   }
 
   @Test
@@ -248,7 +249,7 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema)
         .put(TS1_COLUMN.name(), null)
         .put(TS2_COLUMN.name(), TS2);
-    assertExtractedOffset(-1, TS2, schema, record, "");
+    assertExtractedOffset(-1, TS2, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -260,7 +261,7 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema)
         .put(TS1_COLUMN.name().toUpperCase(), TS1)
         .put(TS2_COLUMN.name(), TS2);
-    TimestampIncrementingOffset offset = criteriaTs.extractValues(schema, record, null, "");
+    TimestampIncrementingOffset offset = criteriaTs.extractValues(schema, record, null, TimestampGranularity.CONNECT_LOGICAL);
     assertEquals(TS1, offset.getTimestampOffset());
   }
 
@@ -273,7 +274,7 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema)
         .put(TS1_COLUMN.name(), null)
         .put(TS2_COLUMN.name().toUpperCase(), TS2);
-    assertExtractedOffset(-1, TS2, schema, record, "");
+    assertExtractedOffset(-1, TS2, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test(expected = DataException.class)
@@ -283,7 +284,7 @@ public class TimestampIncrementingCriteriaTest {
         .build();
     record = new Struct(schema)
         .put(TS1_COLUMN.name(), TS1);
-    assertExtractedOffset(-1, TS2, schema, record, "");
+    assertExtractedOffset(-1, TS2, schema, record, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test(expected = DataException.class)
@@ -305,7 +306,7 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema)
         .put(lowerCaseColumnName, TS1)
         .put(upperCaseColumnName, TS2);
-    criteriaTs.extractValues(schema, record, null, "");
+    criteriaTs.extractValues(schema, record, null, TimestampGranularity.CONNECT_LOGICAL);
   }
 
   @Test
@@ -326,7 +327,7 @@ public class TimestampIncrementingCriteriaTest {
     record = new Struct(schema)
         .put(lowerCaseColumnName, TS1)
         .put(upperCaseColumnName, TS2);
-    TimestampIncrementingOffset offset = criteriaTs.extractValues(schema, record, null, "");
+    TimestampIncrementingOffset offset = criteriaTs.extractValues(schema, record, null, TimestampGranularity.CONNECT_LOGICAL);
     assertEquals(TS1, offset.getTimestampOffset());
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -100,7 +100,7 @@ public class TimestampIncrementingTableQuerierTest {
         10211197100L, // Timestamp delay
         TimeZone.getTimeZone("UTC"),
         "",
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
+        JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -99,7 +99,8 @@ public class TimestampIncrementingTableQuerierTest {
         initialOffset.toMap(),
         10211197100L, // Timestamp delay
         TimeZone.getTimeZone("UTC"),
-        ""
+        "",
+        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
     );
   }
 
@@ -232,7 +233,7 @@ public class TimestampIncrementingTableQuerierTest {
     expect(schemaMapping.schema()).andReturn(schema()).times(2);
     expect(resultSet.next()).andReturn(true);
     expect(schemaMapping.fieldSetters()).andReturn(Collections.emptyList());
-    expect(criteria.extractValues(anyObject(), anyObject(), anyObject())).andReturn(offset);
+    expect(criteria.extractValues(anyObject(), anyObject(), anyObject(), anyObject())).andReturn(offset);
   }
 
   private void expectReset() throws Exception {

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
@@ -96,7 +96,8 @@ public class TimestampTableQuerierTest {
         new TimestampIncrementingOffset(initialTimestampOffset, null).toMap(),
         10211197100L, // Timestamp delay
         TimeZone.getTimeZone("UTC"),
-        ""
+        "",
+        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
     );
   }
 
@@ -340,7 +341,7 @@ public class TimestampTableQuerierTest {
     expect(resultSet.next()).andReturn(true);
     expect(schemaMapping.fieldSetters()).andReturn(Collections.emptyList());
     TimestampIncrementingOffset offset = new TimestampIncrementingOffset(timestamp, null);
-    expect(criteria.extractValues(anyObject(), anyObject(), anyObject())).andReturn(offset);
+    expect(criteria.extractValues(anyObject(), anyObject(), anyObject(), anyObject())).andReturn(offset);
   }
 
   private void expectReset() throws Exception {

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
@@ -97,7 +97,7 @@ public class TimestampTableQuerierTest {
         10211197100L, // Timestamp delay
         TimeZone.getTimeZone("UTC"),
         "",
-        JdbcSourceConnectorConfig.TIMESTAMP_GRANULARITY_CONNECT_LOGICAL
+        JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateTimeUtilsTest {
+
+  @Test
+  public void testTimestampToNanos() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(141362049);
+    long nanos = DateTimeUtils.toEpochNanos(timestamp);
+    assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
+  }
+
+  @Test
+  public void testTimestampToString() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(141362049);
+    String nanos = String.valueOf(DateTimeUtils.toEpochNanos(timestamp));
+    assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTime() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(141362049);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+}


### PR DESCRIPTION
## Problem
Background
Oracle DB stores a timestamp with microseconds granularity. The JDBC connector produces events that have the same timestamps when the connector rounds up timestamp to milliseconds, causing downstream applications not to sort events properly and not to be able to compare records with higher precision. 

## Solution
Adding micros and millis format negatively impacts the rollout as the offset management becomes backward-incompatible due to loss of precision. So we will have three new config types,

- `connect-logical` (default)
- `nanos-long` (nanos is epoch as Int64)
- `nanos-string` (nanos is epoch as String)
- `nanos-iso-datetime-string` (`yyyy-MM-dd'T'HH:mm:ss.n` for eg., `2022-01-05T12:07:56.702041000`)

We also discussed not allowing the customers to define the iso string format as it might risk losing the column's precision, leading to incompatibility during rollouts. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
