### PR TITLE
CCDB-4692: [JDBC Connector] Demote logging containing query contents from DEBUG to TRACE

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -70,7 +70,7 @@ public class BulkTableQuerier extends TableQuerier {
     String queryStr = builder.toString();
 
     recordQuery(queryStr);
-    log.debug("{} prepared SQL query: {}", this, queryStr);
+    log.trace("{} prepared SQL query: {}", this, queryStr);
     stmt = dialect.createPreparedStatement(db, queryStr);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -148,7 +148,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
     
     String queryString = builder.toString();
     recordQuery(queryString);
-    log.debug("{} prepared SQL query: {}", this, queryString);
+    log.trace("{} prepared SQL query: {}", this, queryString);
     stmt = dialect.createPreparedStatement(db, queryString);
   }
 


### PR DESCRIPTION
Signed-off-by: Aakash Shah <ashah@confluent.io>

## Problem
RCCA-5813 discovered that there is DEBUG logging present in the JDBC connector that logs query contents.

## Solution
Demote the logging from DEBUG to TRACE.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backport to 10.0.x