### PR TITLE
RCCA-7885,MMA-11946: Add default value for Connection URL config and remove redundant code

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -58,6 +58,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "``jdbc:sqlserver://localhost;instance=SQLEXPRESS;"
           + "databaseName=db_name``";
   private static final String CONNECTION_URL_DISPLAY = "JDBC URL";
+  private static final String CONNECTION_URL_DEFAULT = "";
 
   public static final String CONNECTION_USER_CONFIG = CONNECTION_PREFIX + "user";
   private static final String CONNECTION_USER_DOC = "JDBC connection user.";
@@ -323,6 +324,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     config.define(
         CONNECTION_URL_CONFIG,
         Type.STRING,
+        CONNECTION_URL_DEFAULT,
         Importance.HIGH,
         CONNECTION_URL_DOC,
         DATABASE_GROUP,
@@ -653,10 +655,6 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public JdbcSourceConnectorConfig(Map<String, ?> props) {
     super(CONFIG_DEF, props);
-    String mode = getString(JdbcSourceConnectorConfig.MODE_CONFIG);
-    if (mode.equals(JdbcSourceConnectorConfig.MODE_UNSPECIFIED)) {
-      throw new ConfigException("Query mode must be specified");
-    }
   }
 
   public String topicPrefix() {


### PR DESCRIPTION
## Problem
- https://confluentinc.atlassian.net/browse/MMA-11946

When trying to create a JDBC source connector in C3, it returns missing required configuration "connection.url" which has no default value. but we can see the "connection.url" is defined. 

![image](https://user-images.githubusercontent.com/30872045/182784983-cc653c17-99ee-41b1-b728-ec1799f9d455.png)

Even though this is a C3 UI bug, customer was not able to upgrade confluent platform to 7.1.1 because they are seeing that tasks fails with the same exception - `org.apache.kafka.common.config.ConfigException: Missing required configuration "connection.url" which has no default value` when they upgrade to 7.1.1. More details in this thread - https://confluent.slack.com/archives/C03NGEF6GTD/p1657710853069849


## Solution
- I was able to find the reason why connector task was failing when customer try to upgrade to v7.1.1. This is due to a recent  bug fix in kafka - https://issues.apache.org/jira/browse/KAFKA-9887. In the older CP versions, tasks was failing during startup but the error was not propogating up as mentioned in this bug and it was getting registered as successful startup.

- The fix here is very simple - We need to add a default value for config `connection.url`. Here, I have added the default value "". 
- Also after this change, I had to remove this[ redundant code](https://github.com/confluentinc/kafka-connect-jdbc/blob/10.0.x/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java#L656-L659) as this exception was thrown when task tries to instantiate `JdbcSourceConnectorConfig` class. This is redundant as it is being validated here as well - https://github.com/confluentinc/kafka-connect-jdbc/blob/10.0.x/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java#L754.

 
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
- Existing UT and ITs are green
- We shared a debug snapshot jar with customer to test if these changes works. Customer has already tested this in their environment and confirm that this works.
- Manual testing on CP - 7.1.1
- Have verified that this changes are working on master branch as well - Build a snapshot version of connector on master branch with these changes and was able to load connector template in C3 UI. 

Able to see template in C3 UI (With these changes)
<img width="1788" alt="image" src="https://user-images.githubusercontent.com/30872045/182827762-a26b0db2-3669-48e9-a0f2-7a8f3bfd473b.png">


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
