### PR TITLE
Improve the iso date time format to have better nanos precision

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -199,7 +199,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "built-in representations \n"
           + "  * nanos_long: represents timestamp values as nanos since epoch\n"
           + "  * nanos_string: represents timestamp values as nanos since epoch in string\n"
-          + "  * nanos_iso_datetime_string: uses the iso format 'yyyy-MM-dd'T'HH:mm:ss.n'\n";
+          + "  * nanos_iso_datetime_string: uses iso format 'yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'\n";
   public static final String TIMESTAMP_GRANULARITY_DISPLAY = "Timestamp granularity for "
       + "timestamp columns";
   private static final EnumRecommender TIMESTAMP_GRANULARITY_RECOMMENDER =

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -34,7 +34,7 @@ public class DateTimeUtils {
   static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
   static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
   static final DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.n");
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
 
   private static final ThreadLocal<Map<TimeZone, Calendar>> TIMEZONE_CALENDARS =
       ThreadLocal.withInitial(HashMap::new);

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -63,6 +63,34 @@ public class DateTimeUtilsTest {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
     String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("141362049", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNanosLeading0s() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(1);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("000000001", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNanosTrailing0s() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(100);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("000000100", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNanos0s() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(0);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("000000000", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
     assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
   }
 


### PR DESCRIPTION
## Problem
The old iso date format `yyyy-MM-dd'T'HH:mm:ss.n` did not format nanos properly
```
jshell> DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.n");
jshell> var t= Timestamp.from(java.time.Instant.now())
t ==> 2022-01-26 11:43:39.669414
jshell> t.getNanos()
$10 ==> 669414000
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$11 ==> "2022-01-26T11:43:39.669414000"
jshell> t.setNanos(0)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$13 ==> "2022-01-26T11:43:39.0"
jshell> t.setNanos(001)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$15 ==> "2022-01-26T11:43:39.1"
```
The format stips the leading and trailing 0s making it result in a Timestamp with invalid precision

## Solution
Change the format to `yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS`
```
jshell> DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
jshell>  t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$20 ==> "2022-01-26T11:43:39.669414000"
jshell> t.setNanos(001)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$23 ==> "2022-01-26T11:43:39.000000001"
jshell> t.setNanos(0)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$25 ==> "2022-01-26T11:43:39.000000000"
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
