### PR TITLE
isolate sql transaction mode in connector validation

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -15,6 +15,9 @@
 
 package io.confluent.connect.jdbc;
 
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG;
+
+import java.util.Optional;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -27,7 +30,13 @@ import org.apache.kafka.connect.util.ConnectorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
@@ -39,8 +48,6 @@ import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.Version;
-
-import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG;
 
 /**
  * JdbcConnector is a Kafka Connect Connector implementation that watches a JDBC database and
@@ -142,13 +149,16 @@ public class JdbcSourceConnector extends SourceConnector {
   public Config validate(Map<String, String> connectorConfigs) {
     Config config = super.validate(connectorConfigs);
     configValue(config, TRANSACTION_ISOLATION_MODE_CONFIG)
-            .filter(txmode -> JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT.equals(
-                    JdbcSourceConnectorConfig.TransactionIsolationMode.valueOf(txmode.value().toString())))
-            .ifPresent(txmode -> {
-              JdbcSourceConnectorConfig jdbcSourceConnectorConfig
-                      = new JdbcSourceConnectorConfig(connectorConfigs);
-              jdbcSourceConnectorConfig.validateMultiConfigs(config);
-            });
+        .filter(
+            txmode ->
+                JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT.equals(
+                    JdbcSourceConnectorConfig.TransactionIsolationMode.valueOf(
+                        txmode.value().toString())))
+        .ifPresent(txmode -> {
+          JdbcSourceConnectorConfig jdbcSourceConnectorConfig
+              = new JdbcSourceConnectorConfig(connectorConfigs);
+          jdbcSourceConnectorConfig.validateMultiConfigs(config);
+        });
     return config;
   }
 
@@ -224,11 +234,12 @@ public class JdbcSourceConnector extends SourceConnector {
 
   private Optional<ConfigValue> configValue(Config config, String name) {
     return config.configValues()
-            .stream()
-            .filter(cfg -> name.equals(cfg.name())
-                    && cfg.errorMessages().isEmpty())
-            .findFirst();
+        .stream()
+        .filter(cfg -> name.equals(cfg.name())
+            && cfg.errorMessages().isEmpty())
+        .findFirst();
   }
+
   @Override
   public ConfigDef config() {
     return JdbcSourceConnectorConfig.CONFIG_DEF;

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -18,6 +18,7 @@ package io.confluent.connect.jdbc;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -26,13 +27,7 @@ import org.apache.kafka.connect.util.ConnectorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
@@ -44,6 +39,8 @@ import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.Version;
+
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG;
 
 /**
  * JdbcConnector is a Kafka Connect Connector implementation that watches a JDBC database and
@@ -144,9 +141,14 @@ public class JdbcSourceConnector extends SourceConnector {
   @Override
   public Config validate(Map<String, String> connectorConfigs) {
     Config config = super.validate(connectorConfigs);
-    JdbcSourceConnectorConfig jdbcSourceConnectorConfig
-            = new JdbcSourceConnectorConfig(connectorConfigs);
-    jdbcSourceConnectorConfig.validateMultiConfigs(config);
+    configValue(config, TRANSACTION_ISOLATION_MODE_CONFIG)
+            .filter(txmode -> JdbcSourceConnectorConfig.TransactionIsolationMode.SQL_SERVER_SNAPSHOT.equals(
+                    JdbcSourceConnectorConfig.TransactionIsolationMode.valueOf(txmode.value().toString())))
+            .ifPresent(txmode -> {
+              JdbcSourceConnectorConfig jdbcSourceConnectorConfig
+                      = new JdbcSourceConnectorConfig(connectorConfigs);
+              jdbcSourceConnectorConfig.validateMultiConfigs(config);
+            });
     return config;
   }
 
@@ -220,6 +222,13 @@ public class JdbcSourceConnector extends SourceConnector {
     }
   }
 
+  private Optional<ConfigValue> configValue(Config config, String name) {
+    return config.configValues()
+            .stream()
+            .filter(cfg -> name.equals(cfg.name())
+                    && cfg.errorMessages().isEmpty())
+            .findFirst();
+  }
   @Override
   public ConfigDef config() {
     return JdbcSourceConnectorConfig.CONFIG_DEF;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -388,33 +388,26 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                     )
             ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
 
-    TransactionIsolationMode transactionIsolationMode =
-            TransactionIsolationMode.valueOf(
-                    this.getString(TRANSACTION_ISOLATION_MODE_CONFIG)
-            );
-    if (transactionIsolationMode == TransactionIsolationMode.SQL_SERVER_SNAPSHOT) {
-      DatabaseDialect dialect;
-      final String dialectName = this.getString(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG);
-      if (dialectName != null && !dialectName.trim().isEmpty()) {
-        dialect = DatabaseDialects.create(dialectName, this);
-      } else {
-        dialect = DatabaseDialects.findBestFor(this.getString(CONNECTION_URL_CONFIG), this);
-      }
-      if (!dialect.name().equals(
-              DatabaseDialects.create(
-                      SqlServerDatabaseDialectName, this
-              ).name()
-      )
-      ) {
-        configValues
-                .get(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG)
-                .addErrorMessage("Isolation mode of `"
-                        + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
-                        + "` can only be configured with a Sql Server Dialect"
-          );
-      }
+    DatabaseDialect dialect;
+    final String dialectName = this.getString(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG);
+    if (dialectName != null && !dialectName.trim().isEmpty()) {
+      dialect = DatabaseDialects.create(dialectName, this);
+    } else {
+      dialect = DatabaseDialects.findBestFor(this.getString(CONNECTION_URL_CONFIG), this);
     }
-
+    if (!dialect.name().equals(
+            DatabaseDialects.create(
+                    SqlServerDatabaseDialectName, this
+            ).name()
+    )
+    ) {
+      configValues
+              .get(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG)
+              .addErrorMessage("Isolation mode of `"
+                      + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
+                      + "` can only be configured with a Sql Server Dialect"
+              );
+    }
     return config;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -382,11 +382,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public Config validateMultiConfigs(Config config) {
     HashMap<String, ConfigValue> configValues = new HashMap<>();
     config.configValues().stream()
-            .filter((configValue) ->
-                    configValue.name().equals(
-                            JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
-                    )
-            ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
+        .filter((configValue) ->
+            configValue.name().equals(
+                JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG
+            )
+        ).forEach(configValue -> configValues.putIfAbsent(configValue.name(), configValue));
 
     DatabaseDialect dialect;
     final String dialectName = this.getString(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG);
@@ -396,17 +396,12 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       dialect = DatabaseDialects.findBestFor(this.getString(CONNECTION_URL_CONFIG), this);
     }
     if (!dialect.name().equals(
-            DatabaseDialects.create(
-                    SqlServerDatabaseDialectName, this
-            ).name()
-    )
-    ) {
+        DatabaseDialects.create(SqlServerDatabaseDialectName, this).name())) {
       configValues
-              .get(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG)
-              .addErrorMessage("Isolation mode of `"
-                      + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
-                      + "` can only be configured with a Sql Server Dialect"
-              );
+          .get(JdbcSourceConnectorConfig.TRANSACTION_ISOLATION_MODE_CONFIG)
+          .addErrorMessage("Isolation mode of `"
+              + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
+              + "` can only be configured with a Sql Server Dialect");
     }
     return config;
   }

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -360,6 +360,13 @@ public class JdbcSourceConnectorTest {
 
   }
 
+  @Test
+  public void testValidateConnectorPropertyWithoutDefaultValue() {
+    props.remove(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
+    Config config = connector.validate(props);
+  }
+
+
   private String tables(String... names) {
     List<TableId> tableIds = new ArrayList<>();
     for (String name : names) {


### PR DESCRIPTION
## Problem
The PR https://github.com/confluentinc/kafka-connect-jdbc/pull/1169 introduced a validation that is provoking a failure in the [connector plugin validation endpoint](https://github.com/confluentinc/kafka-connect-jdbc/pull/1169). More specifically, if you call the validate endpoint for the JDBC Source Connector with only the _connector.class_ parameter, it returns the error below:

`An unexpected error occurred: org.apache.kafka.common.config.ConfigException: Missing required configuration "connection.url" which has no default value.`

The reason is the validation instantiates the class JdbcSourceConnectorConfig and additional validations are made. The key _**connection.url**_  has no default value, so it is failing when checking its value. For parameters that have default values is OK.

This is the same error mentioned in https://github.com/confluentinc/kafka-connect-jdbc/issues/1198

## Solution
Only instantiate the class JdbcSourceConnectorConfig when the transaction mode is SQL_SERVER_SNAPSHOT. The error will continue happening for that transaction mode, but at least not for the other configurations. I didn't want to modify the database dialects creation and modify the https://github.com/confluentinc/kafka-connect-jdbc/pull/1169 behaviour.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
