### PR TITLE
CCDB-4512: Fix handling of PostgreSQL NUMERIC/DECIMAL types with unspecified scale

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -342,4 +342,39 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
+  @Override
+  protected int decimalScale(ColumnDefinition defn) {
+    if (defn.scale() == NUMERIC_TYPE_SCALE_UNSET) {
+      return NUMERIC_TYPE_SCALE_HIGH;
+    }
+
+    // Postgres requires DECIMAL/NUMERIC columns to have a precision greater than zero
+    // If the precision appears to be zero, it's because the user didn't define a fixed precision
+    // for the column.
+    if (defn.precision() == 0) {
+      // In that case, a scale of zero indicates that there also isn't a fixed scale defined for
+      // the column. Instead of treating that column as if its scale is actually zero (which can
+      // cause issues since it may contain values that aren't possible with a scale of zero, like
+      // 12.12), we fall back on NUMERIC_TYPE_SCALE_HIGH to try to avoid loss of precision
+      if (defn.scale() == 0) {
+        log.debug(
+            "Column {} does not appear to have a fixed scale defined; defaulting to {}",
+            defn.id(),
+            NUMERIC_TYPE_SCALE_HIGH
+        );
+        return NUMERIC_TYPE_SCALE_HIGH;
+      } else {
+        // Should never happen, but if it does may signal an edge case
+        // that we need to add new logic for
+        log.warn(
+            "Column {} has a precision of zero, but a non-zero scale of {}",
+            defn.id(),
+            defn.scale()
+        );
+      }
+    }
+
+    return defn.scale();
+  }
+
 }


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CCDB-4512), [GitHub issue](https://github.com/confluentinc/kafka-connect-jdbc/issues/480)

## Problem
The Postgres JDBC driver we use returns a scale and precision of zero for `NUMERIC` and `DECIMAL` columns that do not have a fixed precision and scale defined. However, the [Postgres spec](https://www.postgresql.org/docs/13/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL) indicates that a column defined without a fixed precision or scale can contain values with non-zero scale and (obviously) non-zero precision.

This causes issues when we invoke [`ResultSet::getBigDecimal`](https://github.com/confluentinc/kafka-connect-jdbc/blob/fe850317e48c6cc5da2e8c3d5c77bc4c12ba9653/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java#L1357) with a scale of zero on a `ResultSet` that contains a value with a non-zero scale for the column; specifically, the driver throws an `ArithmeticException` and the connector fails.

## Solution
We can catch the case where a column does not have a fixed precision or scale defined and default to the [current fallback value](https://github.com/confluentinc/kafka-connect-jdbc/blob/fe850317e48c6cc5da2e8c3d5c77bc4c12ba9653/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java#L106) for columns with an unknown scale.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Several unit tests are added to verify the expected behavior. I also ran this locally against a Dockerized PostgreSQL table with a column defined as `NUMERIC` containing the value `-13.39`; without the changes, the connector failed, and with them, the connector successfully produced a logical decimal value for that column.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Target 5.2.x, `pint merge` forward.