### PR TITLE
RCCA 7749 Use national character methods for unicode strings

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -15,14 +15,18 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.ThreadLocalRandom;
 
+import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.ColumnId;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -38,6 +42,10 @@ import io.confluent.connect.jdbc.util.TableId;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatabaseDialect> {
 
@@ -412,5 +420,32 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
         "jdbc:sqlserver://;password=****;servername=server_name;keyStoreSecret=****;"
         + "gsscredential=****;integratedSecurity=true;authenticationScheme=JavaKerberos"
     );
+  }
+
+  @Test
+  public void shouldBindStringAccordingToColumnDef() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    String value = "random text";
+    Schema schema = Schema.STRING_SCHEMA;
+    PreparedStatement stmtVarchar = mock(PreparedStatement.class);
+    ColumnDefinition colDefVarchar = mock(ColumnDefinition.class);
+    when(colDefVarchar.type()).thenReturn(Types.VARCHAR);
+
+    PreparedStatement stmtNchar = mock(PreparedStatement.class);
+    ColumnDefinition colDefNchar = mock(ColumnDefinition.class);
+    when(colDefNchar.type()).thenReturn(Types.NCHAR);
+
+    PreparedStatement stmtNvarchar = mock(PreparedStatement.class);
+    ColumnDefinition colDefNvarchar = mock(ColumnDefinition.class);
+    when(colDefNvarchar.type()).thenReturn(Types.NVARCHAR);
+
+    dialect.bindField(stmtVarchar, index, schema, value, colDefVarchar);
+    verify(stmtVarchar, times(1)).setString(index, value);
+
+    dialect.bindField(stmtNchar, index, schema, value, colDefNchar);
+    verify(stmtNchar, times(1)).setNString(index, value);
+
+    dialect.bindField(stmtNvarchar, index, schema, value, colDefNvarchar);
+    verify(stmtNvarchar, times(1)).setNString(index, value);
   }
 }


### PR DESCRIPTION
## Problem
The JDBC sink connector when used with SqlServer, observes performance degradation due to passing of string query parameters in unicode format. 

## Solution
The recommended approach is to use `setStringParametersAsUnicode=false` when using non-unicode data types such as CHAR, VARCHAR, LONGVARCHAR JDBC types.
However, if unicode data types such as NCHAR, NVARCHAR, LONGNVARCHAR are used, the application should use national character methods such as setNString, setNCharacterStream etc. Otherwise, it could lead to data loss.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
