### PR TITLE
[ci skip] MINOR: Fix snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
     <packaging>jar</packaging>
-    <version>10.4.x-SNAPSHOT</version>
+    <version>10.3.1-SNAPSHOT</version>
     <name>kafka-connect-jdbc</name>
     <organization>
         <name>Confluent, Inc.</name>


### PR DESCRIPTION
On `master`, the POM `<version>` should always end in `.0-SNAPSHOT`. On all `.x` branches, the POM `<version>` should always end in `.r-SNAPSHOT`, where `r` is the patch version number of the latest release from that branch, plus one (i.e., if the latest release on the `8.9.x` branch is `8.9.3`, the POM `<version>` should end in `.4-SNAPSHOT`).

This PR corrects the version on the `10.3.x` branch.

NOTE: This should not be propagated forward via `pint merge` as that would overwrite the development version on the master branch, which is correct as-is. As a result, I've added `[ci skip]` to the PR title to disable automatic invocation of `pint merge`.