### PR TITLE
Use racially neutral terms in codebase

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -96,25 +96,25 @@ public class JdbcSourceConnector extends SourceConnector {
     long tablePollMs = config.getLong(JdbcSourceConnectorConfig.TABLE_POLL_INTERVAL_MS_CONFIG);
     long tableStartupLimitMs =
         config.getLong(JdbcSourceConnectorConfig.TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_CONFIG);
-    List<String> whitelist = config.getList(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG);
-    Set<String> whitelistSet = whitelist.isEmpty() ? null : new HashSet<>(whitelist);
-    List<String> blacklist = config.getList(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
-    Set<String> blacklistSet = blacklist.isEmpty() ? null : new HashSet<>(blacklist);
+    List<String> include = config.tableInclude();
+    Set<String> includeSet = include.isEmpty() ? null : new HashSet<>(include);
+    List<String> exclude = config.tableExclude();
+    Set<String> excludeSet = exclude.isEmpty() ? null : new HashSet<>(exclude);
 
-    if (whitelistSet != null && blacklistSet != null) {
-      throw new ConnectException(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + " and "
-                                 + JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG + " are "
+    if (includeSet != null && excludeSet != null) {
+      throw new ConnectException(JdbcSourceConnectorConfig.TABLE_INCLUDE_CONFIG + " and "
+                                 + JdbcSourceConnectorConfig.TABLE_EXCLUDE_CONFIG + " are "
                                  + "exclusive.");
     }
     String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
     if (!query.isEmpty()) {
-      if (whitelistSet != null || blacklistSet != null) {
+      if (includeSet != null || excludeSet != null) {
         throw new ConnectException(JdbcSourceConnectorConfig.QUERY_CONFIG + " may not be combined"
                                    + " with whole-table copying settings.");
       }
       // Force filtering out the entire set of tables since the one task we'll generate is for the
       // query.
-      whitelistSet = Collections.emptySet();
+      includeSet = Collections.emptySet();
 
     }
     tableMonitorThread = new TableMonitorThread(
@@ -123,8 +123,8 @@ public class JdbcSourceConnector extends SourceConnector {
         context,
         tableStartupLimitMs,
         tablePollMs,
-        whitelistSet,
-        blacklistSet,
+        includeSet,
+        excludeSet,
         Time.SYSTEM
     );
     if (query.isEmpty()) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -116,7 +116,7 @@ public class BufferedRecords {
           tableId.tableName(),
           config.pkMode,
           config.pkFields,
-          config.fieldsWhitelist,
+          config.fieldsInclude,
           schemaPair
       );
       dbStructure.createOrAmendIfNecessary(

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -61,14 +61,14 @@ public class FieldsMetadata {
       final String tableName,
       final JdbcSinkConfig.PrimaryKeyMode pkMode,
       final List<String> configuredPkFields,
-      final Set<String> fieldsWhitelist,
+      final Set<String> fieldsInclude,
       final SchemaPair schemaPair
   ) {
     return extract(
         tableName,
         pkMode,
         configuredPkFields,
-        fieldsWhitelist,
+        fieldsInclude,
         schemaPair.keySchema,
         schemaPair.valueSchema
     );
@@ -78,7 +78,7 @@ public class FieldsMetadata {
       final String tableName,
       final JdbcSinkConfig.PrimaryKeyMode pkMode,
       final List<String> configuredPkFields,
-      final Set<String> fieldsWhitelist,
+      final Set<String> fieldsInclude,
       final Schema keySchema,
       final Schema valueSchema
   ) {
@@ -115,7 +115,7 @@ public class FieldsMetadata {
         if (keyFieldNames.contains(field.name())) {
           continue;
         }
-        if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(field.name())) {
+        if (!fieldsInclude.isEmpty() && !fieldsInclude.contains(field.name())) {
           continue;
         }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -227,20 +227,32 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   private static final String TABLE_POLL_INTERVAL_MS_DISPLAY
       = "Metadata Change Monitoring Interval (ms)";
 
+  public static final String TABLE_INCLUDE_CONFIG = "table.include";
+  private static final String TABLE_INCLUDE_DOC =
+      "List of tables to include in copying. If specified, ``table.exclude`` may not be set. "
+      + "Use a comma-separated list to specify multiple tables "
+      + "(for example, ``table.include: \"User, Address, Email\"``).";
+  public static final String TABLE_INCLUDE_DEFAULT = "";
+  private static final String TABLE_INCLUDE_DISPLAY = "Table Include";
+
   public static final String TABLE_WHITELIST_CONFIG = "table.whitelist";
   private static final String TABLE_WHITELIST_DOC =
-      "List of tables to include in copying. If specified, ``table.blacklist`` may not be set. "
-      + "Use a comma-separated list to specify multiple tables "
-      + "(for example, ``table.whitelist: \"User, Address, Email\"``).";
-  public static final String TABLE_WHITELIST_DEFAULT = "";
+      "Deprecated. Use " + TABLE_INCLUDE_CONFIG + " instead.";
+  public static final String TABLE_WHITELIST_DEFAULT = TABLE_INCLUDE_DEFAULT;
   private static final String TABLE_WHITELIST_DISPLAY = "Table Whitelist";
+
+  public static final String TABLE_EXCLUDE_CONFIG = "table.exclude";
+  private static final String TABLE_EXCLUDE_DOC =
+      "List of tables to exclude from copying. If specified, ``table.exclude`` may not be set. "
+      + "Use a comma-separated list to specify multiple tables "
+      + "(for example, ``table.exclude: \"User, Address, Email\"``).";
+  public static final String TABLE_EXCLUDE_DEFAULT = "";
+  private static final String TABLE_EXCLUDE_DISPLAY = "Table Exclude";
 
   public static final String TABLE_BLACKLIST_CONFIG = "table.blacklist";
   private static final String TABLE_BLACKLIST_DOC =
-      "List of tables to exclude from copying. If specified, ``table.whitelist`` may not be set. "
-      + "Use a comma-separated list to specify multiple tables "
-      + "(for example, ``table.blacklist: \"User, Address, Email\"``).";
-  public static final String TABLE_BLACKLIST_DEFAULT = "";
+      "Deprecated. Use " + TABLE_EXCLUDE_CONFIG + " instead.";
+  public static final String TABLE_BLACKLIST_DEFAULT = TABLE_EXCLUDE_DEFAULT;
   private static final String TABLE_BLACKLIST_DISPLAY = "Table Blacklist";
 
   public static final String SCHEMA_PATTERN_CONFIG = "schema.pattern";
@@ -429,7 +441,9 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.LONG,
         CONNECTION_URL_DISPLAY,
-        Arrays.asList(TABLE_WHITELIST_CONFIG, TABLE_BLACKLIST_CONFIG)
+        Arrays.asList(
+          TABLE_INCLUDE_CONFIG, TABLE_EXCLUDE_CONFIG,
+          TABLE_WHITELIST_CONFIG, TABLE_BLACKLIST_CONFIG)
     ).define(
         CONNECTION_USER_CONFIG,
         Type.STRING,
@@ -472,20 +486,40 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         Width.SHORT,
         CONNECTION_BACKOFF_DISPLAY
     ).define(
+        TABLE_INCLUDE_CONFIG,
+        Type.LIST,
+        TABLE_INCLUDE_DEFAULT,
+        Importance.MEDIUM,
+        TABLE_INCLUDE_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.LONG,
+        TABLE_INCLUDE_DISPLAY
+    ).define(
         TABLE_WHITELIST_CONFIG,
         Type.LIST,
         TABLE_WHITELIST_DEFAULT,
-        Importance.MEDIUM,
+        Importance.LOW,
         TABLE_WHITELIST_DOC,
         DATABASE_GROUP,
         ++orderInGroup,
         Width.LONG,
         TABLE_WHITELIST_DISPLAY
     ).define(
+        TABLE_EXCLUDE_CONFIG,
+        Type.LIST,
+        TABLE_EXCLUDE_DEFAULT,
+        Importance.MEDIUM,
+        TABLE_EXCLUDE_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.LONG,
+        TABLE_EXCLUDE_DISPLAY
+    ).define(
         TABLE_BLACKLIST_CONFIG,
         Type.LIST,
         TABLE_BLACKLIST_DEFAULT,
-        Importance.MEDIUM,
+        Importance.LOW,
         TABLE_BLACKLIST_DOC,
         DATABASE_GROUP,
         ++orderInGroup,
@@ -795,6 +829,22 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public String topicPrefix() {
     return getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG).trim();
+  }
+
+  public List<String> tableInclude() {
+    List<String> include = getList(JdbcSourceConnectorConfig.TABLE_INCLUDE_CONFIG);
+    if (include.isEmpty()) {
+      include = getList(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG);
+    }
+    return include;
+  }
+
+  public List<String> tableExclude() {
+    List<String> exclude = getList(JdbcSourceConnectorConfig.TABLE_EXCLUDE_CONFIG);
+    if (exclude.isEmpty()) {
+      exclude = getList(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
+    }
+    return exclude;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -246,6 +246,14 @@ public class JdbcSourceConnectorTest {
   public void testConflictingQueryTableSettings() {
     final String sample_query = "SELECT foo, bar FROM sample_table";
     props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
+    props.put(JdbcSourceConnectorConfig.TABLE_INCLUDE_CONFIG, "foo,bar");
+    connector.start(props);
+  }
+
+  @Test(expected = ConnectException.class)
+  public void testConflictingQueryTableSettingsLegacy() {
+    final String sample_query = "SELECT foo, bar FROM sample_table";
+    props.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sample_query);
     props.put(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, "foo,bar");
     connector.start(props);
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -15,8 +15,10 @@
 package io.confluent.connect.jdbc.sink;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import io.confluent.connect.jdbc.util.TableType;
@@ -27,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class JdbcSinkConfigTest {
 
@@ -111,6 +114,20 @@ public class JdbcSinkConfigTest {
     props.put("table.types", "table \t \n");
     createConfig();
     assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void testInclude() {
+    createConfig();
+    assertTrue(config.fieldsInclude.isEmpty());
+
+    props.put(JdbcSinkConfig.FIELDS_WHITELIST, "f1,f2");
+    createConfig();
+    assertEquals(new HashSet<>(Arrays.asList("f1", "f2")), config.fieldsInclude);
+
+    props.put(JdbcSinkConfig.FIELDS_INCLUDE, "f1");
+    createConfig();
+    assertEquals(Collections.singleton("f1"), config.fieldsInclude);
   }
 
   protected void createConfig() {

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -238,7 +238,7 @@ public class FieldsMetadataTest {
   }
 
   @Test
-  public void recordValuePkModeWithPkFieldsAndWhitelistFiltering() {
+  public void recordValuePkModeWithPkFieldsAndFiltering() {
     final Schema valueSchema =
         SchemaBuilder.struct()
             .field("field1", Schema.INT64_SCHEMA)
@@ -311,7 +311,7 @@ public class FieldsMetadataTest {
     return extract(pkMode, pkFields, Collections.<String>emptySet(), keySchema, valueSchema);
   }
 
-  private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Set<String> whitelist, Schema keySchema, Schema valueSchema) {
-    return FieldsMetadata.extract("table", pkMode, pkFields, whitelist, keySchema, valueSchema);
+  private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Set<String> include, Schema keySchema, Schema valueSchema) {
+    return FieldsMetadata.extract("table", pkMode, pkFields, include, keySchema, valueSchema);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -28,6 +28,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -99,8 +100,8 @@ public class JdbcSourceConnectorConfigTest {
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
     // Should have no recommended values
-    assertWhitelistRecommendations();
-    assertBlacklistRecommendations();
+    assertIncludeRecommendations();
+    assertExcludeRecommendations();
   }
 
   @Test
@@ -110,8 +111,8 @@ public class JdbcSourceConnectorConfigTest {
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
     // Should have no recommended values
-    assertWhitelistRecommendations();
-    assertBlacklistRecommendations();
+    assertIncludeRecommendations();
+    assertExcludeRecommendations();
   }
 
   @Test
@@ -121,8 +122,8 @@ public class JdbcSourceConnectorConfigTest {
     props.put(JdbcSourceConnectorConfig.TABLE_TYPE_CONFIG, "VIEW");
     configDef = JdbcSourceConnectorConfig.baseConfigDef();
     results = configDef.validate(props);
-    assertWhitelistRecommendations();
-    assertBlacklistRecommendations();
+    assertIncludeRecommendations();
+    assertExcludeRecommendations();
   }
 
   @SuppressWarnings("unchecked")
@@ -253,6 +254,24 @@ public class JdbcSourceConnectorConfigTest {
     assertFalse(connectionAttemptsConfig.errorMessages().isEmpty());
   }
 
+  @Test
+  public void testIncludeExclude() {
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, "bulk");
+
+    props.put(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, "t1,t2");
+    props.put(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG, "t3,t4");
+    JdbcSourceConnectorConfig config = new JdbcSourceConnectorConfig(props);
+    assertEquals(Arrays.asList("t1", "t2"), config.tableInclude());
+    assertEquals(Arrays.asList("t3", "t4"), config.tableExclude());
+
+    props.put(JdbcSourceConnectorConfig.TABLE_INCLUDE_CONFIG, "t1");
+    props.put(JdbcSourceConnectorConfig.TABLE_EXCLUDE_CONFIG, "t4");
+    config = new JdbcSourceConnectorConfig(props);
+    assertEquals(Arrays.asList("t1"), config.tableInclude());
+    assertEquals(Arrays.asList("t4"), config.tableExclude());
+  }
+
   @SuppressWarnings("unchecked")
   protected <T> void assertContains(Collection<T> actual, T... expected) {
     for (T e : expected) {
@@ -274,12 +293,12 @@ public class JdbcSourceConnectorConfigTest {
   }
 
   @SuppressWarnings("unchecked")
-  protected <T> void assertWhitelistRecommendations(T... recommendedValues) {
-    assertContains(namedValue(results, JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG).recommendedValues(), recommendedValues);
+  protected <T> void assertIncludeRecommendations(T... recommendedValues) {
+    assertContains(namedValue(results, JdbcSourceConnectorConfig.TABLE_INCLUDE_CONFIG).recommendedValues(), recommendedValues);
   }
 
   @SuppressWarnings("unchecked")
-  protected <T> void assertBlacklistRecommendations(T... recommendedValues) {
-    assertContains(namedValue(results, JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG).recommendedValues(), recommendedValues);
+  protected <T> void assertExcludeRecommendations(T... recommendedValues) {
+    assertContains(namedValue(results, JdbcSourceConnectorConfig.TABLE_EXCLUDE_CONFIG).recommendedValues(), recommendedValues);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableMonitorThreadTest.java
@@ -181,11 +181,11 @@ public class TableMonitorThreadTest {
   }
 
   @Test
-  public void testWhitelist() throws Exception {
-    Set<String> whitelist = new HashSet<>(Arrays.asList("foo", "bar"));
+  public void testInclude() throws Exception {
+    Set<String> include = new HashSet<>(Arrays.asList("foo", "bar"));
     EasyMock.expect(dialect.expressionBuilder()).andReturn(ExpressionBuilder.create()).anyTimes();
     tableMonitorThread = new TableMonitorThread(dialect, connectionProvider, context,
-        STARTUP_LIMIT, POLL_INTERVAL, whitelist, null, MockTime.SYSTEM);
+        STARTUP_LIMIT, POLL_INTERVAL, include, null, MockTime.SYSTEM);
     expectTableNames(LIST_FOO_BAR, shutdownThread());
     EasyMock.replay(connectionProvider, dialect);
 
@@ -197,11 +197,11 @@ public class TableMonitorThreadTest {
   }
 
   @Test
-  public void testBlacklist() throws Exception {
-    Set<String> blacklist = new HashSet<>(Arrays.asList("bar", "baz"));
+  public void testExclude() throws Exception {
+    Set<String> exclude = new HashSet<>(Arrays.asList("bar", "baz"));
     EasyMock.expect(dialect.expressionBuilder()).andReturn(ExpressionBuilder.create()).anyTimes();
     tableMonitorThread = new TableMonitorThread(dialect, connectionProvider, context,
-        STARTUP_LIMIT, POLL_INTERVAL, null, blacklist, MockTime.SYSTEM);
+        STARTUP_LIMIT, POLL_INTERVAL, null, exclude, MockTime.SYSTEM);
     expectTableNames(LIST_FOO_BAR_BAZ, shutdownThread());
     EasyMock.replay(connectionProvider, dialect);
 
@@ -281,11 +281,11 @@ public class TableMonitorThreadTest {
   }
 
   @Test
-  public void testDuplicateWithUnqualifiedWhitelist() throws Exception {
-    Set<String> whitelist = new HashSet<>(Arrays.asList("dup"));
+  public void testDuplicateWithUnqualifiedInclude() throws Exception {
+    Set<String> include = new HashSet<>(Arrays.asList("dup"));
     EasyMock.expect(dialect.expressionBuilder()).andReturn(ExpressionBuilder.create()).anyTimes();
     tableMonitorThread = new TableMonitorThread(dialect, connectionProvider, context,
-        STARTUP_LIMIT, POLL_INTERVAL, whitelist, null, MockTime.SYSTEM);
+        STARTUP_LIMIT, POLL_INTERVAL, include, null, MockTime.SYSTEM);
     expectTableNames(LIST_DUP_ONLY, shutdownThread());
     context.requestTaskReconfiguration();
     EasyMock.expectLastCall();
@@ -300,11 +300,11 @@ public class TableMonitorThreadTest {
   }
 
   @Test
-  public void testDuplicateWithUnqualifiedBlacklist() throws Exception {
-    Set<String> blacklist = new HashSet<>(Arrays.asList("foo"));
+  public void testDuplicateWithUnqualifiedExclude() throws Exception {
+    Set<String> exclude = new HashSet<>(Arrays.asList("foo"));
     EasyMock.expect(dialect.expressionBuilder()).andReturn(ExpressionBuilder.create()).anyTimes();
     tableMonitorThread = new TableMonitorThread(dialect, connectionProvider, context,
-        STARTUP_LIMIT, POLL_INTERVAL, null, blacklist, MockTime.SYSTEM);
+        STARTUP_LIMIT, POLL_INTERVAL, null, exclude, MockTime.SYSTEM);
     expectTableNames(LIST_DUP_WITH_ALL, shutdownThread());
     context.requestTaskReconfiguration();
     EasyMock.expectLastCall();
@@ -319,11 +319,11 @@ public class TableMonitorThreadTest {
   }
 
   @Test
-  public void testDuplicateWithQualifiedWhitelist() throws Exception {
-    Set<String> whitelist = new HashSet<>(Arrays.asList("dup1.dup", "foo"));
+  public void testDuplicateWithQualifiedInclude() throws Exception {
+    Set<String> include = new HashSet<>(Arrays.asList("dup1.dup", "foo"));
     EasyMock.expect(dialect.expressionBuilder()).andReturn(ExpressionBuilder.create()).anyTimes();
     tableMonitorThread = new TableMonitorThread(dialect, connectionProvider, context,
-        STARTUP_LIMIT, POLL_INTERVAL, whitelist, null, MockTime.SYSTEM);
+        STARTUP_LIMIT, POLL_INTERVAL, include, null, MockTime.SYSTEM);
     expectTableNames(LIST_DUP_WITH_ALL, shutdownThread());
     EasyMock.replay(connectionProvider, dialect);
 
@@ -334,11 +334,11 @@ public class TableMonitorThreadTest {
   }
 
   @Test
-  public void testDuplicateWithQualifiedBlacklist() throws Exception {
-    Set<String> blacklist = new HashSet<>(Arrays.asList("dup1.dup", "foo"));
+  public void testDuplicateWithQualifiedExclude() throws Exception {
+    Set<String> exclude = new HashSet<>(Arrays.asList("dup1.dup", "foo"));
     EasyMock.expect(dialect.expressionBuilder()).andReturn(ExpressionBuilder.create()).anyTimes();
     tableMonitorThread = new TableMonitorThread(dialect, connectionProvider, context,
-        STARTUP_LIMIT, POLL_INTERVAL, null, blacklist, MockTime.SYSTEM);
+        STARTUP_LIMIT, POLL_INTERVAL, null, exclude, MockTime.SYSTEM);
     expectTableNames(LIST_DUP_WITH_ALL, shutdownThread());
     EasyMock.replay(connectionProvider, dialect);
 

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/MSSQLDateTimeIT.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECTION_PASSWORD_CONFIG;
-import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG;
+import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TABLE_INCLUDE_CONFIG;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.MODE_CONFIG;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.MODE_TIMESTAMP;
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING;
@@ -254,7 +254,7 @@ public class MSSQLDateTimeIT extends BaseConnectorIT {
         props.put(CONNECTION_URL_CONFIG, MSSQL_URL);
         props.put(CONNECTION_USER_CONFIG, "sa");
         props.put(CONNECTION_PASSWORD_CONFIG, "reallyStrongPwd123");
-        props.put(TABLE_WHITELIST_CONFIG, MSSQL_Table);
+        props.put(TABLE_INCLUDE_CONFIG, MSSQL_Table);
         props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "start_time");
         props.put(TOPIC_PREFIX_CONFIG, "test-");
         props.put(POLL_INTERVAL_MS_CONFIG, "30");


### PR DESCRIPTION
## Problem
Some configurations and many variables throughout the code base use racially charged terms.

## Solution
- Introduce new configurations. Existing configurations using racially charged terms are marked as deprecated.
- Update variables to use racially neutral terms only.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
N/A


## Test Strategy
Updated existing tests + added some new for logic handling new configurations.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests: 
I tried running them but they all fail:
```
[ERROR] io.confluent.connect.jdbc.source.integration.MySQLOOMIT.testStreamingReads  Time elapsed: 0.902 s  <<< ERROR!
ch.vorburger.exec.ManagedProcessException: An error occurred while installing the database
[ERROR] io.confluent.connect.jdbc.source.integration.PostgresOOMIT.testTableLocksWithStreamingReads  Time elapsed: 0.154 s  <<< ERROR!
java.lang.IllegalStateException: Process [/var/folders/6f/c4r3kvwd76l9c0k_59qzh_r00000gn/T/embedded-pg/PG-2c0c4f55a015ab253337e3d05ca5fd21/bin/initdb, -A, trust, -U, postgres, -D, /var/folders/6f/c4r3kvwd76l9c0k_59qzh_r00000gn/T/epg3642288202649490811, -E, UTF-8] failed
[ERROR] io.confluent.connect.jdbc.source.integration.PostgresOOMIT.testStreamingReads  Time elapsed: 0.011 s  <<< ERROR!
java.lang.IllegalStateException: Process [/var/folders/6f/c4r3kvwd76l9c0k_59qzh_r00000gn/T/embedded-pg/PG-2c0c4f55a015ab253337e3d05ca5fd21/bin/initdb, -A, trust, -U, postgres, -D, /var/folders/6f/c4r3kvwd76l9c0k_59qzh_r00000gn/T/epg8522825206449835467, -E, UTF-8] failed
```
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
