### PR TITLE
Add base Firebird dialect implementation

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/FirebirdDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/FirebirdDatabaseDialect.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.util.Collection;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.TableId;
+
+/**
+ * A {@link DatabaseDialect} for Firebird.
+ *
+ * @author <a href="mailto:vasiliy.yashkov@red-soft.ru">Vasiliy Yashkov</a>
+ */
+public class FirebirdDatabaseDialect extends GenericDatabaseDialect {
+
+  /**
+   * The provider for {@link FirebirdDatabaseDialect}.
+   */
+  public static class Provider extends DatabaseDialectProvider.SubprotocolBasedProvider {
+    public Provider() {
+      super(FirebirdDatabaseDialect.class.getSimpleName(), "firebird");
+    }
+
+    @Override
+    public DatabaseDialect create(AbstractConfig config) {
+      return new FirebirdDatabaseDialect(config);
+    }
+  }
+
+  /**
+   * Create a new dialect instance with the given connector configuration.
+   *
+   * @param config the connector configuration; may not be null
+   */
+  public FirebirdDatabaseDialect(AbstractConfig config) {
+    super(config, new IdentifierRules(".", "\"", "\""));
+  }
+
+  /**
+   * CURRENT_TIMESTAMP returns the current server date and time in the session time zone.
+   * The default is 3 decimals, i.e. milliseconds precision.
+   *
+   * @return the query string
+   */
+  @Override
+  protected String currentTimestampDatabaseQuery() {
+    return "SELECT CURRENT_TIMESTAMP FROM RDB$DATABASE";
+  }
+
+  @Override
+  protected String checkConnectionQuery() {
+    return "SELECT 1 FROM RDB$DATABASE";
+  }
+
+  @Override
+  protected String getSqlType(SinkRecordField field) {
+    if (field.schemaName() != null) {
+      switch (field.schemaName()) {
+        case Decimal.LOGICAL_NAME:
+          return "DECIMAL(18," + field.schemaParameters().get(Decimal.SCALE_FIELD) + ")";
+        case Date.LOGICAL_NAME:
+          return "DATE";
+        case Time.LOGICAL_NAME:
+          return "TIME";
+        case Timestamp.LOGICAL_NAME:
+          return "TIMESTAMP";
+        default:
+          // fall through to normal types
+      }
+    }
+    switch (field.schemaType()) {
+      case INT8:
+      case INT16:
+        return "SMALLINT";
+      case INT32:
+        return "INT";
+      case INT64:
+        return "BIGINT";
+      case FLOAT32:
+        return "FLOAT";
+      case FLOAT64:
+        return "DOUBLE PRECISION";
+      case BOOLEAN:
+        return "BOOLEAN";
+      case STRING:
+        return "BLOB SUB_TYPE TEXT";
+      case BYTES:
+        return "BLOB SUB_TYPE BINARY";
+      default:
+        return super.getSqlType(field);
+    }
+  }
+
+  @Override
+  public String buildUpsertQueryStatement(
+      final TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns
+  ) {
+    final ExpressionBuilder.Transform<ColumnId> transform = (builder, col) -> {
+      builder.append(table)
+          .append(".")
+          .appendColumnName(col.name())
+          .append("=SOURCE.")
+          .appendColumnName(col.name());
+    };
+
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("MERGE INTO ");
+    builder.append(table);
+    builder.append(" USING (SELECT ");
+    builder.appendList()
+        .delimitedBy(", ")
+        .transformedBy(ExpressionBuilder.columnNamesWithPrefix("? "))
+        .of(keyColumns, nonKeyColumns);
+    builder.append(" FROM RDB$DATABASE) SOURCE ON(");
+    builder.appendList()
+        .delimitedBy(" AND ")
+        .transformedBy(transform)
+        .of(keyColumns);
+    builder.append(")");
+    if (nonKeyColumns != null && !nonKeyColumns.isEmpty()) {
+      builder.append(" WHEN MATCHED THEN UPDATE SET ");
+      builder.appendList()
+          .delimitedBy(",")
+          .transformedBy(transform)
+          .of(nonKeyColumns);
+    }
+
+    builder.append(" WHEN NOT MATCHED THEN INSERT(");
+    builder.appendList()
+        .delimitedBy(",")
+        .of(nonKeyColumns, keyColumns);
+    builder.append(") VALUES(");
+    builder.appendList()
+        .delimitedBy(",")
+        .transformedBy(ExpressionBuilder.columnNamesWithPrefix("SOURCE."))
+        .of(nonKeyColumns, keyColumns);
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -1,6 +1,7 @@
 io.confluent.connect.jdbc.dialect.GenericDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.Db2DatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.DerbyDatabaseDialect$Provider
+io.confluent.connect.jdbc.dialect.FirebirdDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.OracleDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SqliteDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.PostgreSqlDatabaseDialect$Provider

--- a/src/test/java/io/confluent/connect/jdbc/dialect/FirebirdDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/FirebirdDatabaseDialectTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import org.junit.Test;
+
+import io.confluent.connect.jdbc.util.QuoteMethod;
+
+import static org.junit.Assert.assertEquals;
+
+public class FirebirdDatabaseDialectTest extends BaseDialectTest<FirebirdDatabaseDialect> {
+
+  @Override
+  protected FirebirdDatabaseDialect createDialect() {
+    return new FirebirdDatabaseDialect(sourceConfigWithUrl("jdbc:firebirdsql://server:port"));
+  }
+
+  @Test
+  public void createOneColNoPk() {
+    verifyCreateOneColNoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"col1\" INT NOT NULL)");
+  }
+
+  @Test
+  public void createOneColOnePk() {
+    verifyCreateOneColOnePk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INT NOT NULL," +
+            System.lineSeparator() + "PRIMARY KEY(\"pk1\"))");
+  }
+
+  @Test
+  public void createThreeColTwoPk() {
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INT NOT NULL," +
+            System.lineSeparator() + "\"pk2\" INT NOT NULL," + System.lineSeparator() +
+            "\"col1\" INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(\"pk1\",\"pk2\"))");
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 INT NOT NULL," +
+            System.lineSeparator() + "pk2 INT NOT NULL," + System.lineSeparator() +
+            "col1 INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
+  }
+
+  @Test
+  public void alterAddOneCol() {
+    verifyAlterAddOneCol("ALTER TABLE \"myTable\" ADD \"newcol1\" INT NULL");
+  }
+
+  @Test
+  public void alterAddTwoCol() {
+    verifyAlterAddTwoCols(
+        "ALTER TABLE \"myTable\" " + System.lineSeparator() + "ADD \"newcol1\" INT NULL," +
+            System.lineSeparator() + "ADD \"newcol2\" INT DEFAULT 42");
+  }
+
+  @Test
+  public void shouldBuildAlterTableStatement() {
+    assertStatements(
+        new String[]{
+            "ALTER TABLE \"myTable\" \n"
+                + "ADD \"c1\" INT NOT NULL,\n"
+                + "ADD \"c2\" BIGINT NOT NULL,\n"
+                + "ADD \"c3\" BLOB SUB_TYPE TEXT NOT NULL,\n"
+                + "ADD \"c4\" BLOB SUB_TYPE TEXT NULL,\n"
+                + "ADD \"c5\" DATE DEFAULT '2001-03-15',\n"
+                + "ADD \"c6\" TIME DEFAULT '00:00:00.000',\n"
+                + "ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+                + "ADD \"c8\" DECIMAL(18,4) NULL,\n"
+                + "ADD \"c9\" BOOLEAN DEFAULT 1"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+        new String[]{
+            "ALTER TABLE myTable \n"
+                + "ADD c1 INT NOT NULL,\n"
+                + "ADD c2 BIGINT NOT NULL,\n"
+                + "ADD c3 BLOB SUB_TYPE TEXT NOT NULL,\n"
+                + "ADD c4 BLOB SUB_TYPE TEXT NULL,\n"
+                + "ADD c5 DATE DEFAULT '2001-03-15',\n"
+                + "ADD c6 TIME DEFAULT '00:00:00.000',\n"
+                + "ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+                + "ADD c8 DECIMAL(18,4) NULL,\n"
+                + "ADD c9 BOOLEAN DEFAULT 1"
+        },
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+  }
+
+  @Test
+  public void shouldBuildUpsertStatement() {
+    String expected = "MERGE INTO \"myTable\" USING (SELECT ? \"id1\", ? \"id2\", ? \"columnA\", " +
+        "? \"columnB\", ? \"columnC\", ? \"columnD\" FROM RDB$DATABASE) SOURCE ON" +
+        "(\"myTable\".\"id1\"=SOURCE.\"id1\" AND \"myTable\".\"id2\"=SOURCE" +
+        ".\"id2\") WHEN MATCHED THEN UPDATE SET \"myTable\".\"columnA\"=SOURCE" +
+        ".\"columnA\",\"myTable\".\"columnB\"=SOURCE.\"columnB\",\"myTable\"" +
+        ".\"columnC\"=SOURCE.\"columnC\",\"myTable\".\"columnD\"=SOURCE" +
+        ".\"columnD\" WHEN NOT MATCHED THEN INSERT(\"myTable\".\"columnA\"," +
+        "\"myTable\".\"columnB\",\"myTable\".\"columnC\",\"myTable\".\"columnD\"," +
+        "\"myTable\".\"id1\",\"myTable\".\"id2\") VALUES(SOURCE.\"columnA\"," +
+        "SOURCE.\"columnB\",SOURCE.\"columnC\",SOURCE.\"columnD\",SOURCE" +
+        ".\"id1\",SOURCE.\"id2\")";
+    String sql = dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD);
+    assertEquals(expected, sql);
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithoutCredentialsInProperties() {
+    assertSanitizedUrl(
+        "jdbc:firebirdsql://localhost:3050/employee",
+        "jdbc:firebirdsql://localhost:3050/employee"
+    );
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithCredentialsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:firebirdsql://localhost/employee?user=SYSDBA&password=masterkey&authPlugins=Legacy_Auth,Srp512",
+        "jdbc:firebirdsql://localhost/employee?user=SYSDBA&password=****&authPlugins=Legacy_Auth,Srp512"
+    );
+
+  }
+}


### PR DESCRIPTION
## Problem
The current implementation of the `kafka-connect-jdbc` does not support the `Firebird`. It does not allow to use some features, i.e. `upsert`. In addition, the base dialect does not take into account the mapping between `Firebird` data types and `Kafka` schema types.

## Solution
Creating a dialect for `Firebird` that implements and overrides basic features of the generic database dialect.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no


## Test Strategy


<!--- Mark x in the box for all that apply. -->
Several unit tests have been added to test the `Firebird` dialect. Manual testing was done with docker-compose, which was running `kafka`, `connect-jdbc` and the `Firebird` server. Testing was performed on `Firebird 4.0.1` and `Jaybird 4.0.5 for Java 11 / JDBC 4.3`.
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

