### PR TITLE
Support Postgres partitioned table #1092

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ target/
 .idea/
 .ipr
 
+# Eclipse IDE
+.project
+.classpath
+.checkstyle
+.settings/
+
 # Documentation build output
 /docs/_build
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.package.home>target/${project.artifactId}-${project.version}-package</project.package.home>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-        <testcontainers.version>1.16.2</testcontainers.version>
+        <testcontainers.version>1.17.3</testcontainers.version>
     </properties>
 
     <repositories>
@@ -242,6 +242,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oracle-xe</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -249,8 +249,9 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String TABLE_TYPES_DOC =
       "The comma-separated types of database tables to which the sink connector can write. "
       + "By default this is ``" + TableType.TABLE + "``, but any combination of ``"
-      + TableType.TABLE + "`` and ``" + TableType.VIEW + "`` is allowed. Not all databases "
-      + "support writing to views, and when they do the the sink connector will fail if the "
+      + TableType.TABLE + "``, ``" + TableType.PARTITIONED_TABLE + "`` and ``"
+      + TableType.VIEW + "`` is allowed. Not all databases support writing to views, "
+      + "and when they do the sink connector will fail if the "
       + "view definition does not match the records' schemas (regardless of ``"
       + AUTO_EVOLVE + "``).";
 

