### PR TITLE
CCDB-4777: Change JDBC auto.create for STRING types from CLOB to VARC…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -200,7 +200,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
       case BOOLEAN:
         return "NUMBER(1,0)";
       case STRING:
-        return "CLOB";
+        return "VARCHAR2(4000)";
       case BYTES:
         return "BLOB";
       default:

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -79,7 +79,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     assertPrimitiveMapping(Type.FLOAT64, "BINARY_DOUBLE");
     assertPrimitiveMapping(Type.BOOLEAN, "NUMBER(1,0)");
     assertPrimitiveMapping(Type.BYTES, "BLOB");
-    assertPrimitiveMapping(Type.STRING, "CLOB");
+    assertPrimitiveMapping(Type.STRING, "VARCHAR2(4000)");
   }
 
   @Test
@@ -99,7 +99,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     verifyDataTypeMapping("BINARY_FLOAT", Schema.FLOAT32_SCHEMA);
     verifyDataTypeMapping("BINARY_DOUBLE", Schema.FLOAT64_SCHEMA);
     verifyDataTypeMapping("NUMBER(1,0)", Schema.BOOLEAN_SCHEMA);
-    verifyDataTypeMapping("CLOB", Schema.STRING_SCHEMA);
+    verifyDataTypeMapping("VARCHAR2(4000)", Schema.STRING_SCHEMA);
     verifyDataTypeMapping("BLOB", Schema.BYTES_SCHEMA);
     verifyDataTypeMapping("NUMBER(*,0)", Decimal.schema(0));
     verifyDataTypeMapping("NUMBER(*,42)", Decimal.schema(42));
@@ -126,8 +126,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Test
   public void shouldBuildCreateQueryStatement() {
     String expected = "CREATE TABLE \"myTable\" (\n" + "\"c1\" NUMBER(10,0) NOT NULL,\n" +
-                      "\"c2\" NUMBER(19,0) NOT NULL,\n" + "\"c3\" CLOB NOT NULL,\n" +
-                      "\"c4\" CLOB NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
+                      "\"c2\" NUMBER(19,0) NOT NULL,\n" + "\"c3\" VARCHAR2(4000) NOT NULL,\n" +
+                      "\"c4\" VARCHAR2(4000) NULL,\n" + "\"c5\" DATE DEFAULT '2001-03-15',\n" +
                       "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
                       "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
                       "\"c8\" NUMBER(*,4) NULL,\n" +
@@ -144,8 +144,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
             "ALTER TABLE \"myTable\" ADD(\n" +
             "\"c1\" NUMBER(10,0) NOT NULL,\n" +
             "\"c2\" NUMBER(19,0) NOT NULL,\n" +
-            "\"c3\" CLOB NOT NULL,\n" +
-            "\"c4\" CLOB NULL,\n" +
+            "\"c3\" VARCHAR2(4000) NOT NULL,\n" +
+            "\"c4\" VARCHAR2(4000) NULL,\n" +
             "\"c5\" DATE DEFAULT '2001-03-15',\n" +
             "\"c6\" DATE DEFAULT '00:00:00.000',\n" +
             "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +
@@ -163,8 +163,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
             "ALTER TABLE myTable ADD(\n" +
             "c1 NUMBER(10,0) NOT NULL,\n" +
             "c2 NUMBER(19,0) NOT NULL,\n" +
-            "c3 CLOB NOT NULL,\n" +
-            "c4 CLOB NULL,\n" +
+            "c3 VARCHAR2(4000) NOT NULL,\n" +
+            "c4 VARCHAR2(4000) NULL,\n" +
             "c5 DATE DEFAULT '2001-03-15',\n" +
             "c6 DATE DEFAULT '00:00:00.000',\n" +
             "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n" +


### PR DESCRIPTION
…HAR.

## Problem
For Oracle JDBC Connector, String fields were getting mapped to CLOB. This was causing performance degradation.

## Solution
For OracleDialect of JDBC Connector, mapping String fields to VARCHAR2(4000). If this cannot handle some specific/corner case, then the workaround is that end user has to upfront create the table/column manually with the needed data type.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x ] no

##### If yes, where?

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x ] Unit tests
- [x ] Integration tests
- [ ] System tests
- [x ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
