### PR TITLE
CCDB 5027 Replaced logredactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>42.3.3</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
-        <logredactor.version>1.0.10</logredactor.version>
         <slf4j.version>1.7.36</slf4j.version>
         <licenses.name>Confluent Community License</licenses.name>
         <licenses.version>${project.version}</licenses.version>
@@ -152,11 +151,9 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>logredactor</artifactId>
-            <version>${logredactor.version}</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
logredactor is not necessarily required as per this:
https://confluentinc.atlassian.net/wiki/spaces/~913794610/pages/2772764716/Backport+reload4j+to+replace+Confluent-log4j

## Solution
Replaced it with ch.qos.reload4j.reload4j

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
