### PR TITLE
CCDB-4586: Request to add a `Prefix` or a `Snapshot` mode for JDBC Source Connector to execute the query in snapshot mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>${mssqlserver.jdbc.driver.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc;
 
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
@@ -133,6 +134,15 @@ public class JdbcSourceConnector extends SourceConnector {
   @Override
   public Class<? extends Task> taskClass() {
     return JdbcSourceTask.class;
+  }
+
+  @Override
+  public Config validate(Map<String, String> connectorConfigs) {
+    Config config = super.validate(connectorConfigs);
+    JdbcSourceConnectorConfig jdbcSourceConnectorConfig
+            = new JdbcSourceConnectorConfig(connectorConfigs);
+    jdbcSourceConnectorConfig.validateMultiConfigs(config);
+    return config;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -202,6 +202,18 @@ public interface DatabaseDialect extends ConnectionProvider {
    */
   boolean tableExists(Connection connection, TableId tableId) throws SQLException;
 
+
+  /**
+   * Set the isolation mode for the connection.
+   * Isolation modes can differ by database so this provides an interface for
+   * the mode to be overridden.
+   *
+   * @param connection the database connection; may not be null
+   * @param configValue
+   * @throws SQLException if there's an error setting the isolation mode
+   */
+  void setConnectionIsolationMode(Connection connection, String configValue);
+
   /**
    * Create the definition for the columns described by the database metadata using the current
    * schema and catalog patterns defined in the configuration.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -32,6 +32,7 @@ import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TransactionIsolationMode;
 import io.confluent.connect.jdbc.source.TimestampIncrementingCriteria;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.ColumnId;
@@ -209,10 +210,13 @@ public interface DatabaseDialect extends ConnectionProvider {
    * the mode to be overridden.
    *
    * @param connection the database connection; may not be null
-   * @param configValue
+   * @param transactionIsolationMode the transaction isolation config
    * @throws SQLException if there's an error setting the isolation mode
    */
-  void setConnectionIsolationMode(Connection connection, String configValue);
+  void setConnectionIsolationMode(
+          Connection connection,
+          TransactionIsolationMode transactionIsolationMode
+  );
 
   /**
    * Create the definition for the columns described by the database metadata using the current

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -633,23 +633,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  protected static int mapToAnsiSqlTransactionIsolationMode(
-          JdbcSourceConnectorConfig.TransactionIsolationMode isolationMode
-  ) {
-    switch (isolationMode) {
-      case READ_UNCOMMITTED:
-        return Connection.TRANSACTION_READ_UNCOMMITTED;
-      case READ_COMMITTED:
-        return Connection.TRANSACTION_READ_COMMITTED;
-      case REPEATABLE_READ:
-        return Connection.TRANSACTION_REPEATABLE_READ;
-      case SERIALIZABLE:
-        return Connection.TRANSACTION_SERIALIZABLE;
-      default:
-        return -1;
-    }
-  }
-
   protected String displayableTableTypes(String[] types, String delim) {
     return Arrays.stream(types).sorted().collect(Collectors.joining(delim));
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -606,16 +606,18 @@ public class GenericDatabaseDialect implements DatabaseDialect {
           Connection connection,
           TransactionIsolationMode transactionIsolationMode
   ) {
-    int isolationMode =
-            mapToAnsiSqlTransactionIsolationMode(
-                    transactionIsolationMode
-            );
-    if (isolationMode == -1) {
-      // not an ANSI-SQL isolation mode.
-      log.warn("Unable to set transaction.isolation.mode: "
-              +  transactionIsolationMode.name()
-              +  ". This mode is not supported by the database."
-              + "No transaction isolation mode will be set for the queries");
+    if (transactionIsolationMode
+            == TransactionIsolationMode.DEFAULT) {
+      return;
+    }
+    int isolationMode = TransactionIsolationMode.get(
+            transactionIsolationMode
+    );
+    if (transactionIsolationMode
+            == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION
+            && !name().equals(SqlServerDatabaseDialect.class.getSimpleName())) {
+      log.warn("Unable to set transaction.isolation.mode: " +  transactionIsolationMode.name()
+              +  ". This is only valid for a Connector with Sql Server dialect. ");
       return;
     }
     try {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -613,13 +613,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     int isolationMode = TransactionIsolationMode.get(
             transactionIsolationMode
     );
-    if (transactionIsolationMode
-            == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION
-            && !name().equals(SqlServerDatabaseDialect.class.getSimpleName())) {
-      log.warn("Unable to set transaction.isolation.mode: " +  transactionIsolationMode.name()
-              +  ". This is only valid for a Connector with Sql Server dialect. ");
-      return;
-    }
     try {
       DatabaseMetaData metadata = connection.getMetaData();
       if (metadata.supportsTransactionIsolationLevel(isolationMode)) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -622,20 +622,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       if (metadata.supportsTransactionIsolationLevel(isolationMode)) {
         connection.setTransactionIsolation(isolationMode);
       } else {
-        log.warn("Unable to set transaction.isolation.mode: "
-                +  configValue
-                +  ". This mode is not supported by the database."
-                + "No transaction isolation mode will be set for the queries");
+        throw new ConfigException("Transaction Isolation level not supported by database");
       }
-    }  catch (IllegalArgumentException ex) {
-      log.warn("Unable to read transaction.isolation.mode. No transaction isolation mode will be set for the queries");
-    } catch (SQLException ex) {
+    } catch (SQLException | ConfigException ex) {
       log.warn("Unable to set transaction.isolation.mode: " +  configValue
-              +  ". No transaction isolation mode will be set for the queries");
+              +  ". No transaction isolation mode will be set for the queries: " + ex.getMessage());
     }
   }
 
-  private static int mapToAnsiSqlTransactionIsolationMode(
+  protected static int mapToAnsiSqlTransactionIsolationMode(
           JdbcSourceConnectorConfig.TransactionIsolationMode isolationMode
   ) {
     switch (isolationMode) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -18,7 +18,6 @@ package io.confluent.connect.jdbc.dialect;
 import java.time.ZoneOffset;
 import java.util.TimeZone;
 
-import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
@@ -79,6 +78,7 @@ import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.NumericMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TimestampGranularity;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TransactionIsolationMode;
 import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
 import io.confluent.connect.jdbc.source.TimestampIncrementingCriteria;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
@@ -602,17 +602,18 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  public void setConnectionIsolationMode(Connection connection, String configValue) {
+  public void setConnectionIsolationMode(
+          Connection connection,
+          TransactionIsolationMode transactionIsolationMode
+  ) {
     int isolationMode =
             mapToAnsiSqlTransactionIsolationMode(
-                    JdbcSourceConnectorConfig.TransactionIsolationMode.valueOf(
-                            configValue
-                    )
+                    transactionIsolationMode
             );
     if (isolationMode == -1) {
       // not an ANSI-SQL isolation mode.
       log.warn("Unable to set transaction.isolation.mode: "
-              +  configValue
+              +  transactionIsolationMode.name()
               +  ". This mode is not supported by the database."
               + "No transaction isolation mode will be set for the queries");
       return;
@@ -625,7 +626,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         throw new ConfigException("Transaction Isolation level not supported by database");
       }
     } catch (SQLException | ConfigException ex) {
-      log.warn("Unable to set transaction.isolation.mode: " +  configValue
+      log.warn("Unable to set transaction.isolation.mode: " +  transactionIsolationMode.name()
               +  ". No transaction isolation mode will be set for the queries: " + ex.getMessage());
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -27,7 +27,12 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -423,10 +428,17 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
               connection.getMetaData();
 
       if (mappedValue == -1) {
-        if (isolationMode == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION) {
-          SQLServerConnection sqlServerConnection = (SQLServerConnection) connection;
-          if (metadata.supportsTransactionIsolationLevel(SQLServerConnection.TRANSACTION_SNAPSHOT)) {
-            sqlServerConnection.setTransactionIsolation(SQLServerConnection.TRANSACTION_SNAPSHOT);
+        if (isolationMode
+                == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION
+        ) {
+          SQLServerConnection sqlServerConnection
+                  = (SQLServerConnection) connection;
+          if (metadata
+                  .supportsTransactionIsolationLevel(SQLServerConnection.TRANSACTION_SNAPSHOT)
+          ) {
+            sqlServerConnection.setTransactionIsolation(
+                    SQLServerConnection.TRANSACTION_SNAPSHOT
+            );
           }
         } else {
           throw new ConfigException("Transaction Isolation level not supported by database");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -424,8 +424,10 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
 
       if (mappedValue == -1) {
         if (isolationMode == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION) {
-          Statement statement = connection.createStatement();
-          statement.execute("SET TRANSACTION ISOLATION LEVEL SNAPSHOT");
+          SQLServerConnection sqlServerConnection = (SQLServerConnection) connection;
+          if (metadata.supportsTransactionIsolationLevel(SQLServerConnection.TRANSACTION_SNAPSHOT)) {
+            sqlServerConnection.setTransactionIsolation(SQLServerConnection.TRANSACTION_SNAPSHOT);
+          }
         } else {
           throw new ConfigException("Transaction Isolation level not supported by database");
         }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -15,7 +15,10 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TransactionIsolationMode;
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -24,10 +27,7 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.sql.*;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -403,6 +403,45 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
       }
     }
     verifiedSqlServerTimestamp = true;
+  }
+
+  @Override
+  public void setConnectionIsolationMode(Connection connection, String configValue) {
+    TransactionIsolationMode isolationMode = TransactionIsolationMode.valueOf(
+                    configValue
+            );
+
+    int mappedValue = mapToAnsiSqlTransactionIsolationMode(
+                    isolationMode
+            );
+
+    try {
+      DatabaseMetaData metadata = connection.getMetaData();
+
+      if (mappedValue == -1) {
+        if (isolationMode == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION) {
+          SQLServerConnection sqlServerConnection = (SQLServerConnection) connection;
+          if (metadata.supportsTransactionIsolationLevel(SQLServerConnection.TRANSACTION_SNAPSHOT)) {
+            sqlServerConnection.setTransactionIsolation(SQLServerConnection.TRANSACTION_SNAPSHOT);
+          }
+        } else {
+          throw new ConfigException("Transaction Isolation level not supported by database");
+        }
+      } else {
+        // ANSI SQL transaction types.
+        if (metadata.supportsTransactionIsolationLevel(mappedValue)) {
+          connection.setTransactionIsolation(mappedValue);
+        } else {
+          throw new ConfigException("Transaction Isolation level not supported by database");
+        }
+      }
+    } catch (SQLException | ConfigException ex) {
+      log.warn("Unable to set transaction.isolation.mode: "
+              +  configValue
+              +  ". This mode is not supported by the database."
+              + "No transaction isolation mode will be set for the queries: "
+              + ex.getMessage());
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -343,7 +343,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   private static final String TRANSACTION_ISOLATION_MODE_DOC =
           "Mode to control which transaction isolation level is used when running queries "
                   + "against the database. By default no explicit transaction isolation"
-                  + "mode is set. SQL_SERVER_SNAPSHOT_ISOLATION_MODE will only work"
+                  + "mode is set. SQL_SERVER_SNAPSHOT will only work"
                   + "against a connector configured to write to Sql Server. "
                   + " Options include:\n"
                   + "  * DEFAULT\n "

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.sql.Connection;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 import io.confluent.connect.jdbc.util.EnumRecommender;
@@ -330,6 +332,23 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "  In most cases it only makes sense to have either TABLE or VIEW.";
   private static final String TABLE_TYPE_DISPLAY = "Table Types";
 
+  //TODO: no default
+  public static final String TRANSACTION_ISOLATION_MODE_DEFAULT = TransactionIsolationMode.READ_COMMITTED.name();
+  public static final String TRANSACTION_ISOLATION_MODE_CONFIG = "transaction.isolation.mode";
+  private static final String TRANSACTION_ISOLATION_MODE_DOC =
+          "Mode to control which transaction isolation level is used when running queries against the database. Options"
+                  + " include:\n"
+                  + "  * READ_UNCOMMITED\n"
+                  + "  * READ_COMMITED\n"
+                  + "  * REPEATABLE_READ\n"
+                  + "  * SERIALZABLE\n"
+                  + "  * SQL_SERVER_SNAPSHOT_ISOLATION_MODE\n"
+                  + "  fill me in.";
+  private static final String TRANSACTION_ISOLATION_MODE_DISPLAY = "Transaction Isolation Mode";
+
+  private static final EnumRecommender TRANSACTION_ISOLATION_MODE_RECOMMENDER =
+          EnumRecommender.in(TransactionIsolationMode.values());
+
   public static ConfigDef baseConfigDef() {
     ConfigDef config = new ConfigDef();
     addDatabaseOptions(config);
@@ -565,7 +584,18 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         MODE_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        QUERY_SUFFIX_DISPLAY);
+        QUERY_SUFFIX_DISPLAY)
+    .define(
+        TRANSACTION_ISOLATION_MODE_CONFIG,
+        Type.STRING,
+        TRANSACTION_ISOLATION_MODE_DEFAULT,
+        Importance.LOW,
+        TRANSACTION_ISOLATION_MODE_DOC,
+        MODE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TRANSACTION_ISOLATION_MODE_DISPLAY,
+        TRANSACTION_ISOLATION_MODE_RECOMMENDER);
   }
 
   private static final void addConnectorOptions(ConfigDef config) {
@@ -872,6 +902,9 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     }
   }
 
+  public enum TransactionIsolationMode {
+    READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT_ISOLATION
+  }
   protected JdbcSourceConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> props) {
     super(subclassConfigDef, props);
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import java.sql.Connection;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -27,7 +26,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 import io.confluent.connect.jdbc.util.EnumRecommender;
@@ -333,11 +331,13 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   private static final String TABLE_TYPE_DISPLAY = "Table Types";
 
   //TODO: no default
-  public static final String TRANSACTION_ISOLATION_MODE_DEFAULT = TransactionIsolationMode.READ_COMMITTED.name();
+  public static final String TRANSACTION_ISOLATION_MODE_DEFAULT =
+          TransactionIsolationMode.DEFAULT.name();
   public static final String TRANSACTION_ISOLATION_MODE_CONFIG = "transaction.isolation.mode";
   private static final String TRANSACTION_ISOLATION_MODE_DOC =
-          "Mode to control which transaction isolation level is used when running queries against the database. Options"
-                  + " include:\n"
+          "Mode to control which transaction isolation level is used when running queries"
+                  + " against the database. Options include:\n"
+                  + "  * DEFAULT\n "
                   + "  * READ_UNCOMMITED\n"
                   + "  * READ_COMMITED\n"
                   + "  * REPEATABLE_READ\n"
@@ -584,8 +584,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         MODE_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        QUERY_SUFFIX_DISPLAY)
-    .define(
+        QUERY_SUFFIX_DISPLAY
+    ).define(
         TRANSACTION_ISOLATION_MODE_CONFIG,
         Type.STRING,
         TRANSACTION_ISOLATION_MODE_DEFAULT,
@@ -595,7 +595,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         TRANSACTION_ISOLATION_MODE_DISPLAY,
-        TRANSACTION_ISOLATION_MODE_RECOMMENDER);
+        TRANSACTION_ISOLATION_MODE_RECOMMENDER
+    );
   }
 
   private static final void addConnectorOptions(ConfigDef config) {
@@ -903,8 +904,10 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   }
 
   public enum TransactionIsolationMode {
-    READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT_ISOLATION
+    DEFAULT, READ_UNCOMMITTED, READ_COMMITTED,
+    REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT_ISOLATION
   }
+
   protected JdbcSourceConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> props) {
     super(subclassConfigDef, props);
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.sql.Connection;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -907,8 +908,24 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public enum TransactionIsolationMode {
     DEFAULT, READ_UNCOMMITTED, READ_COMMITTED,
-    REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT_ISOLATION
+    REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT_ISOLATION;
+
+    public static int get(TransactionIsolationMode mode) {
+      switch (mode) {
+        case READ_UNCOMMITTED:
+          return Connection.TRANSACTION_READ_UNCOMMITTED;
+        case READ_COMMITTED:
+          return Connection.TRANSACTION_READ_COMMITTED;
+        case REPEATABLE_READ:
+          return Connection.TRANSACTION_REPEATABLE_READ;
+        case SERIALIZABLE:
+          return Connection.TRANSACTION_SERIALIZABLE;
+        default:
+          return -1;
+      }
+    }
   }
+
 
   protected JdbcSourceConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> props) {
     super(subclassConfigDef, props);

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -340,7 +340,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           TransactionIsolationMode.DEFAULT.name();
   public static final String TRANSACTION_ISOLATION_MODE_CONFIG = "transaction.isolation.mode";
   private static final String TRANSACTION_ISOLATION_MODE_DOC =
-          "Mode to control which transaction isolation level is used when running queries. "
+          "Mode to control which transaction isolation level is used when running queries "
                   + "against the database. By default no explicit transaction isolation"
                   + "mode is set. SQL_SERVER_SNAPSHOT_ISOLATION_MODE will only work"
                   + "against a connector configured to write to Sql Server. "

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -330,20 +330,22 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "  In most cases it only makes sense to have either TABLE or VIEW.";
   private static final String TABLE_TYPE_DISPLAY = "Table Types";
 
-  //TODO: no default
   public static final String TRANSACTION_ISOLATION_MODE_DEFAULT =
           TransactionIsolationMode.DEFAULT.name();
   public static final String TRANSACTION_ISOLATION_MODE_CONFIG = "transaction.isolation.mode";
   private static final String TRANSACTION_ISOLATION_MODE_DOC =
-          "Mode to control which transaction isolation level is used when running queries"
-                  + " against the database. Options include:\n"
+          "Mode to control which transaction isolation level is used when running queries. "
+                  + "against the database. By default no explicit transaction isolation"
+                  + "mode is set. SQL_SERVER_SNAPSHOT_ISOLATION_MODE will only work"
+                  + "against a connector configured to write to Sql Server. "
+                  + "The Microsoft Sql Server driver is a requirement to use this feature. "
+                  + " Options include:\n"
                   + "  * DEFAULT\n "
                   + "  * READ_UNCOMMITED\n"
                   + "  * READ_COMMITED\n"
                   + "  * REPEATABLE_READ\n"
                   + "  * SERIALZABLE\n"
-                  + "  * SQL_SERVER_SNAPSHOT_ISOLATION_MODE\n"
-                  + "  fill me in.";
+                  + "  * SQL_SERVER_SNAPSHOT_ISOLATION_MODE\n";
   private static final String TRANSACTION_ISOLATION_MODE_DISPLAY = "Transaction Isolation Mode";
 
   private static final EnumRecommender TRANSACTION_ISOLATION_MODE_RECOMMENDER =

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -344,13 +344,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                   + "against the database. By default no explicit transaction isolation"
                   + "mode is set. SQL_SERVER_SNAPSHOT_ISOLATION_MODE will only work"
                   + "against a connector configured to write to Sql Server. "
-                  + "The Microsoft Sql Server driver is a requirement to use this feature. "
                   + " Options include:\n"
                   + "  * DEFAULT\n "
                   + "  * READ_UNCOMMITED\n"
                   + "  * READ_COMMITED\n"
                   + "  * REPEATABLE_READ\n"
-                  + "  * SERIALZABLE\n"
+                  + "  * SERIALIZABLE\n"
                   + "  * SQL_SERVER_SNAPSHOT_ISOLATION_MODE\n";
   private static final String TRANSACTION_ISOLATION_MODE_DISPLAY = "Transaction Isolation Mode";
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
@@ -350,7 +351,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                   + "  * READ_COMMITED\n"
                   + "  * REPEATABLE_READ\n"
                   + "  * SERIALIZABLE\n"
-                  + "  * SQL_SERVER_SNAPSHOT_ISOLATION_MODE\n";
+                  + "  * SQL_SERVER_SNAPSHOT\n";
   private static final String TRANSACTION_ISOLATION_MODE_DISPLAY = "Transaction Isolation Mode";
 
   private static final EnumRecommender TRANSACTION_ISOLATION_MODE_RECOMMENDER =
@@ -379,7 +380,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
             TransactionIsolationMode.valueOf(
                     this.getString(TRANSACTION_ISOLATION_MODE_CONFIG)
             );
-    if (transactionIsolationMode == TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION) {
+    if (transactionIsolationMode == TransactionIsolationMode.SQL_SERVER_SNAPSHOT) {
       DatabaseDialect dialect;
       final String dialectName = this.getString(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG);
       if (dialectName != null && !dialectName.trim().isEmpty()) {
@@ -396,7 +397,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         configValues
                 .get(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG)
                 .addErrorMessage("Isolation mode of `"
-                        + TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION.name()
+                        + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
                         + "` can only be configured with a Sql Server Dialect"
           );
       }
@@ -953,7 +954,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public enum TransactionIsolationMode {
     DEFAULT, READ_UNCOMMITTED, READ_COMMITTED,
-    REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT_ISOLATION;
+    REPEATABLE_READ, SERIALIZABLE, SQL_SERVER_SNAPSHOT;
 
     public static int get(TransactionIsolationMode mode) {
       switch (mode) {
@@ -965,6 +966,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           return Connection.TRANSACTION_REPEATABLE_READ;
         case SERIALIZABLE:
           return Connection.TRANSACTION_SERIALIZABLE;
+        case SQL_SERVER_SNAPSHOT:
+          return SQLServerConnection.TRANSACTION_SNAPSHOT;
         default:
           return -1;
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.sql.DatabaseMetaData;
 import java.sql.SQLNonTransientException;
 import java.util.TimeZone;
 import org.apache.kafka.common.config.ConfigException;
@@ -105,6 +106,11 @@ public class JdbcSourceTask extends SourceTask {
     log.info("Using JDBC dialect {}", dialect.name());
 
     cachedConnectionProvider = connectionProvider(maxConnAttempts, retryBackoff);
+
+    String isolationModeString = config.getString(
+            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+    );
+    dialect.setConnectionIsolationMode(cachedConnectionProvider.getConnection(), isolationModeString);
 
     List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -107,18 +107,17 @@ public class JdbcSourceTask extends SourceTask {
 
     cachedConnectionProvider = connectionProvider(maxConnAttempts, retryBackoff);
 
-    TransactionIsolationMode isolationMode = TransactionIsolationMode
-            .valueOf(
-                    config.getString(
-                            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+
+    dialect.setConnectionIsolationMode(
+            cachedConnectionProvider.getConnection(),
+            TransactionIsolationMode
+                    .valueOf(
+                            config.getString(
+                                    JdbcSourceConnectorConfig
+                                            .TRANSACTION_ISOLATION_MODE_CONFIG
+                            )
                     )
-            );
-    if (isolationMode != TransactionIsolationMode.DEFAULT) {
-      dialect.setConnectionIsolationMode(
-              cachedConnectionProvider.getConnection(),
-              isolationMode
-      );
-    }
+    );
 
     List<String> tables = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.jdbc;
 
-import io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.ConnectorContext;
@@ -50,7 +49,10 @@ import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JdbcSourceConnector.class, DatabaseDialect.class})

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -259,7 +259,7 @@ public class JdbcSourceConnectorTest {
   @Test
   public void testSqlServerIsolationModeWithCorrectDialect() {
 
-    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT");
     props.put(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG, "SqlServerDatabaseDialect");
 
     Config config = connector.validate(props);
@@ -280,7 +280,7 @@ public class JdbcSourceConnectorTest {
 
   @Test
   public void testSqlServerIsolationModeIncorrectDialect() {
-    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT");
     props.put(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG, "MySqlDatabaseDialect");
 
     Config config = connector.validate(props);
@@ -298,7 +298,7 @@ public class JdbcSourceConnectorTest {
     assertFalse(errors.isEmpty());
     assertEquals(1, errors.size());
     assertTrue(errors.get(0).contains(
-            "Isolation mode of `SQL_SERVER_SNAPSHOT_ISOLATION` can only be"
+            "Isolation mode of `SQL_SERVER_SNAPSHOT` can only be"
                     + " configured with a Sql Server Dialect")
     );
   }
@@ -311,7 +311,7 @@ public class JdbcSourceConnectorTest {
     sqlServerConnectionUrlTypes.add("jdbc:jtds:sqlserver://localhost;user=Me");
 
     for (String urlType : sqlServerConnectionUrlTypes) {
-      props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+      props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT");
       props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, urlType);
 
       Config config = connector.validate(props);
@@ -333,7 +333,7 @@ public class JdbcSourceConnectorTest {
 
   @Test
   public void testSqlServerIsolationModeWithIncorrectUrl() {
-    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT");
     props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:mysql://localhost:3306/sakila?profileSQL=true");
 
     Config config = connector.validate(props);
@@ -351,7 +351,7 @@ public class JdbcSourceConnectorTest {
     assertFalse(errors.isEmpty());
     assertEquals(1, errors.size());
     assertTrue(errors.get(0).contains(
-            "Isolation mode of `SQL_SERVER_SNAPSHOT_ISOLATION` can only be"
+            "Isolation mode of `SQL_SERVER_SNAPSHOT` can only be"
                     + " configured with a Sql Server Dialect")
     );
 

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -15,6 +15,9 @@
 
 package io.confluent.connect.jdbc;
 
+import io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
@@ -47,9 +50,7 @@ import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JdbcSourceConnector.class, DatabaseDialect.class})
@@ -58,7 +59,7 @@ public class JdbcSourceConnectorTest {
 
   private JdbcSourceConnector connector;
   private EmbeddedDerby db;
-  private Map<String, String> connProps;
+  private Map<String, String> props;
 
   public static class MockJdbcSourceConnector extends JdbcSourceConnector {
     CachedConnectionProvider provider;
@@ -84,10 +85,10 @@ public class JdbcSourceConnectorTest {
   public void setup() {
     connector = new JdbcSourceConnector();
     db = new EmbeddedDerby();
-    connProps = new HashMap<>();
-    connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
-    connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
-    connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
+    props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
   }
 
   @After
@@ -139,7 +140,7 @@ public class JdbcSourceConnectorTest {
 
     PowerMock.replayAll();
 
-    connector.start(connProps);
+    connector.start(props);
     connector.stop();
 
     PowerMock.verifyAll();
@@ -149,7 +150,7 @@ public class JdbcSourceConnectorTest {
   public void testNoTablesNoTasks() throws Exception {
     // Tests case where there are no readable tables and ensures that no tasks
     // are returned to be run
-    connector.start(connProps);
+    connector.start(props);
     List<Map<String, String>> configs = connector.taskConfigs(3);
     assertTrue(configs.isEmpty());
     connector.stop();
@@ -170,7 +171,7 @@ public class JdbcSourceConnectorTest {
     EasyMock.replay(connectorContext);
     connector.initialize(connectorContext);
 
-    connector.start(connProps);
+    connector.start(props);
     assertTrue(
         "Connector should have request task reconfiguration after reading tables from the database",
         taskReconfigurationLatch.await(10, TimeUnit.SECONDS)
@@ -201,7 +202,7 @@ public class JdbcSourceConnectorTest {
     EasyMock.replay(connectorContext);
     connector.initialize(connectorContext);
 
-    connector.start(connProps);
+    connector.start(props);
     assertTrue(
         "Connector should have request task reconfiguration after reading tables from the database",
         taskReconfigurationLatch.await(10, TimeUnit.SECONDS)
@@ -227,8 +228,8 @@ public class JdbcSourceConnectorTest {
     db.createTable("test1", "id", "INT NOT NULL");
     db.createTable("test2", "id", "INT NOT NULL");
     final String sample_query = "SELECT foo, bar FROM sample_table";
-    connProps.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
-    connector.start(connProps);
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
+    connector.start(props);
     List<Map<String, String>> configs = connector.taskConfigs(3);
     assertEquals(1, configs.size());
     assertTaskConfigsHaveParentConfigs(configs);
@@ -242,9 +243,9 @@ public class JdbcSourceConnectorTest {
   @Test(expected = ConnectException.class)
   public void testConflictingQueryTableSettings() {
     final String sample_query = "SELECT foo, bar FROM sample_table";
-    connProps.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
-    connProps.put(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, "foo,bar");
-    connector.start(connProps);
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
+    props.put(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, "foo,bar");
+    connector.start(props);
   }
 
   private void assertTaskConfigsHaveParentConfigs(List<Map<String, String>> configs) {
@@ -252,6 +253,109 @@ public class JdbcSourceConnectorTest {
       assertEquals(this.db.getUrl(),
                    config.get(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG));
     }
+  }
+
+
+  @Test
+  public void testSqlServerIsolationModeWithCorrectDialect() {
+
+    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+    props.put(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG, "SqlServerDatabaseDialect");
+
+    Config config = connector.validate(props);
+    HashMap<String, ConfigValue> configValues = new HashMap<>();
+    config.configValues().stream()
+            .filter((configValue) ->
+                    configValue.name().equals(
+                            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+                    )
+            ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
+
+    assertTrue(
+            configValues.get(
+                    JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+            ).errorMessages().isEmpty()
+    );
+  }
+
+  @Test
+  public void testSqlServerIsolationModeIncorrectDialect() {
+    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+    props.put(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG, "MySqlDatabaseDialect");
+
+    Config config = connector.validate(props);
+    HashMap<String, ConfigValue> configValues = new HashMap<>();
+    config.configValues().stream()
+            .filter((configValue) ->
+                    configValue.name().equals(
+                            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+                    )
+            ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
+
+    List<String> errors = configValues.get(
+            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+    ).errorMessages();
+    assertFalse(errors.isEmpty());
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains(
+            "Isolation mode of `SQL_SERVER_SNAPSHOT_ISOLATION` can only be"
+                    + " configured with a Sql Server Dialect")
+    );
+  }
+
+  @Test
+  public void testSqlServerIsolationModeWithCorrectUrl() {
+    List<String> sqlServerConnectionUrlTypes = new ArrayList<>();
+    sqlServerConnectionUrlTypes.add("jdbc:sqlserver://localhost;user=Me");
+    sqlServerConnectionUrlTypes.add("jdbc:microsoft:sqlserver://localhost;user=Me");
+    sqlServerConnectionUrlTypes.add("jdbc:jtds:sqlserver://localhost;user=Me");
+
+    for (String urlType : sqlServerConnectionUrlTypes) {
+      props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+      props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, urlType);
+
+      Config config = connector.validate(props);
+      HashMap<String, ConfigValue> configValues = new HashMap<>();
+      config.configValues().stream()
+              .filter((configValue) ->
+                      configValue.name().equals(
+                              JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+                      )
+              ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
+
+      assertTrue(
+              configValues.get(
+                      JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+              ).errorMessages().isEmpty()
+      );
+    }
+  }
+
+  @Test
+  public void testSqlServerIsolationModeWithIncorrectUrl() {
+    props.put(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG, "SQL_SERVER_SNAPSHOT_ISOLATION");
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:mysql://localhost:3306/sakila?profileSQL=true");
+
+    Config config = connector.validate(props);
+    HashMap<String, ConfigValue> configValues = new HashMap<>();
+    config.configValues().stream()
+            .filter((configValue) ->
+                    configValue.name().equals(
+                            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+                    )
+            ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
+
+    List<String> errors = configValues.get(
+            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+    ).errorMessages();
+    assertFalse(errors.isEmpty());
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains(
+            "Isolation mode of `SQL_SERVER_SNAPSHOT_ISOLATION` can only be"
+                    + " configured with a Sql Server Dialect")
+    );
+
+
   }
 
   private String tables(String... names) {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -559,7 +559,7 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
     // this transaction isolation mode is not supported. No error is expected.
     // Just a warning. Old isolation mode is maintained.
     dialect.setConnectionIsolationMode(conn,
-            JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION
+            JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT
     );
     // confirm transaction isolation mode does not change.
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_SERIALIZABLE);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -556,8 +556,8 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
     );
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_SERIALIZABLE);
 
-    // this transaction isolation mode is not supported
-    // confirm no error is thrown
+    // this transaction isolation mode is not supported. No error is expected.
+    // Just a warning. Old isolation mode is maintained.
     dialect.setConnectionIsolationMode(conn,
             JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION
     );

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -534,32 +534,32 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
     // READ_UNCOMMITTED
     dialect.setConnectionIsolationMode(conn,
-            JdbcSourceConnectorConfig.TransactionIsolationMode.READ_UNCOMMITTED.name()
+            JdbcSourceConnectorConfig.TransactionIsolationMode.READ_UNCOMMITTED
     );
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_READ_UNCOMMITTED);
 
     // READ_COMMITTED
     dialect.setConnectionIsolationMode(conn,
-            JdbcSourceConnectorConfig.TransactionIsolationMode.READ_COMMITTED.name()
+            JdbcSourceConnectorConfig.TransactionIsolationMode.READ_COMMITTED
     );
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_READ_COMMITTED);
 
     // REPEATABLE READ
     dialect.setConnectionIsolationMode(conn,
-            JdbcSourceConnectorConfig.TransactionIsolationMode.REPEATABLE_READ.name()
+            JdbcSourceConnectorConfig.TransactionIsolationMode.REPEATABLE_READ
     );
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_REPEATABLE_READ);
 
     // SERIALIZABLE
     dialect.setConnectionIsolationMode(conn,
-            JdbcSourceConnectorConfig.TransactionIsolationMode.SERIALIZABLE.name()
+            JdbcSourceConnectorConfig.TransactionIsolationMode.SERIALIZABLE
     );
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_SERIALIZABLE);
 
     // this transaction isolation mode is not supported
     // confirm no error is thrown
     dialect.setConnectionIsolationMode(conn,
-            JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION.name()
+            JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION
     );
     // confirm transaction isolation mode does not change.
     assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_SERIALIZABLE);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.jdbc.dialect;
 
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -524,6 +525,44 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
     verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.INT32_SCHEMA, "foo", false));
     verifyWriteColumnSpec("foo DUMMY NOT NULL", new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "foo", true));
     verifyWriteColumnSpec("foo DUMMY NULL", new SinkRecordField(Schema.OPTIONAL_INT32_SCHEMA, "foo", false));
+  }
+
+  @Test
+  public void setTransactionIsolationModes() throws SQLException {
+    GenericDatabaseDialect dialect = dummyDialect();
+    Connection conn = db.getConnection();
+
+    // READ_UNCOMMITTED
+    dialect.setConnectionIsolationMode(conn,
+            JdbcSourceConnectorConfig.TransactionIsolationMode.READ_UNCOMMITTED.name()
+    );
+    assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_READ_UNCOMMITTED);
+
+    // READ_COMMITTED
+    dialect.setConnectionIsolationMode(conn,
+            JdbcSourceConnectorConfig.TransactionIsolationMode.READ_COMMITTED.name()
+    );
+    assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_READ_COMMITTED);
+
+    // REPEATABLE READ
+    dialect.setConnectionIsolationMode(conn,
+            JdbcSourceConnectorConfig.TransactionIsolationMode.REPEATABLE_READ.name()
+    );
+    assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_REPEATABLE_READ);
+
+    // SERIALIZABLE
+    dialect.setConnectionIsolationMode(conn,
+            JdbcSourceConnectorConfig.TransactionIsolationMode.SERIALIZABLE.name()
+    );
+    assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_SERIALIZABLE);
+
+    // this transaction isolation mode is not supported
+    // confirm no error is thrown
+    dialect.setConnectionIsolationMode(conn,
+            JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT_ISOLATION.name()
+    );
+    // confirm transaction isolation mode does not change.
+    assertEquals(conn.getTransactionIsolation(), Connection.TRANSACTION_SERIALIZABLE);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -137,6 +137,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
+    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
     mockCachedConnectionProvider.close();
 
     PowerMock.expectLastCall();


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

## Problem
Customers want the ability to set transaction isolation for queries.  Ansi-sql supports `READ_UNCOMMITTED `, `READ_COMMITTED`, `REPEATABLE_READ`, `SERIALIZABLE`.  We want to set the infrastructure to support custom db specific isolation modes as well. For version 1, we're supporting `SQL_SERVER_SNAPSHOT_ISOLATION` for Sql Server as well.

## Solution
Provide a config to set an isolation mode. We implement the isolation mode setting in the dialect classes to allow specific dbs to override the generic implementation and set custom isolation modes.

Note that we still gate keep which isolation modes are supported by limiting the `TransactionIsolationMode` enum (internal to the config class). However we are able to expand on this model and set isolation modes for more dbs. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
