### PR TITLE
Improve the iso date time format to have better nanos precision

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1391,7 +1391,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       case Types.TIMESTAMP: {
         return rs -> {
           Timestamp timestamp = rs.getTimestamp(col, DateTimeUtils.getTimeZoneCalendar(timeZone));
-          return tsGranularity.fromTimestamp.apply(timestamp);
+          return tsGranularity.fromTimestamp.apply(timestamp, timeZone);
         };
       }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -199,7 +199,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "built-in representations \n"
           + "  * nanos_long: represents timestamp values as nanos since epoch\n"
           + "  * nanos_string: represents timestamp values as nanos since epoch in string\n"
-          + "  * nanos_iso_datetime_string: uses the iso format 'yyyy-MM-dd'T'HH:mm:ss.n'\n";
+          + "  * nanos_iso_datetime_string: uses iso format 'yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'\n";
   public static final String TIMESTAMP_GRANULARITY_DISPLAY = "Timestamp granularity for "
       + "timestamp columns";
   private static final EnumRecommender TIMESTAMP_GRANULARITY_RECOMMENDER =

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -32,6 +32,7 @@ import io.confluent.connect.jdbc.util.EnumRecommender;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TimeZoneValidator;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -820,16 +821,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     CONNECT_LOGICAL(optional -> optional
         ? org.apache.kafka.connect.data.Timestamp.builder().optional().build()
         : org.apache.kafka.connect.data.Timestamp.builder().build(),
-        timestamp -> timestamp,
-        timestamp -> (Timestamp) timestamp),
+        (timestamp, tz) -> timestamp,
+        (timestamp, tz) -> (Timestamp) timestamp),
 
     NANOS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
-        DateTimeUtils::toEpochNanos,
-        epochNanos -> DateTimeUtils.toTimestamp((Long) epochNanos)),
+        (timestamp, tz) -> DateTimeUtils.toEpochNanos(timestamp),
+        (epochNanos, tz) -> DateTimeUtils.toTimestamp((Long) epochNanos)),
 
     NANOS_STRING(optional -> optional ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA,
-        DateTimeUtils::toEpochNanosString,
-        epochNanosString -> {
+        (timestamp, tz) -> DateTimeUtils.toEpochNanosString(timestamp),
+        (epochNanosString, tz) -> {
           try {
             return DateTimeUtils.toTimestamp((String) epochNanosString);
           } catch (NumberFormatException  e) {
@@ -843,11 +844,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     NANOS_ISO_DATETIME_STRING(optional -> optional
         ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA,
         DateTimeUtils::toIsoDateTimeString,
-        isoDateTimeString -> DateTimeUtils.toTimestampFromIsoDateTime((String) isoDateTimeString));
+        (isoDateTimeString, tz) ->
+            DateTimeUtils.toTimestampFromIsoDateTime((String) isoDateTimeString, tz));
 
     public final Function<Boolean, Schema> schemaFunction;
-    public final Function<Timestamp, Object> fromTimestamp;
-    public final Function<Object, Timestamp> toTimestamp;
+    public final BiFunction<Timestamp, TimeZone, Object> fromTimestamp;
+    public final BiFunction<Object, TimeZone, Timestamp> toTimestamp;
 
     public static final String DEFAULT = CONNECT_LOGICAL.name().toLowerCase(Locale.ROOT);
 
@@ -864,8 +866,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     }
 
     TimestampGranularity(Function<Boolean, Schema> schemaFunction,
-        Function<Timestamp, Object> fromTimestamp,
-        Function<Object, Timestamp> toTimestamp) {
+        BiFunction<Timestamp, TimeZone, Object> fromTimestamp,
+        BiFunction<Object, TimeZone, Timestamp> toTimestamp) {
       this.schemaFunction = schemaFunction;
       this.fromTimestamp = fromTimestamp;
       this.toTimestamp = toTimestamp;

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -230,7 +230,7 @@ public class TimestampIncrementingCriteria {
   ) {
     caseAdjustedTimestampColumns.computeIfAbsent(schema, this::findCaseSensitiveTimestampColumns);
     for (String timestampColumn : caseAdjustedTimestampColumns.get(schema)) {
-      Timestamp ts = timestampGranularity.toTimestamp.apply(record.get(timestampColumn));
+      Timestamp ts = timestampGranularity.toTimestamp.apply(record.get(timestampColumn), timeZone);
       if (ts != null) {
         return ts;
       }

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -34,7 +34,7 @@ public class DateTimeUtils {
   static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
   static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
   static final DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.n");
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
 
   private static final ThreadLocal<Map<TimeZone, Calendar>> TIMEZONE_CALENDARS =
       ThreadLocal.withInitial(HashMap::new);

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -221,8 +221,8 @@ public class TimestampIncrementingCriteriaTest {
         .field(TS2_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
         .build();
     record = new Struct(schema)
-        .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS1))
-        .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2));
+        .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS1, utcTimeZone))
+        .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2, utcTimeZone));
     assertExtractedOffset(-1, TS1, schema, record,
         TimestampGranularity.NANOS_ISO_DATETIME_STRING);
   }
