### PR TITLE
CCDB-4354: preflight cross-fields validation for configuration PK_MODE

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -80,8 +80,8 @@ public class JdbcSinkConnector extends SinkConnector {
          */
         .ifPresent(pkMode -> {
           if (!pkMode.recommendedValues().contains(pkMode.value())) {
-            pkMode.addErrorMessage("'" + pkMode.name() + "' can only have value in list "
-                + pkMode.recommendedValues());
+            pkMode.addErrorMessage("'" + pkMode.value() + "' is invalid:"
+                + " Deletes are only supported for pk.mode 'record_key'");
           }
         });
 

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -83,7 +83,8 @@ public class JdbcSinkConnector extends SinkConnector {
         .filter(deleteEnabled -> Boolean.TRUE.equals(deleteEnabled.value()))
         .ifPresent(deleteEnabled -> configValue(config, PK_MODE)
             .ifPresent(pkMode -> {
-              if (!RECORD_KEY.name().toLowerCase(Locale.ROOT).equals(pkMode.value())) {
+              if (!RECORD_KEY.name().toLowerCase(Locale.ROOT).equals(pkMode.value())
+              && !RECORD_KEY.name().toUpperCase(Locale.ROOT).equals(pkMode.value())) {
                 String conflictMsg = "Deletes are only supported for pk.mode record_key";
                 pkMode.addErrorMessage(conflictMsg);
                 deleteEnabled.addErrorMessage(conflictMsg);

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -84,7 +84,7 @@ public class JdbcSinkConnector extends SinkConnector {
         .ifPresent(deleteEnabled -> configValue(config, PK_MODE)
             .ifPresent(pkMode -> {
               if (!RECORD_KEY.name().toLowerCase(Locale.ROOT).equals(pkMode.value())
-              && !RECORD_KEY.name().toUpperCase(Locale.ROOT).equals(pkMode.value())) {
+                  && !RECORD_KEY.name().toUpperCase(Locale.ROOT).equals(pkMode.value())) {
                 String conflictMsg = "Deletes are only supported for pk.mode record_key";
                 pkMode.addErrorMessage(conflictMsg);
                 deleteEnabled.addErrorMessage(conflictMsg);

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -72,13 +72,18 @@ public class JdbcSinkConnector extends SinkConnector {
 
     config.configValues()
         .stream()
-        /** use recommended values for configuration validation
+        .filter(cfg -> PK_MODE.equals(cfg.name()))
+        .findFirst()
+        /**
+         * use recommended values for configuration validation
          * {@link PrimaryKeyModeRecommender#validValues}
          */
-        .filter(cfg -> PK_MODE.equals(cfg.name())
-            && !cfg.recommendedValues().contains(cfg.value()))
-        .findFirst()
-        .ifPresent(cfg -> cfg.addErrorMessage("'" + cfg.value() + "' is not valid"));
+        .ifPresent(pkMode -> {
+          if (!pkMode.recommendedValues().contains(pkMode.value())) {
+            pkMode.addErrorMessage("'" + pkMode.name() + "' can only have value in list "
+                + pkMode.recommendedValues());
+          }
+        });
 
     return config;
   }

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -78,8 +78,7 @@ public class JdbcSinkConnector extends SinkConnector {
         .filter(cfg -> PK_MODE.equals(cfg.name())
             && !cfg.recommendedValues().contains(cfg.value()))
         .findFirst()
-        .ifPresent(cfg -> cfg.addErrorMessage("'" + cfg.value() + "' is not in valid values "
-            + cfg.recommendedValues()));
+        .ifPresent(cfg -> cfg.addErrorMessage("'" + cfg.value() + "' is not valid"));
 
     return config;
   }

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
@@ -46,8 +46,11 @@ public class JdbcSinkConnectorTest {
         EMPTY_LIST, configErrors(connector.validate(connConfig), PK_MODE));
 
     connConfig.put("pk.mode", "none");
+
+    final String conflictMsg = "Deletes are only supported for pk.mode record_key";
+
     assertEquals("'record_key' is the only valid mode when 'delete.enabled' == true",
-        singletonList("'none' is invalid: Deletes are only supported for pk.mode 'record_key'"),
+        singletonList(conflictMsg),
         configErrors(connector.validate(connConfig), PK_MODE));
   }
 
@@ -74,8 +77,6 @@ public class JdbcSinkConnectorTest {
     connConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSinkConnector");
     connConfig.put("delete.enabled", "false");
     connConfig.put("pk.mode", "gibberish");
-
-    List<String> errors = configErrors(connector.validate(connConfig), PK_MODE);
 
     assertEquals("no double reporting for unknown pk.mode",
         1, configErrors(connector.validate(connConfig), PK_MODE).size());

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
@@ -85,8 +85,8 @@ public class JdbcSinkConnectorTest {
   private List<String> configErrors(Config config, String propertyName) {
     return config.configValues()
         .stream()
-        .filter(cfg -> propertyName.equals(cfg.name()))
-        .flatMap(cfg -> propertyName.equals(cfg.name()) ? cfg.errorMessages().stream() : Stream.empty())
+        .flatMap(cfg -> propertyName.equals(cfg.name()) ?
+            cfg.errorMessages().stream() : Stream.empty())
         .collect(Collectors.toList());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
@@ -42,7 +42,11 @@ public class JdbcSinkConnectorTest {
     connConfig.put("delete.enabled", "true");
 
     connConfig.put("pk.mode", "record_key");
-    assertEquals("'record_key' is the only valid mode when 'delete.enabled' == true",
+    assertEquals("'pk.mode must be 'RECORD_KEY/record_key' when 'delete.enabled' == true",
+        EMPTY_LIST, configErrors(connector.validate(connConfig), PK_MODE));
+
+    connConfig.put("pk.mode", "RECORD_KEY");
+    assertEquals("pk.mode must be 'RECORD_KEY/record_key' when 'delete.enabled' == true",
         EMPTY_LIST, configErrors(connector.validate(connConfig), PK_MODE));
 
     connConfig.put("pk.mode", "none");

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
@@ -1,16 +1,28 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.connect.jdbc;
 
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.config.Config;
 
 import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.PK_MODE;
 import static org.junit.Assert.*;
 
-import org.apache.kafka.common.config.ConfigValue;
 import org.junit.Test;
 
 public class JdbcSinkConnectorTest {
@@ -18,53 +30,41 @@ public class JdbcSinkConnectorTest {
   @Test
   public void testValidationWhenDeleteEnabled() {
 
+    JdbcSinkConnector connector = new JdbcSinkConnector();
+
     Map<String, String> connConfig = new HashMap<>();
     connConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSinkConnector");
     connConfig.put("delete.enabled", "true");
-    connConfig.put("pk.mode", "none");
-
-    JdbcSinkConnector connector = new JdbcSinkConnector();
-
-    List<String> pkModeError = connector.validate(connConfig)
-        .configValues()
-        .stream()
-        .filter(cfg -> PK_MODE.equals(cfg.name()))
-        .map(ConfigValue::errorMessages)
-        .findFirst()
-        .orElse(Collections.emptyList());
-
-    assertFalse(pkModeError.isEmpty());
 
     connConfig.put("pk.mode", "record_key");
+    assertFalse("'record_key' is the only valid mode when 'delete.enabled' == true",
+        hasConfigError(connector.validate(connConfig), PK_MODE));
 
-    pkModeError = connector.validate(connConfig)
-        .configValues()
-        .stream()
-        .filter(cfg -> PK_MODE.equals(cfg.name()))
-        .map(ConfigValue::errorMessages)
-        .findFirst()
-        .orElse(Collections.emptyList());
-
-    assertTrue(pkModeError.isEmpty());
+    connConfig.put("pk.mode", "none");
+    assertTrue("'record_key' is the only valid mode when 'delete.enabled' == true",
+        hasConfigError(connector.validate(connConfig), PK_MODE));
   }
 
   @Test
   public void testValidationWhenDeleteNotEnabled() {
 
+    JdbcSinkConnector connector = new JdbcSinkConnector();
+
     Map<String, String> connConfig = new HashMap<>();
     connConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSinkConnector");
+    connConfig.put("delete.enabled", "false");
+
     connConfig.put("pk.mode", "none");
+    assertFalse("any defined mode is valid when 'delete.enabled' == false",
+        hasConfigError(connector.validate(connConfig), PK_MODE));
+  }
 
-    JdbcSinkConnector connector = new JdbcSinkConnector();
-    Config config = connector.validate(connConfig);
-
-    List<String> pkModeError = config.configValues()
+  private boolean hasConfigError(Config config, String propertyName) {
+    return config.configValues()
         .stream()
-        .filter(cfg -> PK_MODE.equals(cfg.name()))
-        .map(ConfigValue::errorMessages)
+        .filter(cfg -> propertyName.equals(cfg.name())
+            && !cfg.errorMessages().isEmpty())
         .findFirst()
-        .orElse(Collections.emptyList());
-
-    assertTrue(pkModeError.isEmpty());
+        .isPresent();
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
@@ -1,0 +1,70 @@
+package io.confluent.connect.jdbc;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.config.Config;
+
+import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.PK_MODE;
+import static org.junit.Assert.*;
+
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.Test;
+
+public class JdbcSinkConnectorTest {
+
+  @Test
+  public void testValidationWhenDeleteEnabled() {
+
+    Map<String, String> connConfig = new HashMap<>();
+    connConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSinkConnector");
+    connConfig.put("delete.enabled", "true");
+    connConfig.put("pk.mode", "none");
+
+    JdbcSinkConnector connector = new JdbcSinkConnector();
+
+    List<String> pkModeError = connector.validate(connConfig)
+        .configValues()
+        .stream()
+        .filter(cfg -> PK_MODE.equals(cfg.name()))
+        .map(ConfigValue::errorMessages)
+        .findFirst()
+        .orElse(Collections.emptyList());
+
+    assertFalse(pkModeError.isEmpty());
+
+    connConfig.put("pk.mode", "record_key");
+
+    pkModeError = connector.validate(connConfig)
+        .configValues()
+        .stream()
+        .filter(cfg -> PK_MODE.equals(cfg.name()))
+        .map(ConfigValue::errorMessages)
+        .findFirst()
+        .orElse(Collections.emptyList());
+
+    assertTrue(pkModeError.isEmpty());
+  }
+
+  @Test
+  public void testValidationWhenDeleteNotEnabled() {
+
+    Map<String, String> connConfig = new HashMap<>();
+    connConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSinkConnector");
+    connConfig.put("pk.mode", "none");
+
+    JdbcSinkConnector connector = new JdbcSinkConnector();
+    Config config = connector.validate(connConfig);
+
+    List<String> pkModeError = config.configValues()
+        .stream()
+        .filter(cfg -> PK_MODE.equals(cfg.name()))
+        .map(ConfigValue::errorMessages)
+        .findFirst()
+        .orElse(Collections.emptyList());
+
+    assertTrue(pkModeError.isEmpty());
+  }
+}


### PR DESCRIPTION
## Problem
Misconfigured `pk.mode` and `delete.enabled` combination should not be surfaced by throwing an exception when the connector or task starts. Instead, the connector should notify the user that it is configured incorrectly via the Connector::validate method.

## Solution

Do cross-fields configuration validation in `Connector::validate` method, utilizing existing logic from [PrimaryKeyModeRecommender](https://github.com/confluentinc/kafka-connect-jdbc/blob/348e49f4a93261dd7b1365f469af426fa9ee8c6c/src/main/java/io/confluent/connect/jdbc/util/PrimaryKeyModeRecommender.java#L41).

Ref:
1. [How to Write a Connector for Kafka Connect](https://www.confluent.io/blog/write-a-kafka-connect-connector-with-configuration-handling/)
2. [kafka-connect-elasticsearch](https://github.com/confluentinc/kafka-connect-elasticsearch/blob/6f1a02586748a549b9c09178a6506fd13dde2b77/src/main/java/io/confluent/connect/elasticsearch/Validator.java#L97)
3. [Connect Configuration Validation](https://kafka.apache.org/documentation/#connect_configs)
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
