### PR TITLE
CCDB-4632: fix a race condition in table monitoring thraed startup

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceConnector;
@@ -92,6 +93,8 @@ public class JdbcSourceConnector extends SourceConnector {
     cachedConnectionProvider.getConnection();
 
     long tablePollMs = config.getLong(JdbcSourceConnectorConfig.TABLE_POLL_INTERVAL_MS_CONFIG);
+    long tableStartupLimitMs =
+        config.getLong(JdbcSourceConnectorConfig.TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_CONFIG);
     List<String> whitelist = config.getList(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG);
     Set<String> whitelistSet = whitelist.isEmpty() ? null : new HashSet<>(whitelist);
     List<String> blacklist = config.getList(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
@@ -117,9 +120,11 @@ public class JdbcSourceConnector extends SourceConnector {
         dialect,
         cachedConnectionProvider,
         context,
+        tableStartupLimitMs,
         tablePollMs,
         whitelistSet,
-        blacklistSet
+        blacklistSet,
+        Time.SYSTEM
     );
     tableMonitorThread.start();
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -177,6 +177,14 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String TIMESTAMP_COLUMN_NAME_DEFAULT = "";
   private static final String TIMESTAMP_COLUMN_NAME_DISPLAY = "Timestamp Column Name";
 
+  public static final String TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_CONFIG =
+      "table.monitoring.startup.polling.limit.ms";
+  private static final String TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DOC =
+      "The amount of time to wait for the table monitoring thread to complete initial table read.";
+  public static final long TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DEFAULT = 10 * 1000;
+  private static final String TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DISPLAY =
+      "Table Monitoring Thread Startup Polling Limit (ms)";
+
   public static final String TABLE_POLL_INTERVAL_MS_CONFIG = "table.poll.interval.ms";
   private static final String TABLE_POLL_INTERVAL_MS_DOC =
       "Frequency in ms to poll for new or removed tables, which may result in updated task "
@@ -554,6 +562,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         BATCH_MAX_ROWS_DISPLAY
+    ).define(
+        TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_CONFIG,
+        Type.LONG,
+        TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DEFAULT,
+        Importance.LOW,
+        TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.SHORT,
+        TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DISPLAY
     ).define(
         TABLE_POLL_INTERVAL_MS_CONFIG,
         Type.LONG,


### PR DESCRIPTION
## Problem
In https://github.com/confluentinc/kafka-connect-jdbc/pull/1145 , `JdbcSourceConnector::taskConfigs` was made to be entirely non-blocking. This introduced a race condition between the table monitoring thread initialization and connector thread calling `JdbcSourceConnector::taskConfigs` . When the table monitoring thread is not yet done initializing, the call to `TableMonitoringThread::tables` will return null and cause `taskConfigs` to not generate any tasks. The expectation is that when the table monitoring thread is done with initialization, it will call `ConnectorContext::requestTaskReconfiguration` to request reconfiguration and trigger another call to `taskConfigs` .

While this works in the normal path, the reconfiguration is predicated on the connector being in [running](https://github.com/apache/kafka/blob/7795ca0fee650db181cd5e83c99d4cab15b8d37e/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java#L1455-L1458) state. In rare scenarios where the connector was paused before the table monitoring thread has finished its initial table read, the connector ends up in a state with a paused connector and no tasks. Since the connector was paused when the table monitoring thread finished initialization, the `reconfiguration` request was ignored. Furthermore, since the tables list has not changed, there will be no more attempts to reconfigure the connector to get it back to a good state on resume. The only way to get out of this state is to first resume the connector, then restart it.

## Solution
Re-introduce a small amount of blocking time to the `taskConfigs` request. This gives the table monitoring thread some time to finish the initial table load request. Introduce a new config parameter `table.monitoring.startup.polling.limit.ms` to control the maximum amount of time to wait on table monitoring thread initial read.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Existing unit test was updated. A new unit test was added.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Land in `5.3.x` and `pint merge` back to master.