@@ -273,8 +273,8 @@ public class TimestampIncrementingCriteriaTest {
         .field(TS2_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
         .build();
     record = new Struct(schema)
-        .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS1))
-        .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2));
+        .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS1, utcTimeZone))
+        .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2, utcTimeZone));
     assertExtractedOffset(-1, TS1, schema, record,
         TimestampGranularity.NANOS_STRING);
   }

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -20,11 +20,15 @@ import org.junit.Test;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class DateTimeUtilsTest {
+
+  private TimeZone utcTimeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
 
   @Test
   public void testTimestampToNanosLong() {
@@ -62,43 +66,43 @@ public class DateTimeUtilsTest {
   public void testTimestampToIsoDateTime() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
-    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp, utcTimeZone);
     assertEquals("141362049", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
-    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime, utcTimeZone));
   }
 
   @Test
   public void testTimestampToIsoDateTimeNanosLeading0s() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(1);
-    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp, utcTimeZone);
     assertEquals("000000001", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
-    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime, utcTimeZone));
   }
 
   @Test
   public void testTimestampToIsoDateTimeNanosTrailing0s() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(100);
-    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp, utcTimeZone);
     assertEquals("000000100", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
-    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime, utcTimeZone));
   }
 
   @Test
   public void testTimestampToIsoDateTimeNanos0s() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(0);
-    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp, utcTimeZone);
     assertEquals("000000000", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
-    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime, utcTimeZone));
   }
 
   @Test
   public void testTimestampToIsoDateTimeNull() {
-    String isoDateTime = DateTimeUtils.toIsoDateTimeString(null);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(null, utcTimeZone);
     assertNull(isoDateTime);
-    Timestamp timestamp = DateTimeUtils.toTimestampFromIsoDateTime(null);
+    Timestamp timestamp = DateTimeUtils.toTimestampFromIsoDateTime(null, utcTimeZone);
     assertNull(timestamp);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -63,6 +63,34 @@ public class DateTimeUtilsTest {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
     String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("141362049", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNanosLeading0s() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(1);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("000000001", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNanosTrailing0s() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(100);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("000000100", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
+    assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
+  }
+
+  @Test
+  public void testTimestampToIsoDateTimeNanos0s() {
+    Timestamp timestamp = Timestamp.from(Instant.now());
+    timestamp.setNanos(0);
+    String isoDateTime = DateTimeUtils.toIsoDateTimeString(timestamp);
+    assertEquals("000000000", isoDateTime.substring(isoDateTime.lastIndexOf('.') + 1));
     assertEquals(timestamp, DateTimeUtils.toTimestampFromIsoDateTime(isoDateTime));
   }
 


### PR DESCRIPTION
## Problem
The old iso date format `yyyy-MM-dd'T'HH:mm:ss.n` did not format nanos properly
```
jshell> DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.n");
jshell> var t= Timestamp.from(java.time.Instant.now())
t ==> 2022-01-26 11:43:39.669414
jshell> t.getNanos()
$10 ==> 669414000
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$11 ==> "2022-01-26T11:43:39.669414000"
jshell> t.setNanos(0)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$13 ==> "2022-01-26T11:43:39.0"
jshell> t.setNanos(001)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$15 ==> "2022-01-26T11:43:39.1"
```
The format stips the leading and trailing 0s making it result in a Timestamp with invalid precision

## Solution
Change the format to `yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS`
```
jshell> DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
jshell>  t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$20 ==> "2022-01-26T11:43:39.669414000"
jshell> t.setNanos(001)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$23 ==> "2022-01-26T11:43:39.000000001"
jshell> t.setNanos(0)
jshell> t.toLocalDateTime().format(ISO_DATE_TIME_NANOS_FORMAT);
$25 ==> "2022-01-26T11:43:39.000000000"
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
