### PR TITLE
[MINOR] Fix missing msssql driver in v10.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>${mssqlserver.jdbc.driver.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/kafka-connect-jdbc/pull/1169 moved the `mssql-jdbc` driver to the `provided` dependency from the `runtime` dependency. This led to the driver not being packaged in the connector package as it was in the older versions say `10.2.x`

## Solution
Add back the dependency as compile-time so that it's packaged:
```
❯ ls target/kafka-connect-jdbc-10.4.0-package/share/java/kafka-connect-jdbc
checker-qual-3.5.0.jar         kafka-connect-jdbc-10.4.0.jar  ojdbc8-production-19.7.0.0.pom orai18n-19.7.0.0.jar           postgresql-42.3.3.jar          sqlite-jdbc-3.25.2.jar         xmlparserv2-19.7.0.0.jar
common-utils-6.0.0.jar         mssql-jdbc-8.4.1.jre8.jar      ons-19.7.0.0.jar               osdt_cert-19.7.0.0.jar         simplefan-19.7.0.0.jar         ucp-19.7.0.0.jar
jtds-1.3.1.jar                 ojdbc8-19.7.0.0.jar            oraclepki-19.7.0.0.jar         osdt_core-19.7.0.0.jar         slf4j-api-1.7.30.jar           xdb-19.7.0.0.jar
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
