### PR TITLE
CCDB 5027 migrate log4j to reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <licenses>
         <license>
             <name>Confluent Community License</name>
-            <url>http://www.confluent.io/confluent-community-license</url>
+            <url>https://www.confluent.io/confluent-community-license</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -61,6 +61,8 @@
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>42.3.3</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
+        <logredactor.version>1.0.10</logredactor.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <licenses.name>Confluent Community License</licenses.name>
         <licenses.version>${project.version}</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -71,7 +73,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 
@@ -146,13 +148,15 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <artifactId>logredactor</artifactId>
+            <version>${logredactor.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -184,6 +188,12 @@
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## Problem
The migration from log4j to reload4j was not done for this repository. As a result it was failing builds with the deprecated dependencies.

## Solution
Replaced with new dependencies.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
pint-merge to other branches.