--- a/src/main/java/io/confluent/connect/jdbc/util/TableType.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableType.java
@@ -21,7 +21,9 @@ import java.util.stream.Collectors;
 
 public enum TableType {
 
-  TABLE("TABLE", "Table"), VIEW("VIEW", "View");
+  TABLE("TABLE", "Table"),
+  PARTITIONED_TABLE("PARTITIONED TABLE", "Partitioned Table"),
+  VIEW("VIEW", "View");
 
   private final String value;
   private final String capitalCase;

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -87,6 +87,13 @@ public class JdbcSinkConfigTest {
   }
 
   @Test
+  public void shouldCreateConfigWithPartitionedTableOnly() {
+    props.put("table.types", "partitioned table");
+    createConfig();
+    assertTableTypes(TableType.PARTITIONED_TABLE);
+  }
+
+  @Test
   public void shouldCreateConfigWithViewAndTable() {
     props.put("table.types", "view,table");
     createConfig();

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresPartitionedIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresPartitionedIT.java
@@ -1,7 +1,6 @@
 package io.confluent.connect.jdbc.sink.integration;
 
 import java.sql.*;
-import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Map;
@@ -11,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.connect.jdbc.integration.BaseConnectorIT;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresPartitionedIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresPartitionedIT.java
@@ -1,0 +1,140 @@
+package io.confluent.connect.jdbc.sink.integration;
+
+import java.sql.*;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.integration.BaseConnectorIT;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Category(IntegrationTest.class)
+public class PostgresPartitionedIT extends BaseConnectorIT {
+
+	@Rule
+	public PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>("postgres:14-bullseye");
+
+	Connection connection;
+	private JsonConverter jsonConverter;
+	private Map<String, String> props;
+
+	private static final String KEY = "key";
+	private static final String MEASUREMENTS = "measurements";
+
+	@Before
+	public void setup() throws SQLException {
+		startConnect();
+
+		jsonConverter = jsonConverter();
+
+		props = baseSinkProps();
+		props.put(JdbcSinkConfig.CONNECTION_URL, postgresql.getJdbcUrl());
+		props.put(JdbcSinkConfig.CONNECTION_USER, postgresql.getUsername());
+		props.put(JdbcSinkConfig.CONNECTION_PASSWORD, postgresql.getPassword());
+		props.put(JdbcSinkConfig.PK_MODE, "record_value");
+		props.put(JdbcSinkConfig.PK_FIELDS, KEY);
+		props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+		props.put(JdbcSinkConfig.INSERT_MODE, "insert");
+		props.put(JdbcSinkConfig.TABLE_TYPES_CONFIG, "PARTITIONED TABLE");
+		props.put("topics", MEASUREMENTS);
+
+		// create topic in Kafka
+		connect.kafka().createTopic(MEASUREMENTS, 1);
+
+		createPartitionedTableAndPartition();
+	}
+
+	private void createPartitionedTableAndPartition() throws SQLException {
+		// Create table taken from https://www.postgresql.org/docs/14/ddl-partitioning.html
+		connection = DriverManager.getConnection(
+				postgresql.getJdbcUrl(),
+				postgresql.getUsername(),
+				postgresql.getPassword());
+		try (Statement s = connection.createStatement()) {
+			s.execute("CREATE TABLE " + MEASUREMENTS + " ("
+					+ "    key             int not null,"
+					+ "    city_id         int not null,"
+					+ "    logdate         date not null,"
+					+ "    peaktemp        int,"
+					+ "    unitsales       int"
+					+ ") PARTITION BY RANGE (logdate);");
+			s.execute("CREATE TABLE " + MEASUREMENTS + "_y1970"
+					+ "    PARTITION OF " + MEASUREMENTS
+					+ "    FOR VALUES FROM ('1970-01-01') TO ('1971-01-01');");
+		}
+	}
+
+	@After
+	public void tearDown() throws SQLException {
+		connection.close();
+		stopConnect();
+	}
+
+	@Test
+	public void shouldInsertMeasurement() throws Exception {
+		Schema schema = SchemaBuilder.struct()
+				.field(KEY, Schema.INT32_SCHEMA)
+				.field("city_id", Schema.INT32_SCHEMA)
+				.field("logdate", Date.SCHEMA)
+				.field("peaktemp", Schema.INT32_SCHEMA)
+				.field("unitsales", Schema.INT32_SCHEMA)
+				.build();
+
+		java.util.Date logdate = new java.util.Date(0);
+
+		Struct value = new Struct(schema)
+				.put(KEY, 1)
+				.put("city_id", 2)
+				.put("logdate", logdate)
+				.put("peaktemp", 4)
+				.put("unitsales", 5);
+
+		String connectorName = "jdbc-sink-connector";
+		connect.configureConnector(connectorName, props);
+		waitForConnectorToStart(connectorName, 1);
+		
+		produceRecord(schema, value);
+		
+		waitForCommittedRecords(connectorName, Collections.singleton(MEASUREMENTS), 1, 1, TimeUnit.MINUTES.toMillis(3));
+
+		assertSinkRecordValues(value);
+	}
+
+	private void assertSinkRecordValues(Struct value) throws SQLException, Exception {
+		try (Statement s = connection.createStatement();
+				ResultSet rs = s.executeQuery("SELECT * FROM " + MEASUREMENTS
+						+ " ORDER BY KEY DESC FETCH FIRST 1 ROWS ONLY")) {
+			assertTrue(rs.next());
+
+			assertEquals(value.getInt32(KEY).intValue(), rs.getInt(1));
+			assertEquals(value.getInt32("city_id").intValue(), rs.getInt(2));
+			Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+			assertEquals(value.get("logdate"), rs.getDate(3, calendar));
+			assertEquals(value.getInt32("peaktemp").intValue(), rs.getInt(4));
+			assertEquals(value.getInt32("unitsales").intValue(), rs.getInt(5));
+		}
+	}
+
+	private void produceRecord(Schema schema, Struct struct) {
+		String kafkaValue = new String(jsonConverter.fromConnectData(MEASUREMENTS, schema, struct));
+		connect.kafka().produce(MEASUREMENTS, null, kafkaValue);
+	}
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresPartitionedIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresPartitionedIT.java
@@ -1,6 +1,10 @@
 package io.confluent.connect.jdbc.sink.integration;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Map;
@@ -29,112 +33,112 @@ import static org.junit.Assert.assertTrue;
 @Category(IntegrationTest.class)
 public class PostgresPartitionedIT extends BaseConnectorIT {
 
-	@Rule
-	public PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>("postgres:14-bullseye");
+  @Rule
+  public PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>("postgres:14-bullseye");
 
-	Connection connection;
-	private JsonConverter jsonConverter;
-	private Map<String, String> props;
+  Connection connection;
+  private JsonConverter jsonConverter;
+  private Map<String, String> props;
 
-	private static final String KEY = "key";
-	private static final String MEASUREMENTS = "measurements";
+  private static final String KEY = "key";
+  private static final String MEASUREMENTS = "measurements";
 
-	@Before
-	public void setup() throws SQLException {
-		startConnect();
+  @Before
+  public void setup() throws SQLException {
+    startConnect();
 
-		jsonConverter = jsonConverter();
+    jsonConverter = jsonConverter();
 
-		props = baseSinkProps();
-		props.put(JdbcSinkConfig.CONNECTION_URL, postgresql.getJdbcUrl());
-		props.put(JdbcSinkConfig.CONNECTION_USER, postgresql.getUsername());
-		props.put(JdbcSinkConfig.CONNECTION_PASSWORD, postgresql.getPassword());
-		props.put(JdbcSinkConfig.PK_MODE, "record_value");
-		props.put(JdbcSinkConfig.PK_FIELDS, KEY);
-		props.put(JdbcSinkConfig.AUTO_CREATE, "false");
-		props.put(JdbcSinkConfig.INSERT_MODE, "insert");
-		props.put(JdbcSinkConfig.TABLE_TYPES_CONFIG, "PARTITIONED TABLE");
-		props.put("topics", MEASUREMENTS);
+    props = baseSinkProps();
+    props.put(JdbcSinkConfig.CONNECTION_URL, postgresql.getJdbcUrl());
+    props.put(JdbcSinkConfig.CONNECTION_USER, postgresql.getUsername());
+    props.put(JdbcSinkConfig.CONNECTION_PASSWORD, postgresql.getPassword());
+    props.put(JdbcSinkConfig.PK_MODE, "record_value");
+    props.put(JdbcSinkConfig.PK_FIELDS, KEY);
+    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+    props.put(JdbcSinkConfig.INSERT_MODE, "insert");
+    props.put(JdbcSinkConfig.TABLE_TYPES_CONFIG, "PARTITIONED TABLE");
+    props.put("topics", MEASUREMENTS);
 
-		// create topic in Kafka
-		connect.kafka().createTopic(MEASUREMENTS, 1);
+    // create topic in Kafka
+    connect.kafka().createTopic(MEASUREMENTS, 1);
 
-		createPartitionedTableAndPartition();
-	}
+    createPartitionedTableAndPartition();
+  }
 
-	private void createPartitionedTableAndPartition() throws SQLException {
-		// Create table taken from https://www.postgresql.org/docs/14/ddl-partitioning.html
-		connection = DriverManager.getConnection(
-				postgresql.getJdbcUrl(),
-				postgresql.getUsername(),
-				postgresql.getPassword());
-		try (Statement s = connection.createStatement()) {
-			s.execute("CREATE TABLE " + MEASUREMENTS + " ("
-					+ "    key             int not null,"
-					+ "    city_id         int not null,"
-					+ "    logdate         date not null,"
-					+ "    peaktemp        int,"
-					+ "    unitsales       int"
-					+ ") PARTITION BY RANGE (logdate);");
-			s.execute("CREATE TABLE " + MEASUREMENTS + "_y1970"
-					+ "    PARTITION OF " + MEASUREMENTS
-					+ "    FOR VALUES FROM ('1970-01-01') TO ('1971-01-01');");
-		}
-	}
+  private void createPartitionedTableAndPartition() throws SQLException {
+    // Create table taken from https://www.postgresql.org/docs/14/ddl-partitioning.html
+    connection = DriverManager.getConnection(
+        postgresql.getJdbcUrl(),
+        postgresql.getUsername(),
+        postgresql.getPassword());
+    try (Statement s = connection.createStatement()) {
+      s.execute("CREATE TABLE " + MEASUREMENTS + " ("
+          + "    key             int not null,"
+          + "    city_id         int not null,"
+          + "    logdate         date not null,"
+          + "    peaktemp        int,"
+          + "    unitsales       int"
+          + ") PARTITION BY RANGE (logdate);");
+      s.execute("CREATE TABLE " + MEASUREMENTS + "_y1970"
+          + "    PARTITION OF " + MEASUREMENTS
+          + "    FOR VALUES FROM ('1970-01-01') TO ('1971-01-01');");
+    }
+  }
 
-	@After
-	public void tearDown() throws SQLException {
-		connection.close();
-		stopConnect();
-	}
+  @After
+  public void tearDown() throws SQLException {
+    connection.close();
+    stopConnect();
+  }
 
-	@Test
-	public void shouldInsertMeasurement() throws Exception {
-		Schema schema = SchemaBuilder.struct()
-				.field(KEY, Schema.INT32_SCHEMA)
-				.field("city_id", Schema.INT32_SCHEMA)
-				.field("logdate", Date.SCHEMA)
-				.field("peaktemp", Schema.INT32_SCHEMA)
-				.field("unitsales", Schema.INT32_SCHEMA)
-				.build();
+  @Test
+  public void shouldInsertMeasurement() throws Exception {
+    Schema schema = SchemaBuilder.struct()
+        .field(KEY, Schema.INT32_SCHEMA)
+        .field("city_id", Schema.INT32_SCHEMA)
+        .field("logdate", Date.SCHEMA)
+        .field("peaktemp", Schema.INT32_SCHEMA)
+        .field("unitsales", Schema.INT32_SCHEMA)
+        .build();
 
-		java.util.Date logdate = new java.util.Date(0);
+    java.util.Date logdate = new java.util.Date(0);
 
-		Struct value = new Struct(schema)
-				.put(KEY, 1)
-				.put("city_id", 2)
-				.put("logdate", logdate)
-				.put("peaktemp", 4)
-				.put("unitsales", 5);
+    Struct value = new Struct(schema)
+        .put(KEY, 1)
+        .put("city_id", 2)
+        .put("logdate", logdate)
+        .put("peaktemp", 4)
+        .put("unitsales", 5);
 
-		String connectorName = "jdbc-sink-connector";
-		connect.configureConnector(connectorName, props);
-		waitForConnectorToStart(connectorName, 1);
-		
-		produceRecord(schema, value);
-		
-		waitForCommittedRecords(connectorName, Collections.singleton(MEASUREMENTS), 1, 1, TimeUnit.MINUTES.toMillis(3));
+    String connectorName = "jdbc-sink-connector";
+    connect.configureConnector(connectorName, props);
+    waitForConnectorToStart(connectorName, 1);
+    
+    produceRecord(schema, value);
+    
+    waitForCommittedRecords(connectorName, Collections.singleton(MEASUREMENTS), 1, 1, TimeUnit.MINUTES.toMillis(3));
 
-		assertSinkRecordValues(value);
-	}
+    assertSinkRecordValues(value);
+  }
 
-	private void assertSinkRecordValues(Struct value) throws SQLException, Exception {
-		try (Statement s = connection.createStatement();
-				ResultSet rs = s.executeQuery("SELECT * FROM " + MEASUREMENTS
-						+ " ORDER BY KEY DESC FETCH FIRST 1 ROWS ONLY")) {
-			assertTrue(rs.next());
+  private void assertSinkRecordValues(Struct value) throws SQLException, Exception {
+    try (Statement s = connection.createStatement();
+        ResultSet rs = s.executeQuery("SELECT * FROM " + MEASUREMENTS
+            + " ORDER BY KEY DESC FETCH FIRST 1 ROWS ONLY")) {
+      assertTrue(rs.next());
 
-			assertEquals(value.getInt32(KEY).intValue(), rs.getInt(1));
-			assertEquals(value.getInt32("city_id").intValue(), rs.getInt(2));
-			Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-			assertEquals(value.get("logdate"), rs.getDate(3, calendar));
-			assertEquals(value.getInt32("peaktemp").intValue(), rs.getInt(4));
-			assertEquals(value.getInt32("unitsales").intValue(), rs.getInt(5));
-		}
-	}
+      assertEquals(value.getInt32(KEY).intValue(), rs.getInt(1));
+      assertEquals(value.getInt32("city_id").intValue(), rs.getInt(2));
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+      assertEquals(value.get("logdate"), rs.getDate(3, calendar));
+      assertEquals(value.getInt32("peaktemp").intValue(), rs.getInt(4));
+      assertEquals(value.getInt32("unitsales").intValue(), rs.getInt(5));
+    }
+  }
 
-	private void produceRecord(Schema schema, Struct struct) {
-		String kafkaValue = new String(jsonConverter.fromConnectData(MEASUREMENTS, schema, struct));
-		connect.kafka().produce(MEASUREMENTS, null, kafkaValue);
-	}
+  private void produceRecord(Schema schema, Struct struct) {
+    String kafkaValue = new String(jsonConverter.fromConnectData(MEASUREMENTS, schema, struct));
+    connect.kafka().produce(MEASUREMENTS, null, kafkaValue);
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableTypeTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertArrayEquals;
 public class TableTypeTest {
 
   private static EnumSet<TableType> TABLE_ONLY = types(TableType.TABLE);
+  private static EnumSet<TableType> PARTITIONED_TABLE_ONLY = types(TableType.PARTITIONED_TABLE);
   private static EnumSet<TableType> VIEW_ONLY = types(TableType.VIEW);
   private static EnumSet<TableType> TABLE_AND_VIEW = types(TableType.TABLE, TableType.VIEW);
 
@@ -56,6 +57,7 @@ public class TableTypeTest {
   public void shouldComputeJdbcTypeArray() {
     assertArrayEquals(array("TABLE"), TableType.asJdbcTableTypeArray(TABLE_ONLY));
     assertArrayEquals(array("VIEW"), TableType.asJdbcTableTypeArray(VIEW_ONLY));
+    assertArrayEquals(array("PARTITIONED TABLE"), TableType.asJdbcTableTypeArray(PARTITIONED_TABLE_ONLY));
     assertArrayEquals(array("TABLE", "VIEW"), TableType.asJdbcTableTypeArray(TABLE_AND_VIEW));
   }
 


### PR DESCRIPTION
## Problem

Postgres partitioned tables are not supported [after this change in the driver](https://github.com/pgjdbc/pgjdbc/commit/25eb32c8681eaa4aaac801808b6028e9f5dfbea8#diff-0571f8ac3385a7f7bb34e5c77f8afd24810311506989379c2e85c6c16eea6ce4L1287).

#1092

## Solution

Map `PARTITIONED TABLE` as a valid value;
not yet enabled by default, although that could be added still.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
? Merge to master I guess; no plans for backports unless specifically requested.
