### PR TITLE
CCDB-4777: Fixing POM as maven release:branch command failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
     <packaging>jar</packaging>
-    <version>10.5.0-SNAPSHOT</version>
+    <version>10.6.0-SNAPSHOT</version>
     <name>kafka-connect-jdbc</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -49,7 +49,7 @@
         <connection>scm:git:git://github.com/confluentinc/kafka-connect-jdbc.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-jdbc.git</developerConnection>
         <url>https://github.com/confluentinc/kafka-connect-jdbc</url>
-        <tag>10.5.x</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
## Problem

The maven release:branch command ran partially i.e. created the 1.5.x branch but did not update the POM.

## Solution
Making the POM changes manually.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
