### PR TITLE
CCDB-4340 Fix the NPE on timestamp columns that are null

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -825,17 +825,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
     NANOS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         DateTimeUtils::toEpochNanos,
-        timestamp -> DateTimeUtils.toTimestamp((long) timestamp)),
+        epochNanos -> DateTimeUtils.toTimestamp((Long) epochNanos)),
 
     NANOS_STRING(optional -> optional ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA,
-        timestamp -> String.valueOf(DateTimeUtils.toEpochNanos(timestamp)),
-        timestamp -> {
+        DateTimeUtils::toEpochNanosString,
+        epochNanosString -> {
           try {
-            return DateTimeUtils.toTimestamp((String) timestamp);
+            return DateTimeUtils.toTimestamp((String) epochNanosString);
           } catch (NumberFormatException  e) {
             throw new ConnectException(
                 "Invalid value for timestamp column with nanos-string granularity: "
-                    + timestamp
+                    + epochNanosString
                     + e.getMessage());
           }
         }),
@@ -843,7 +843,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     NANOS_ISO_DATETIME_STRING(optional -> optional
         ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA,
         DateTimeUtils::toIsoDateTimeString,
-        timestamp -> DateTimeUtils.toTimestampFromIsoDateTime((String) timestamp));
+        isoDateTimeString -> DateTimeUtils.toTimestampFromIsoDateTime((String) isoDateTimeString));
 
     public final Function<Boolean, Schema> schemaFunction;
     public final Function<Timestamp, Object> fromTimestamp;

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -227,6 +227,45 @@ public class TimestampIncrementingCriteriaTest {
         TimestampGranularity.NANOS_ISO_DATETIME_STRING);
   }
 
+  @Test
+  public void extractWithTsColumnNanosLongNull() throws Exception {
+    schema = SchemaBuilder.struct()
+        .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .build();
+    record = new Struct(schema)
+        .put(TS1_COLUMN.name(), null)
+        .put(TS2_COLUMN.name(), null);
+    assertExtractedOffset(-1, TS0, schema, record,
+        TimestampGranularity.NANOS_LONG);
+  }
+
+  @Test
+  public void extractWithTsColumnNanosStringNull() throws Exception {
+    schema = SchemaBuilder.struct()
+        .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    record = new Struct(schema)
+        .put(TS1_COLUMN.name(), null)
+        .put(TS2_COLUMN.name(), null);
+    assertExtractedOffset(-1, TS0, schema, record,
+        TimestampGranularity.NANOS_STRING);
+  }
+
+  @Test
+  public void extractWithTsColumnIsoDateTimeStringNull() throws Exception {
+    schema = SchemaBuilder.struct()
+        .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .build();
+    record = new Struct(schema)
+        .put(TS1_COLUMN.name(), null)
+        .put(TS2_COLUMN.name(), null);
+    assertExtractedOffset(-1, TS0, schema, record,
+        TimestampGranularity.NANOS_ISO_DATETIME_STRING);
+  }
+
   @Test(expected = ConnectException.class)
   public void extractWithTsColumnIsoDateTimeStringNanosConfig() throws Exception {
     schema = SchemaBuilder.struct()

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -17,15 +17,17 @@ package io.confluent.connect.jdbc.util;
 
 import org.junit.Test;
 
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DateTimeUtilsTest {
 
   @Test
-  public void testTimestampToNanos() {
+  public void testTimestampToNanosLong() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
     long nanos = DateTimeUtils.toEpochNanos(timestamp);
@@ -33,11 +35,27 @@ public class DateTimeUtilsTest {
   }
 
   @Test
-  public void testTimestampToString() {
+  public void testTimestampToNanosLongNull() {
+    Long nanos = DateTimeUtils.toEpochNanos(null);
+    assertNull(nanos);
+    Timestamp timestamp = DateTimeUtils.toTimestamp((Long) null);
+    assertNull(timestamp);
+  }
+
+  @Test
+  public void testTimestampToNanosString() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
-    String nanos = String.valueOf(DateTimeUtils.toEpochNanos(timestamp));
+    String nanos = DateTimeUtils.toEpochNanosString(timestamp);
     assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
+  }
+
+  @Test
+  public void testTimestampToNanosStringNull() {
+    String nanos = DateTimeUtils.toEpochNanosString(null);
+    assertNull(nanos);
+    Timestamp timestamp = DateTimeUtils.toTimestamp((String) null);
+    assertNull(timestamp);
   }
 
   @Test
@@ -46,5 +64,13 @@ public class DateTimeUtilsTest {
     timestamp.setNanos(141362049);
     String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
     assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNull() {
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(null);
+    assertNull(isoDateTime);
+    Timestamp timestamp = DateTimeUtils.toTimestampFromIsoDateTime(null);
+    assertNull(timestamp);
   }
 }


### PR DESCRIPTION
## Problem
For timestamp columns that are optional, the values appear as `null`. When the `timestamp.granularity` config is selected to be `nanos_long` or `nanos_string` or `nanos_iso_datetime_string` this is currently not handled properly and results in NPE

## Solution
This is now handled by the connector 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
