### PR TITLE
Add Redshift dialect implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ derby.log
 __test_database_*
 test.sqlite
 *.db-journal
+
+kafka-connect-jdbc.jar

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,7 +7,7 @@
 <suppressions>
 
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|RedshiftDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect).java"/>
@@ -22,5 +22,5 @@
               files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|TimestampIncrementingTableQuerier).java"/>
+              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|RedshiftDialect|TimestampIncrementingTableQuerier).java"/>
 </suppressions>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,7 +7,7 @@
 <suppressions>
 
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|RedshiftDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|RedshiftDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect).java"/>
@@ -22,5 +22,5 @@
               files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|RedshiftDialect|TimestampIncrementingTableQuerier).java"/>
+              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|RedshiftDatabaseDialect|TimestampIncrementingTableQuerier).java"/>
 </suppressions>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/RedshiftDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/RedshiftDatabaseDialect.java
@@ -55,24 +55,24 @@ import java.util.ArrayList;
 /**
  * A {@link DatabaseDialect} for RedshiftSQL.
  */
-public class RedshiftDialect extends GenericDatabaseDialect {
+public class RedshiftDatabaseDialect extends GenericDatabaseDialect {
 
-  private static final Logger log = LoggerFactory.getLogger(RedshiftDialect.class);
+  private static final Logger log = LoggerFactory.getLogger(RedshiftDatabaseDialect.class);
 
   // Visible for testing
   volatile int maxIdentifierLength = 0;
 
   /**
-   * The provider for {@link RedshiftDialect}.
+   * The provider for {@link RedshiftDatabaseDialect}.
    */
   public static class Provider extends SubprotocolBasedProvider {
     public Provider() {
-      super(RedshiftDialect.class.getSimpleName(), "postgresql");
+      super(RedshiftDatabaseDialect.class.getSimpleName(), "postgresql");
     }
 
     @Override
     public DatabaseDialect create(AbstractConfig config) {
-      return new RedshiftDialect(config);
+      return new RedshiftDatabaseDialect(config);
     }
   }
 
@@ -94,7 +94,7 @@ public class RedshiftDialect extends GenericDatabaseDialect {
    *
    * @param config the connector configuration; may not be null
    */
-  public RedshiftDialect(AbstractConfig config) {
+  public RedshiftDatabaseDialect(AbstractConfig config) {
     super(config, new IdentifierRules(".", "\"", "\""));
   }
 
@@ -322,7 +322,6 @@ public class RedshiftDialect extends GenericDatabaseDialect {
       case BOOLEAN:
         return "BOOLEAN";
       case STRING:
-        // return "TEXT";
         return "VARCHAR(10000)";
       case BYTES:
         return "BYTEA";

--- a/src/main/java/io/confluent/connect/jdbc/dialect/RedshiftDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/RedshiftDialect.java
@@ -301,6 +301,8 @@ public class RedshiftDialect extends GenericDatabaseDialect {
           return "TIME";
         case Timestamp.LOGICAL_NAME:
           return "TIMESTAMP";
+        case "io.debezium.time.ZonedTimestamp":
+          return "TIMESTAMPTZ";
         default:
           // fall through to normal types
       }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/RedshiftDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/RedshiftDialect.java
@@ -1,0 +1,633 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.source.ColumnMapping;
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
+import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.TableDefinition;
+import io.confluent.connect.jdbc.util.TableId;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * A {@link DatabaseDialect} for RedshiftSQL.
+ */
+public class RedshiftDialect extends GenericDatabaseDialect {
+
+  private static final Logger log = LoggerFactory.getLogger(RedshiftDialect.class);
+
+  // Visible for testing
+  volatile int maxIdentifierLength = 0;
+
+  /**
+   * The provider for {@link RedshiftDialect}.
+   */
+  public static class Provider extends SubprotocolBasedProvider {
+    public Provider() {
+      super(RedshiftDialect.class.getSimpleName(), "postgresql");
+    }
+
+    @Override
+    public DatabaseDialect create(AbstractConfig config) {
+      return new RedshiftDialect(config);
+    }
+  }
+
+  static final String JSON_TYPE_NAME = "json";
+  static final String JSONB_TYPE_NAME = "jsonb";
+  static final String UUID_TYPE_NAME = "uuid";
+
+  /**
+   * Define the PG datatypes that require casting upon insert/update statements.
+   */
+  private static final Set<String> CAST_TYPES = Collections.unmodifiableSet(
+      Utils.mkSet(
+          JSON_TYPE_NAME,
+          JSONB_TYPE_NAME,
+          UUID_TYPE_NAME));
+
+  /**
+   * Create a new dialect instance with the given connector configuration.
+   *
+   * @param config the connector configuration; may not be null
+   */
+  public RedshiftDialect(AbstractConfig config) {
+    super(config, new IdentifierRules(".", "\"", "\""));
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    Connection result = super.getConnection();
+    synchronized (this) {
+      if (maxIdentifierLength <= 0) {
+        maxIdentifierLength = computeMaxIdentifierLength(result);
+      }
+    }
+    return result;
+  }
+
+  static int computeMaxIdentifierLength(Connection connection) {
+    String warningMessage = "Unable to query database for maximum table name length; "
+        + "the connector may fail to write to tables with long names";
+    // https://stackoverflow.com/questions/27865770/how-long-can-postgresql-table-names-be/27865772#27865772
+    String nameLengthQuery = "SELECT length(repeat('1234567890', 1000)::NAME);";
+
+    int result;
+    try (ResultSet rs = connection.createStatement().executeQuery(nameLengthQuery)) {
+      if (rs.next()) {
+        result = rs.getInt(1);
+        if (result <= 0) {
+          log.warn(
+              "Cannot accommodate maximum table name length of {} as it is not positive; "
+                  + "table name truncation will be disabled, "
+                  + "and the connector may fail to write to tables with long names",
+              result);
+          result = Integer.MAX_VALUE;
+        } else {
+          log.info(
+              "Maximum table name length for database is {} bytes",
+              result);
+        }
+      } else {
+        log.warn(warningMessage);
+        result = Integer.MAX_VALUE;
+      }
+    } catch (SQLException e) {
+      log.warn(warningMessage, e);
+      result = Integer.MAX_VALUE;
+    }
+    return result;
+  }
+
+  @Override
+  public TableId parseTableIdentifier(String fqn) {
+    TableId result = super.parseTableIdentifier(fqn);
+    if (maxIdentifierLength > 0 && result.tableName().length() > maxIdentifierLength) {
+      String newTableName = result.tableName().substring(0, maxIdentifierLength);
+      log.debug(
+          "Truncating table name from {} to {} in order to respect maximum name length",
+          result.tableName(),
+          newTableName);
+      result = new TableId(
+          result.catalogName(),
+          result.schemaName(),
+          newTableName);
+    }
+    return result;
+  }
+
+  /**
+   * Perform any operations on a {@link PreparedStatement} before it is used. This
+   * is called from
+   * the {@link #createPreparedStatement(Connection, String)} method after the
+   * statement is
+   * created but before it is returned/used.
+   *
+   * <p>
+   * This method sets the {@link PreparedStatement#setFetchDirection(int) fetch
+   * direction}
+   * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver
+   * to allow it to
+   * scroll more efficiently through the result set and prevent out of memory
+   * errors.
+   *
+   * @param stmt the prepared statement; never null
+   * @throws SQLException the error that might result from initialization
+   */
+  @Override
+  protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
+    super.initializePreparedStatement(stmt);
+
+    log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
+    stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+  }
+
+  @Override
+  public String addFieldToSchema(
+      ColumnDefinition columnDefn,
+      SchemaBuilder builder) {
+    // Add the PostgreSQL-specific types first
+    final String fieldName = fieldNameFor(columnDefn);
+    switch (columnDefn.type()) {
+      case Types.BIT: {
+        // PostgreSQL allows variable length bit strings, but when length is 1 then the
+        // driver
+        // returns a 't' or 'f' string value to represent the boolean value, so we need
+        // to handle
+        // this as well as lengths larger than 8.
+        boolean optional = columnDefn.isOptional();
+        int numBits = columnDefn.precision();
+        Schema schema;
+        if (numBits <= 1) {
+          schema = optional ? Schema.OPTIONAL_BOOLEAN_SCHEMA : Schema.BOOLEAN_SCHEMA;
+        } else if (numBits <= 8) {
+          // For consistency with what the connector did before ...
+          schema = optional ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
+        } else {
+          schema = optional ? Schema.OPTIONAL_BYTES_SCHEMA : Schema.BYTES_SCHEMA;
+        }
+        builder.field(fieldName, schema);
+        return fieldName;
+      }
+      case Types.OTHER: {
+        // Some of these types will have fixed size, but we drop this from the schema
+        // conversion
+        // since only fixed byte arrays can have a fixed size
+        if (isJsonType(columnDefn)) {
+          builder.field(
+              fieldName,
+              columnDefn.isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA);
+          return fieldName;
+        }
+
+        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
+          builder.field(
+              fieldName,
+              columnDefn.isOptional()
+                  ? Schema.OPTIONAL_STRING_SCHEMA
+                  : Schema.STRING_SCHEMA);
+          return fieldName;
+        }
+
+        break;
+      }
+      default:
+        break;
+    }
+
+    // Delegate for the remaining logic
+    return super.addFieldToSchema(columnDefn, builder);
+  }
+
+  @Override
+  protected ColumnConverter columnConverterFor(
+      ColumnMapping mapping,
+      ColumnDefinition defn,
+      int col,
+      boolean isJdbc4) {
+    // First handle any PostgreSQL-specific types
+    ColumnDefinition columnDefn = mapping.columnDefn();
+    switch (columnDefn.type()) {
+      case Types.BIT: {
+        // PostgreSQL allows variable length bit strings, but when length is 1 then the
+        // driver
+        // returns a 't' or 'f' string value to represent the boolean value, so we need
+        // to handle
+        // this as well as lengths larger than 8.
+        final int numBits = columnDefn.precision();
+        if (numBits <= 1) {
+          return rs -> rs.getBoolean(col);
+        } else if (numBits <= 8) {
+          // Do this for consistency with earlier versions of the connector
+          return rs -> rs.getByte(col);
+        }
+        return rs -> rs.getBytes(col);
+      }
+      case Types.OTHER: {
+        if (isJsonType(columnDefn)) {
+          return rs -> rs.getString(col);
+        }
+
+        if (UUID.class.getName().equals(columnDefn.classNameForType())) {
+          return rs -> rs.getString(col);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    // Delegate for the remaining logic
+    return super.columnConverterFor(mapping, defn, col, isJdbc4);
+  }
+
+  protected boolean isJsonType(ColumnDefinition columnDefn) {
+    String typeName = columnDefn.typeName();
+    return JSON_TYPE_NAME.equalsIgnoreCase(typeName) || JSONB_TYPE_NAME.equalsIgnoreCase(typeName);
+  }
+
+  @Override
+  protected String getSqlType(SinkRecordField field) {
+    if (field.schemaName() != null) {
+      switch (field.schemaName()) {
+        case Decimal.LOGICAL_NAME:
+          return "DECIMAL";
+        case Date.LOGICAL_NAME:
+          return "DATE";
+        case Time.LOGICAL_NAME:
+          return "TIME";
+        case Timestamp.LOGICAL_NAME:
+          return "TIMESTAMP";
+        default:
+          // fall through to normal types
+      }
+    }
+    switch (field.schemaType()) {
+      case INT8:
+      case INT16:
+        return "SMALLINT";
+      case INT32:
+        return "INT";
+      case INT64:
+        return "BIGINT";
+      case FLOAT32:
+        return "REAL";
+      case FLOAT64:
+        return "DOUBLE PRECISION";
+      case BOOLEAN:
+        return "BOOLEAN";
+      case STRING:
+        // return "TEXT";
+        return "VARCHAR(10000)";
+      case BYTES:
+        return "BYTEA";
+      case ARRAY:
+        SinkRecordField childField = new SinkRecordField(
+            field.schema().valueSchema(),
+            field.name(),
+            field.isPrimaryKey());
+        return getSqlType(childField) + "[]";
+      default:
+        return super.getSqlType(field);
+    }
+  }
+
+  @Override
+  public String buildInsertStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(table);
+    builder.append(" (");
+    builder.appendList()
+        .delimitedBy(",")
+        .transformedBy(ExpressionBuilder.columnNames())
+        .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES (");
+    builder.appendList()
+        .delimitedBy(",")
+        .transformedBy(this.columnValueVariables(definition))
+        .of(keyColumns, nonKeyColumns);
+    builder.append(")");
+    return builder.toString();
+  }
+
+  @Override
+  public String buildUpdateStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("UPDATE ");
+    builder.append(table);
+    builder.append(" SET ");
+    builder.appendList()
+        .delimitedBy(", ")
+        .transformedBy(this.columnNamesWithValueVariables(definition))
+        .of(nonKeyColumns);
+    if (!keyColumns.isEmpty()) {
+      builder.append(" WHERE ");
+      builder.appendList()
+          .delimitedBy(" AND ")
+          .transformedBy(ExpressionBuilder.columnNamesWith(" = ?"))
+          .of(keyColumns);
+    }
+    return builder.toString();
+  }
+
+  @Override
+  public List<String> buildAlterTable(
+      TableId table,
+      Collection<SinkRecordField> fields) {
+    final List<String> queries = new ArrayList<>(fields.size());
+    for (SinkRecordField field : fields) {
+      queries.addAll(super.buildAlterTable(table, Collections.singleton(field)));
+    }
+    return queries;
+  }
+
+  @Override
+  public String buildUpsertQueryStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns,
+      TableDefinition definition) {
+    final Transform<ColumnId> transform = (builder, col) -> {
+      builder.appendColumnName(col.name())
+          .append("=EXCLUDED.")
+          .appendColumnName(col.name());
+    };
+
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(table);
+    builder.append(" (");
+    builder.appendList()
+        .delimitedBy(",")
+        .transformedBy(ExpressionBuilder.columnNames())
+        .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES (");
+    builder.appendList()
+        .delimitedBy(",")
+        .transformedBy(this.columnValueVariables(definition))
+        .of(keyColumns, nonKeyColumns);
+    builder.append(") ON CONFLICT (");
+    builder.appendList()
+        .delimitedBy(",")
+        .transformedBy(ExpressionBuilder.columnNames())
+        .of(keyColumns);
+    if (nonKeyColumns.isEmpty()) {
+      builder.append(") DO NOTHING");
+    } else {
+      builder.append(") DO UPDATE SET ");
+      builder.appendList()
+          .delimitedBy(",")
+          .transformedBy(transform)
+          .of(nonKeyColumns);
+    }
+    return builder.toString();
+  }
+
+  @Override
+  protected void formatColumnValue(
+      ExpressionBuilder builder,
+      String schemaName,
+      Map<String, String> schemaParameters,
+      Schema.Type type,
+      Object value) {
+    if (schemaName == null && Type.BOOLEAN.equals(type)) {
+      builder.append((Boolean) value ? "TRUE" : "FALSE");
+    } else {
+      super.formatColumnValue(builder, schemaName, schemaParameters, type, value);
+    }
+  }
+
+  @Override
+  protected boolean maybeBindPrimitive(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value) throws SQLException {
+
+    switch (schema.type()) {
+      case ARRAY: {
+        Class<?> valueClass = value.getClass();
+        Object newValue = null;
+        Collection<?> valueCollection;
+        if (Collection.class.isAssignableFrom(valueClass)) {
+          valueCollection = (Collection<?>) value;
+        } else if (valueClass.isArray()) {
+          valueCollection = Arrays.asList((Object[]) value);
+        } else {
+          throw new DataException(
+              String.format("Type '%s' is not supported for Array.", valueClass.getName()));
+        }
+
+        // All typecasts below are based on pgjdbc's documentation on how to use
+        // primitive arrays
+        // - https://jdbc.postgresql.org/documentation/head/arrays.html
+        switch (schema.valueSchema().type()) {
+          case INT8: {
+            // Gotta do this the long way, as Postgres has no single-byte integer,
+            // so we want to cast to short as the next best thing, and we can't do that with
+            // toArray.
+
+            newValue = valueCollection.stream()
+                .map(o -> ((Byte) o).shortValue())
+                .toArray(Short[]::new);
+            break;
+          }
+          case INT32:
+            newValue = valueCollection.toArray(new Integer[0]);
+            break;
+          case INT16:
+            newValue = valueCollection.toArray(new Short[0]);
+            break;
+          case BOOLEAN:
+            newValue = valueCollection.toArray(new Boolean[0]);
+            break;
+          case STRING:
+            newValue = valueCollection.toArray(new String[0]);
+            break;
+          case FLOAT64:
+            newValue = valueCollection.toArray(new Double[0]);
+            break;
+          case FLOAT32:
+            newValue = valueCollection.toArray(new Float[0]);
+            break;
+          case INT64:
+            newValue = valueCollection.toArray(new Long[0]);
+            break;
+          default:
+            break;
+        }
+
+        if (newValue != null) {
+          statement.setObject(index, newValue, Types.ARRAY);
+          return true;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    return super.maybeBindPrimitive(statement, index, schema, value);
+  }
+
+  /**
+   * Return the transform that produces an assignment expression each with the
+   * name of one of the
+   * columns and the prepared statement variable. PostgreSQL may require the
+   * variable to have a
+   * type suffix, such as {@code ?::uuid}.
+   *
+   * @param defn the table definition; may be null if unknown
+   * @return the transform that produces the assignment expression for use within
+   *         a prepared
+   *         statement; never null
+   */
+  protected Transform<ColumnId> columnNamesWithValueVariables(TableDefinition defn) {
+    return (builder, columnId) -> {
+      builder.appendColumnName(columnId.name());
+      builder.append(" = ?");
+      builder.append(valueTypeCast(defn, columnId));
+    };
+  }
+
+  /**
+   * Return the transform that produces a prepared statement variable for each of
+   * the columns.
+   * PostgreSQL may require the variable to have a type suffix, such as
+   * {@code ?::uuid}.
+   *
+   * @param defn the table definition; may be null if unknown
+   * @return the transform that produces the variable expression for each column;
+   *         never null
+   */
+  protected Transform<ColumnId> columnValueVariables(TableDefinition defn) {
+    return (builder, columnId) -> {
+      builder.append("?");
+      builder.append(valueTypeCast(defn, columnId));
+    };
+  }
+
+  /**
+   * Return the typecast expression that can be used as a suffix for a value
+   * variable of the
+   * given column in the defined table.
+   *
+   * <p>
+   * This method returns a blank string except for those column types that require
+   * casting
+   * when set with literal values. For example, a column of type {@code uuid} must
+   * be cast when
+   * being bound with with a {@code varchar} literal, since a UUID value cannot be
+   * bound directly.
+   *
+   * @param tableDefn the table definition; may be null if unknown
+   * @param columnId  the column within the table; may not be null
+   * @return the cast expression, or an empty string; never null
+   */
+  protected String valueTypeCast(TableDefinition tableDefn, ColumnId columnId) {
+    if (tableDefn != null) {
+      ColumnDefinition defn = tableDefn.definitionForColumn(columnId.name());
+      if (defn != null) {
+        String typeName = defn.typeName(); // database-specific
+        if (typeName != null) {
+          typeName = typeName.toLowerCase();
+          if (CAST_TYPES.contains(typeName)) {
+            return "::" + typeName;
+          }
+        }
+      }
+    }
+    return "";
+  }
+
+  @Override
+  protected int decimalScale(ColumnDefinition defn) {
+    if (defn.scale() == NUMERIC_TYPE_SCALE_UNSET) {
+      return NUMERIC_TYPE_SCALE_HIGH;
+    }
+
+    // Postgres requires DECIMAL/NUMERIC columns to have a precision greater than
+    // zero
+    // If the precision appears to be zero, it's because the user didn't define a
+    // fixed precision
+    // for the column.
+    if (defn.precision() == 0) {
+      // In that case, a scale of zero indicates that there also isn't a fixed scale
+      // defined for
+      // the column. Instead of treating that column as if its scale is actually zero
+      // (which can
+      // cause issues since it may contain values that aren't possible with a scale of
+      // zero, like
+      // 12.12), we fall back on NUMERIC_TYPE_SCALE_HIGH to try to avoid loss of
+      // precision
+      if (defn.scale() == 0) {
+        log.debug(
+            "Column {} does not appear to have a fixed scale defined; defaulting to {}",
+            defn.id(),
+            NUMERIC_TYPE_SCALE_HIGH);
+        return NUMERIC_TYPE_SCALE_HIGH;
+      } else {
+        // Should never happen, but if it does may signal an edge case
+        // that we need to add new logic for
+        log.warn(
+            "Column {} has a precision of zero, but a non-zero scale of {}",
+            defn.id(),
+            defn.scale());
+      }
+    }
+
+    return defn.scale();
+  }
+
+}

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -4,6 +4,7 @@ io.confluent.connect.jdbc.dialect.DerbyDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.OracleDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SqliteDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.PostgreSqlDatabaseDialect$Provider
+io.confluent.connect.jdbc.dialect.RedshiftDialect$Provider
 io.confluent.connect.jdbc.dialect.MySqlDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -4,7 +4,7 @@ io.confluent.connect.jdbc.dialect.DerbyDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.OracleDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SqliteDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.PostgreSqlDatabaseDialect$Provider
-io.confluent.connect.jdbc.dialect.RedshiftDialect$Provider
+io.confluent.connect.jdbc.dialect.RedshiftDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.MySqlDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider

--- a/src/test/java/io/confluent/connect/jdbc/dialect/RedshiftDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/RedshiftDatabaseDialectTest.java
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.QuoteMethod;
+import io.confluent.connect.jdbc.util.TableDefinition;
+import io.confluent.connect.jdbc.util.TableDefinitionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RedshiftDatabaseDialectTest extends BaseDialectTest<RedshiftDatabaseDialect> {
+
+  @Override
+  protected RedshiftDatabaseDialect createDialect() {
+    return new RedshiftDatabaseDialect(sourceConfigWithUrl("jdbc:postgresql://something"));
+  }
+
+  @Test
+  public void shouldMapPrimitiveSchemaTypeToSqlTypes() {
+    assertPrimitiveMapping(Type.INT8, "SMALLINT");
+    assertPrimitiveMapping(Type.INT16, "SMALLINT");
+    assertPrimitiveMapping(Type.INT32, "INT");
+    assertPrimitiveMapping(Type.INT64, "BIGINT");
+    assertPrimitiveMapping(Type.FLOAT32, "REAL");
+    assertPrimitiveMapping(Type.FLOAT64, "DOUBLE PRECISION");
+    assertPrimitiveMapping(Type.BOOLEAN, "BOOLEAN");
+    assertPrimitiveMapping(Type.BYTES, "BYTEA");
+    assertPrimitiveMapping(Type.STRING, "VARCHAR(10000)");
+  }
+
+  @Test
+  public void shouldMapDecimalSchemaTypeToDecimalSqlType() {
+    assertDecimalMapping(0, "DECIMAL");
+    assertDecimalMapping(3, "DECIMAL");
+    assertDecimalMapping(4, "DECIMAL");
+    assertDecimalMapping(5, "DECIMAL");
+  }
+
+  @Test
+  public void testCustomColumnConverters() {
+    assertColumnConverter(Types.OTHER, RedshiftDatabaseDialect.JSON_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.OTHER, RedshiftDatabaseDialect.JSONB_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.OTHER, RedshiftDatabaseDialect.UUID_TYPE_NAME, Schema.STRING_SCHEMA, UUID.class);
+  }
+
+  @Test
+  public void shouldMapDataTypesForAddingColumnToTable() {
+    verifyDataTypeMapping("SMALLINT", Schema.INT8_SCHEMA);
+    verifyDataTypeMapping("SMALLINT", Schema.INT16_SCHEMA);
+    verifyDataTypeMapping("INT", Schema.INT32_SCHEMA);
+    verifyDataTypeMapping("BIGINT", Schema.INT64_SCHEMA);
+    verifyDataTypeMapping("REAL", Schema.FLOAT32_SCHEMA);
+    verifyDataTypeMapping("DOUBLE PRECISION", Schema.FLOAT64_SCHEMA);
+    verifyDataTypeMapping("BOOLEAN", Schema.BOOLEAN_SCHEMA);
+    verifyDataTypeMapping("VARCHAR(10000)", Schema.STRING_SCHEMA);
+    verifyDataTypeMapping("BYTEA", Schema.BYTES_SCHEMA);
+    verifyDataTypeMapping("DECIMAL", Decimal.schema(0));
+    verifyDataTypeMapping("DATE", Date.SCHEMA);
+    verifyDataTypeMapping("TIME", Time.SCHEMA);
+    verifyDataTypeMapping("TIMESTAMP", Timestamp.SCHEMA);
+  }
+
+  @Test
+  public void shouldMapDateSchemaTypeToDateSqlType() {
+    assertDateMapping("DATE");
+  }
+
+  @Test
+  public void shouldMapTimeSchemaTypeToTimeSqlType() {
+    assertTimeMapping("TIME");
+  }
+
+  @Test
+  public void shouldMapTimestampSchemaTypeToTimestampSqlType() {
+    assertTimestampMapping("TIMESTAMP");
+  }
+
+  @Test
+  public void shouldBuildCreateQueryStatement() {
+    assertEquals(
+        "CREATE TABLE \"myTable\" (\n"
+        + "\"c1\" INT NOT NULL,\n"
+        + "\"c2\" BIGINT NOT NULL,\n"
+        + "\"c3\" VARCHAR(10000) NOT NULL,\n"
+        + "\"c4\" VARCHAR(10000) NULL,\n"
+        + "\"c5\" DATE DEFAULT '2001-03-15',\n"
+        + "\"c6\" TIME DEFAULT '00:00:00.000',\n"
+        + "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "\"c8\" DECIMAL NULL,\n"
+        + "\"c9\" BOOLEAN DEFAULT TRUE,\n"
+        + "PRIMARY KEY(\"c1\"))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "CREATE TABLE myTable (\n"
+        + "c1 INT NOT NULL,\n"
+        + "c2 BIGINT NOT NULL,\n"
+        + "c3 VARCHAR(10000) NOT NULL,\n"
+        + "c4 VARCHAR(10000) NULL,\n"
+        + "c5 DATE DEFAULT '2001-03-15',\n"
+        + "c6 TIME DEFAULT '00:00:00.000',\n"
+        + "c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000',\n"
+        + "c8 DECIMAL NULL,\n"
+        + "c9 BOOLEAN DEFAULT TRUE,\n"
+        + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, sinkRecordFields)
+    );
+  }
+
+  @Test
+  public void shouldBuildAlterTableStatement() {
+    assertStatements(
+      new String[]{
+          "ALTER TABLE \"myTable\" ADD \"c1\" INT NOT NULL",
+          "ALTER TABLE \"myTable\" ADD \"c2\" BIGINT NOT NULL",
+          "ALTER TABLE \"myTable\" ADD \"c3\" VARCHAR(10000) NOT NULL",
+          "ALTER TABLE \"myTable\" ADD \"c4\" VARCHAR(10000) NULL",
+          "ALTER TABLE \"myTable\" ADD \"c5\" DATE DEFAULT '2001-03-15'",
+          "ALTER TABLE \"myTable\" ADD \"c6\" TIME DEFAULT '00:00:00.000'",
+          "ALTER TABLE \"myTable\" ADD \"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
+          "ALTER TABLE \"myTable\" ADD \"c8\" DECIMAL NULL",
+          "ALTER TABLE \"myTable\" ADD \"c9\" BOOLEAN DEFAULT TRUE"
+      },
+      dialect.buildAlterTable(tableId, sinkRecordFields)
+  );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+    assertStatements(
+      new String[]{
+          "ALTER TABLE myTable ADD c1 INT NOT NULL",
+          "ALTER TABLE myTable ADD c2 BIGINT NOT NULL",
+          "ALTER TABLE myTable ADD c3 VARCHAR(10000) NOT NULL",
+          "ALTER TABLE myTable ADD c4 VARCHAR(10000) NULL",
+          "ALTER TABLE myTable ADD c5 DATE DEFAULT '2001-03-15'",
+          "ALTER TABLE myTable ADD c6 TIME DEFAULT '00:00:00.000'",
+          "ALTER TABLE myTable ADD c7 TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'",
+          "ALTER TABLE myTable ADD c8 DECIMAL NULL",
+          "ALTER TABLE myTable ADD c9 BOOLEAN DEFAULT TRUE"
+      },
+      dialect.buildAlterTable(tableId, sinkRecordFields)
+  );
+  }
+
+  @Test
+  public void shouldBuildInsertStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    assertEquals(
+        "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+        "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO myTable (id1,id2,columnA,columnB," +
+        "columnC,columnD) VALUES (?,?,?,?,?,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    tableDefn = builder.build();
+    List<ColumnId> nonPkColumns = new ArrayList<>();
+    nonPkColumns.add(new ColumnId(tableId, "columnA"));
+    nonPkColumns.add(new ColumnId(tableId, "uuidColumn"));
+    nonPkColumns.add(new ColumnId(tableId, "dateColumn"));
+    assertEquals(
+        "INSERT INTO myTable (" +
+        "id1,id2,columnA,uuidColumn,dateColumn" +
+        ") VALUES (?,?,?,?::uuid,?)",
+        dialect.buildInsertStatement(tableId, pkColumns, nonPkColumns, tableDefn)
+    );
+  }
+  @Test
+  public void shouldBuildUpsertStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    assertEquals(
+        "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+        "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
+        "\"id2\") DO UPDATE SET \"columnA\"=EXCLUDED" +
+        ".\"columnA\",\"columnB\"=EXCLUDED.\"columnB\",\"columnC\"=EXCLUDED" +
+        ".\"columnC\",\"columnD\"=EXCLUDED.\"columnD\"",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO myTable (id1,id2,columnA,columnB," +
+        "columnC,columnD) VALUES (?,?,?,?,?,?) ON CONFLICT (id1," +
+        "id2) DO UPDATE SET columnA=EXCLUDED" +
+        ".columnA,columnB=EXCLUDED.columnB,columnC=EXCLUDED" +
+        ".columnC,columnD=EXCLUDED.columnD",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    tableDefn = builder.build();
+    List<ColumnId> nonPkColumns = new ArrayList<>();
+    nonPkColumns.add(new ColumnId(tableId, "columnA"));
+    nonPkColumns.add(new ColumnId(tableId, "uuidColumn"));
+    nonPkColumns.add(new ColumnId(tableId, "dateColumn"));
+    assertEquals(
+        "INSERT INTO myTable (" +
+        "id1,id2,columnA,uuidColumn,dateColumn" +
+        ") VALUES (?,?,?,?::uuid,?) ON CONFLICT (id1," +
+        "id2) DO UPDATE SET " +
+        "columnA=EXCLUDED.columnA," +
+        "uuidColumn=EXCLUDED.uuidColumn," +
+        "dateColumn=EXCLUDED.dateColumn",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, nonPkColumns, tableDefn)
+    );
+  }
+
+  @Test
+  public void shouldComputeValueTypeCast() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    TableDefinition tableDefn = builder.build();
+    ColumnId uuidColumn = tableDefn.definitionForColumn("uuidColumn").id();
+    ColumnId dateColumn = tableDefn.definitionForColumn("dateColumn").id();
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnPK1));
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnPK2));
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnA));
+    assertEquals("::uuid", dialect.valueTypeCast(tableDefn, uuidColumn));
+    assertEquals("", dialect.valueTypeCast(tableDefn, dateColumn));
+  }
+
+  @Test
+  public void createOneColNoPk() {
+    verifyCreateOneColNoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"col1\" INT NOT NULL)");
+  }
+
+  @Test
+  public void createOneColOnePk() {
+    verifyCreateOneColOnePk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INT NOT NULL," +
+        System.lineSeparator() + "PRIMARY KEY(\"pk1\"))");
+  }
+
+  @Test
+  public void createThreeColTwoPk() {
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INT NOT NULL," +
+        System.lineSeparator() + "\"pk2\" INT NOT NULL," + System.lineSeparator() +
+        "\"col1\" INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(\"pk1\",\"pk2\"))");
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 INT NOT NULL," +
+        System.lineSeparator() + "pk2 INT NOT NULL," + System.lineSeparator() +
+        "col1 INT NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
+  }
+
+  @Test
+  public void alterAddOneCol() {
+    verifyAlterAddOneCol("ALTER TABLE \"myTable\" ADD \"newcol1\" INT NULL");
+  }
+
+  @Test
+  public void alterAddTwoCol() {
+    verifyAlterAddTwoCols(
+        "ALTER TABLE \"myTable\" ADD \"newcol1\" INT NULL",
+        "ALTER TABLE \"myTable\" ADD \"newcol2\" INT DEFAULT 42");
+  }
+
+  @Test
+  public void upsert() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("Customer");
+    builder.withColumn("id").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("name").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("salary").type("real", JDBCType.FLOAT, String.class);
+    builder.withColumn("address").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    TableId customer = tableDefn.id();
+    assertEquals(
+        "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
+         "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\"," +
+         "\"salary\"=EXCLUDED.\"salary\",\"address\"=EXCLUDED.\"address\"",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address"),
+            tableDefn
+        )
+    );
+
+    assertEquals(
+            "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
+                    "VALUES (?,?,?,?) ON CONFLICT (\"id\",\"name\",\"salary\",\"address\") DO NOTHING",
+            dialect.buildUpsertQueryStatement(
+                    customer,
+                    columns(customer, "id", "name", "salary", "address"),
+                    columns(customer),
+                    tableDefn
+            )
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO Customer (id,name,salary,address) " +
+        "VALUES (?,?,?,?) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name," +
+        "salary=EXCLUDED.salary,address=EXCLUDED.address",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address"),
+            tableDefn
+        )
+    );
+
+    assertEquals(
+            "INSERT INTO Customer (id,name,salary,address) " +
+                    "VALUES (?,?,?,?) ON CONFLICT (id,name,salary,address) DO NOTHING",
+            dialect.buildUpsertQueryStatement(
+                    customer,
+                    columns(customer, "id", "name", "salary", "address"),
+                    columns(customer),
+                    tableDefn
+            )
+    );
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithoutCredentialsInProperties() {
+    assertSanitizedUrl(
+        "jdbc:postgresql://localhost/test?user=fred&ssl=true",
+        "jdbc:postgresql://localhost/test?user=fred&ssl=true"
+    );
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithCredentialsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
+        "jdbc:postgresql://localhost/test?user=fred&password=****&ssl=true"
+    );
+  }
+
+  @Test
+  @Override
+  public void bindFieldArrayUnsupported() throws SQLException {
+      // Overridden simply to dummy out the test.
+  }
+
+  @Test
+  public void bindFieldPrimitiveValues() throws SQLException {
+    PreparedStatement statement = mock(PreparedStatement.class);
+    int index = ThreadLocalRandom.current().nextInt();
+
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT32_SCHEMA), Collections.singletonList(42)).setObject(index, new Object[] { 42 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT8_SCHEMA), Arrays.asList( (byte) 42, (byte) 12)).setObject(index, new Object[] { (short)42, (short)12 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT16_SCHEMA), Arrays.asList( (short) 42, (short) 12)).setObject(index, new Object[] { (short)42, (short)12 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT32_SCHEMA), Arrays.asList(42, 16 )).setObject(index, new Object[] { 42, 16 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.INT64_SCHEMA), Arrays.asList(42L, 16L )).setObject(index, new Object[] { (long)42, (long)16 }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.FLOAT32_SCHEMA), Arrays.asList(42.5F, 16.2F )).setObject(index, new Object[] { 42.5F, 16.2F }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.FLOAT64_SCHEMA), Arrays.asList(42.5D, 16.2D )).setObject(index, new Object[] { 42.5D, 16.2D }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.STRING_SCHEMA), Arrays.asList("42", "16" )).setObject(index, new Object[] { "42", "16" }, Types.ARRAY);
+    super.verifyBindField(++index, SchemaBuilder.array(Schema.BOOLEAN_SCHEMA), Arrays.asList(true, false, true )).setObject(index, new Object[] { true, false, true }, Types.ARRAY);
+  }
+
+  @Test
+  public void shouldComputeMaxTableNameLength() throws Exception {
+    int expectedMaxLength = 24;
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.next()).thenReturn(true);
+    when(resultSet.getInt(1)).thenReturn(expectedMaxLength);
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenReturn(resultSet);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = RedshiftDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(expectedMaxLength, actualMaxLength);
+  }
+
+  @Test
+  public void shouldGracefullyHandleErrorWhenComputingMaxTableNameLength() throws Exception {
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenThrow(new SQLException("I plead the fifth"));
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = RedshiftDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldGracefullyHandleEmptyResultSetWhenComputingMaxTableNameLength() throws Exception {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.next()).thenReturn(false);
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenReturn(resultSet);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = RedshiftDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldGracefullyHandleInvalidValueWhenComputingMaxTableNameLength() throws Exception {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(resultSet.next()).thenReturn(true);
+    when(resultSet.getInt(1)).thenReturn(0);
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))
+        .thenReturn(resultSet);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    int actualMaxLength = RedshiftDatabaseDialect.computeMaxIdentifierLength(connection);
+
+    assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldTruncateTableNames() {
+
+    final String tableFqn = "some.table";
+
+    // Table name is one byte longer than it's allowed to be; should be truncated
+    dialect.maxIdentifierLength = 4;
+    TableId expectedTableId = new TableId(
+        null,
+        "some",
+        "tabl"
+    );
+    TableId actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+
+    // Table name is exactly as long as it's allowed to be; should not be truncated
+    dialect.maxIdentifierLength = 5;
+    expectedTableId = new TableId(
+        null,
+        "some",
+        "table"
+    );
+    actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+
+    // Something went wrong when computing the max length
+    dialect.maxIdentifierLength = Integer.MAX_VALUE;
+    expectedTableId = new TableId(
+        null,
+        "some",
+        "table"
+    );
+    actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+
+    // We haven't computed the max length at all yet
+    dialect.maxIdentifierLength = 0;
+    expectedTableId = new TableId(
+        null,
+        "some",
+        "table"
+    );
+    actualTableId = dialect.parseTableIdentifier(tableFqn);
+    assertEquals(expectedTableId, actualTableId);
+  }
+
+  @Test
+  public void shouldFallBackOnUnknownDecimalScale() {
+    ColumnId columnId = new ColumnId(new TableId("catalog", "schema", "table"), "column");
+    ColumnDefinition definition = mock(ColumnDefinition.class);
+    when(definition.id()).thenReturn(columnId);
+
+    when(definition.precision()).thenReturn(4);
+    when(definition.scale()).thenReturn(GenericDatabaseDialect.NUMERIC_TYPE_SCALE_UNSET);
+
+    assertEquals(GenericDatabaseDialect.NUMERIC_TYPE_SCALE_HIGH, dialect.decimalScale(definition));
+  }
+
+  @Test
+  public void shouldFallBackOnUnfixedDecimalScale() {
+    ColumnId columnId = new ColumnId(new TableId("catalog", "schema", "table"), "column");
+    ColumnDefinition definition = mock(ColumnDefinition.class);
+    when(definition.id()).thenReturn(columnId);
+
+    when(definition.precision()).thenReturn(0);
+    when(definition.scale()).thenReturn(0);
+
+    assertEquals(GenericDatabaseDialect.NUMERIC_TYPE_SCALE_HIGH, dialect.decimalScale(definition));
+  }
+
+  @Test
+  public void shouldNotFallBackOnKnownDecimalScale() {
+    ColumnId columnId = new ColumnId(new TableId("catalog", "schema", "table"), "column");
+    ColumnDefinition definition = mock(ColumnDefinition.class);
+    when(definition.id()).thenReturn(columnId);
+
+    when(definition.precision()).thenReturn(0);
+    when(definition.scale()).thenReturn(5);
+
+    assertEquals(5, dialect.decimalScale(definition));
+  }
+
+}


### PR DESCRIPTION
## Problem
The current implementation of kafka-connect-jdbc does not properly support Redshift. Adding multiple columns does not work. Redshift converts the TEXT type to VARCHAR(256) by default. For many data, this is a short length. Converts the date from Debezium to TEXT.

## Solution
Creating a dialect for Redshift based on the modified PostgreSQL dialect.

##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
In the datamesh functionality of the EBAC organization https://ebaconline.com.br/

## Test Strategy
Added several modules to check the Redshift language. Manual testing was carried out on the EBAC developer platform.

##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
