### PR TITLE
Allow close() on CachedConnectionProvider while attempting to connect…

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -37,6 +37,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
 
   private int count = 0;
   private Connection connection;
+  private volatile boolean isRunning = true;
 
   public CachedConnectionProvider(
       ConnectionProvider provider
@@ -87,7 +88,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
 
   private void newConnection() throws SQLException {
     int attempts = 0;
-    while (attempts < maxConnectionAttempts) {
+    while (isRunning) {
       try {
         ++count;
         log.info("Attempting to open connection #{} to {}", count, provider);
@@ -96,7 +97,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
         return;
       } catch (SQLException sqle) {
         attempts++;
-        if (attempts < maxConnectionAttempts) {
+        if (isRunning && attempts < maxConnectionAttempts) {
           log.info("Unable to connect to database on attempt {}/{}. Will retry in {} ms.", attempts,
                    maxConnectionAttempts, connectionRetryBackoff, sqle
           );
@@ -113,7 +114,12 @@ public class CachedConnectionProvider implements ConnectionProvider {
   }
 
   @Override
-  public synchronized void close() {
+  public void close() {
+    isRunning = false;
+    closeConnection();
+  }
+
+  private synchronized void closeConnection() {
     if (connection != null) {
       try {
         log.info("Closing connection #{} to {}", count, provider);

--- a/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
@@ -27,6 +27,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -70,6 +73,44 @@ public class CachedConnectionProviderTest {
     assertNotNull(connectionProvider.getConnection());
 
     PowerMock.verifyAll();
+  }
+
+  @Test
+  public void retryTillClose() throws SQLException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    ConnectionProvider connectionProvider = new CachedConnectionProvider(
+            new ConnectionProvider() {
+                @Override
+                public Connection getConnection() throws SQLException {
+                    latch.countDown();
+                    throw new SQLException("test");
+                }
+
+                @Override
+                public boolean isConnectionValid(Connection connection, int timeout) throws SQLException {
+                    return false;
+                }
+
+                @Override
+                public void close() {
+                }
+            }, Integer.MAX_VALUE, 100L);
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    executorService.execute(() -> {
+        try {
+            latch.await();
+            connectionProvider.close();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    });
+
+    try {
+        connectionProvider.getConnection();
+    } catch (ConnectException ce) {
+        assertNotNull(ce);
+    }
   }
 
 }


### PR DESCRIPTION
… (#1205)

## Problem

While CacheConenctionProvider is trying to get a connection, it is impossible to stop.

## Solution

Add a flag to not go on with connection attempt when a close request has been issued.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
