### PR TITLE
Spawn Tasks even when there's no tables that match the include/exclude list.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -154,7 +154,7 @@ public class JdbcSourceConnector extends SourceConnector {
                 + "the list of tables from the database yet"
         );
       } else if (currentTables.isEmpty()) {
-        taskConfigs = new ArrayList<>(1));
+        taskConfigs = new ArrayList<>(1);
         log.warn("No tables were found so there's no work to be done.");
         Map<String, String> taskProps = new HashMap<>(configProperties);
         taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, "[]");

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -154,8 +154,11 @@ public class JdbcSourceConnector extends SourceConnector {
                 + "the list of tables from the database yet"
         );
       } else if (currentTables.isEmpty()) {
-        taskConfigs = Collections.emptyList();
-        log.warn("No tasks will be run because no tables were found");
+        taskConfigs = new ArrayList<>(1));
+        log.warn("No tables were found so there's no work to be done.");
+        Map<String, String> taskProps = new HashMap<>(configProperties);
+        taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, "[]");
+        taskConfigs.add(taskProps);
       } else {
         int numGroups = Math.min(currentTables.size(), maxTasks);
         List<List<TableId>> tablesGrouped =

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -99,15 +99,14 @@ public class JdbcSourceTask extends SourceTask {
       throw new ConnectException("Task is being killed because"
               + " it was not assigned a table nor a query to execute."
               + " If run in table mode please make sure that the tables"
-              + " are exist on the database. If the table does exist on"
+              + " exist on the database. If the table does exist on"
               + " the database, we recommend using the fully qualified"
               + " table name.");
     }
 
     if ((!tables.isEmpty() && !query.isEmpty())) {
-      throw new ConnectException("Invalid configuration: each JdbcSourceTask"
-              + " must have at least one table assigned to it or"
-              + " one query specified");
+      throw new ConnectException("Invalid configuration: a JdbcSourceTask"
+              + " cannot have both a table and a query assigned to it");
     }
 
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -96,11 +96,18 @@ public class JdbcSourceTask extends SourceTask {
     String query = config.getString(JdbcSourceTaskConfig.QUERY_CONFIG);
 
     if ((tables.isEmpty() && query.isEmpty())) {
-      throw new ConnectException("Task is being killed because it was not assigned a table nor a query to execute."
-              + " If run in table mode please make sure that the tables are exist on the database.");
-    } if ((!tables.isEmpty() && !query.isEmpty())) {
-      throw new ConnectException("Invalid configuration: each JdbcSourceTask must have at "
-              + "least one table assigned to it or one query specified");
+      throw new ConnectException("Task is being killed because"
+              + " it was not assigned a table nor a query to execute."
+              + " If run in table mode please make sure that the tables"
+              + " are exist on the database. If the table does exist on"
+              + " the database, we recommend using the fully qualified"
+              + " table name.");
+    }
+
+    if ((!tables.isEmpty() && !query.isEmpty())) {
+      throw new ConnectException("Invalid configuration: each JdbcSourceTask"
+              + " must have at least one table assigned to it or"
+              + " one query specified");
     }
 
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -17,10 +17,12 @@ package io.confluent.connect.jdbc.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.sql.Timestamp;
-import java.time.Duration;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +41,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import io.confluent.connect.jdbc.util.DateTimeUtils;
@@ -868,6 +869,15 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     Map<String, String> props = new HashMap<>();
     props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "[]");
     props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, "");
+    task.start(props);
+  }
+
+  @Test (expected = ConnectException.class)
+  public void testTaskFailsIfBothQueryAndTablesConfigProvided() {
+    initializeTask();
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "[dbo.table]");
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, "Select * from some table");
     task.start(props);
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -17,10 +17,7 @@ package io.confluent.connect.jdbc.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -863,6 +860,15 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     verifyPoll(2, "id", Arrays.asList(3, 4), true, false, false, TOPIC_PREFIX);
 
     PowerMock.verifyAll();
+  }
+
+  @Test (expected = ConnectException.class)
+  public void testTaskFailsIfNoQueryOrTablesConfigProvided() {
+    initializeTask();
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "[]");
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, "");
+    task.start(props);
   }
 
   private void startTask(String timestampColumn, String incrementingColumn, String query) {


### PR DESCRIPTION
Signed-off-by: SajanaW <sweerawardhena@confluent.io>

## Problem
If there's no table found in the TableMonitorThread, we currently just don't spawn any tasks. While this is reasonable behavior, it makes debugging these issues a little bit harder since we see a connector running but no tasks. 

## Solution
We should aim to instead spawn tasks regardless of the table compatibility but immediately fail them to represent this misconfiguration.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
