### PR TITLE
fix null BYTES value insert/upsert for SQL Server

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc.dialect;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
@@ -234,6 +235,11 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
     ZonedDateTime zdt = ZonedDateTime.parse(value, DATE_TIME_FORMATTER);
     zdt = zdt.withZoneSameInstant(timeZone.toZoneId());
     return java.sql.Timestamp.from(zdt.toInstant());
+  }
+
+  @Override
+  protected Integer getSqlTypeForSchema(Schema schema) {
+    return schema.type() == Schema.Type.BYTES ? Types.VARBINARY : null;
   }
 
   @Override

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -480,7 +480,12 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     );
     int index = 0;
     for (Schema schema : nullableTypes) {
-      verifyBindField(++index, schema, null).setObject(index, null);
+      final Integer sqlType = dialect.getSqlTypeForSchema(schema);
+      if (sqlType == null) {
+        verifyBindField(++index, schema, null).setObject(index, null);
+      } else {
+        verifyBindField(++index, schema, null).setNull(index, sqlType);
+      }
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/MicrosoftSqlServerSinkIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/MicrosoftSqlServerSinkIT.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -35,10 +36,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_C
 public class MicrosoftSqlServerSinkIT extends BaseConnectorIT {
     private static final Logger log = LoggerFactory.getLogger(MicrosoftSqlServerSinkIT.class);
     private static final String CONNECTOR_NAME = "jdbc-sink-connector";
-    private static final int TASKS_MAX = 3;
     private static final String MSSQL_URL = "jdbc:sqlserver://0.0.0.0:1433";
-    private static final String MSSQL_Table = "example_table";
-    private static final List<String> KAFKA_TOPICS = Collections.singletonList(MSSQL_Table);
     private Map<String, String> props;
     private Connection connection;
     private JsonConverter jsonConverter;
@@ -78,20 +76,22 @@ public class MicrosoftSqlServerSinkIT extends BaseConnectorIT {
      */
     @Test
     public void verifyConnectorFailsWhenTableNameS() throws Exception {
+        final String table = "example_table";
+
         // Setup up props for the sink connector
-        props = configProperties();
+        props = configProperties(table);
 
         // create table
-        String sql = "CREATE TABLE guest." + MSSQL_Table
+        String sql = "CREATE TABLE guest." + table
                 + " (id int NULL, last_name VARCHAR(50), created_at DATETIME2 NOT NULL);";
         PreparedStatement createStmt = connection.prepareStatement(sql);
         executeSQL(createStmt);
 
         // Create topic in Kafka
-        KAFKA_TOPICS.forEach(topic -> connect.kafka().createTopic(topic, 1));
+        connect.kafka().createTopic(table, 1);
 
         // Configure sink connector
-        configureAndWaitForConnector();
+        configureAndWaitForConnector(1);
 
         //create record and produce it
         Timestamp t = Timestamp.from(
@@ -107,23 +107,47 @@ public class MicrosoftSqlServerSinkIT extends BaseConnectorIT {
                 .put("last_name", "Brams")
                 .put("created_at", t);
 
-        String kafkaValue = new String(jsonConverter.fromConnectData(MSSQL_Table, schema, struct));
-        connect.kafka().produce(MSSQL_Table, null, kafkaValue);
-
-        //sleep till it fails
-        Thread.sleep(Duration.ofSeconds(30).toMillis());
+        String kafkaValue = new String(jsonConverter.fromConnectData(table, schema, struct));
+        connect.kafka().produce(table, null, kafkaValue);
 
         //verify that connector failed because it cannot find the table.
         assertTasksFailedWithTrace(
                 CONNECTOR_NAME,
-                Math.min(KAFKA_TOPICS.size(), TASKS_MAX),
+                1,
                 "Table \"dbo\".\""
-                    + MSSQL_Table
+                    + table
                     + "\" is missing and auto-creation is disabled"
         );
     }
 
-    private Map<String, String> configProperties() {
+    /**
+     * Verify that inserting a null BYTES value succeeds.
+     */
+    @Test
+    public void verifyNullBYTESValue() throws Exception {
+        final String table = "optional_bytes";
+
+        props = configProperties(table);
+        props.put("auto.create", "true");
+
+        connect.kafka().createTopic(table, 1);
+        configureAndWaitForConnector(1);
+
+        final Schema schema = SchemaBuilder.struct().name("com.example.OptionalBytes")
+                .field("id", Schema.INT32_SCHEMA)
+                .field("optional_bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+                .build();
+        final Struct struct = new Struct(schema)
+                .put("id", 1)
+                .put("optional_bytes", null);
+
+        String kafkaValue = new String(jsonConverter.fromConnectData(table, schema, struct));
+        connect.kafka().produce(table, null, kafkaValue);
+
+        waitForCommittedRecords(CONNECTOR_NAME, Collections.singleton(table), 1, 1, TimeUnit.MINUTES.toMillis(2));
+    }
+
+    private Map<String, String> configProperties(String topic) {
         // Create a hashmap to setup sink connector config properties
         Map<String, String> props = new HashMap<>();
 
@@ -139,7 +163,7 @@ public class MicrosoftSqlServerSinkIT extends BaseConnectorIT {
         props.put(JdbcSinkConfig.CONNECTION_USER, USER);
         props.put(JdbcSinkConfig.CONNECTION_PASSWORD, PASS);
         props.put("pk.mode", "none");
-        props.put("topics", MSSQL_Table);
+        props.put("topics", topic);
         return props;
     }
 
@@ -152,12 +176,11 @@ public class MicrosoftSqlServerSinkIT extends BaseConnectorIT {
         }
     }
 
-    private void configureAndWaitForConnector() throws Exception {
+    private void configureAndWaitForConnector(int numTasks) throws Exception {
         // start a sink connector
         connect.configureConnector(CONNECTOR_NAME, props);
 
         // wait for tasks to spin up
-        int minimumNumTasks = Math.min(KAFKA_TOPICS.size(), TASKS_MAX);
-        waitForConnectorToStart(CONNECTOR_NAME, minimumNumTasks);
+        waitForConnectorToStart(CONNECTOR_NAME, numTasks);
     }
 }


### PR DESCRIPTION
## Problem

A sink that sends a null `BYTES` value to SQL Server will throw a `java.sql.BatchUpdateException` with reason "Implicit conversion from data type nvarchar to varbinary(max) is not allowed. Use the CONVERT function to run this query."

This is the problem described in issue #1138.

## Solution

Provide an explicit SQL type for null `BYTES` values in `SqlServerDatabaseDialect.getSqlTypeForSchema()`.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
?