### PR TITLE
CCDB-5069: Fix data loss in timestamp mode due to in-mem offsets

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -98,6 +98,8 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       resultSet = executeQuery();
       String schemaName = tableId != null ? tableId.tableName() : null; // backwards compatible
       schemaMapping = SchemaMapping.create(schemaName, resultSet.getMetaData(), dialect);
+    } else {
+      log.trace("Current ResultSet {} isn't null. Continuing to seek.", resultSet.hashCode());
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -162,12 +162,15 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
       ResultSetMetaData metadata = resultSet.getMetaData();
       dialect.validateSpecificColumnTypes(metadata, timestampColumns);
       schemaMapping = SchemaMapping.create(schemaName, metadata, dialect);
+    } else {
+      log.trace("Current ResultSet {} isn't null. Continuing to seek.", resultSet.hashCode());
     }
 
     // This is called everytime during poll() before extracting records,
     // to ensure that the previous run succeeded, allowing us to move the committedOffset forward.
     // This action is a no-op for the first poll()
     this.committedOffset = this.offset;
+    log.trace("Set the committed offset: {}", committedOffset.getTimestampOffset());
   }
 
   private void findDefaultAutoIncrementingColumn(Connection db) throws SQLException {

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -128,9 +128,9 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
     if (nextRecord == null
         || canCommitTimestamp(currentRecord.timestamp(), nextRecord.timestamp())) {
       latestCommittableTimestamp = currentRecord.timestamp();
+      // set current in memory offset to the latestCommittableTimestamp
+      this.offset = new TimestampIncrementingOffset(latestCommittableTimestamp, null);
     }
-    // set current in memory offset to the latestCommittableTimestamp
-    this.offset = new TimestampIncrementingOffset(latestCommittableTimestamp, null);
     return currentRecord.record(offset);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -131,7 +131,7 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
     }
     // set current in memory offset to the latestCommittableTimestamp
     this.offset = new TimestampIncrementingOffset(latestCommittableTimestamp, null);
-    return currentRecord.record(latestCommittableTimestamp);
+    return currentRecord.record(offset);
   }
 
   private PendingRecord doExtractRecord() {
@@ -153,7 +153,9 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
         record,
         offset
     );
-    Timestamp timestamp = timestampOffset.hasTimestampOffset() ? timestampOffset.getTimestampOffset() : null;
+    Timestamp timestamp = timestampOffset.hasTimestampOffset()
+                          ? timestampOffset.getTimestampOffset()
+                          : null;
     return new PendingRecord(partition, timestamp, topic, record.schema(), record);
   }
 
@@ -206,11 +208,10 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
     }
 
     /**
-     * @param offsetTimestamp the timestamp to use for the record's offset; may be null
+     * @param offset offset with timestamp to use for the record's offset; may be null
      * @return a {@link SourceRecord} whose source offset contains the provided timestamp
      */
-    public SourceRecord record(Timestamp offsetTimestamp) {
-      TimestampIncrementingOffset offset = new TimestampIncrementingOffset(offsetTimestamp, null);
+    public SourceRecord record(TimestampIncrementingOffset offset) {
       return new SourceRecord(
           partition, offset.toMap(), topic, valueSchema, value
       );

--- a/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/EmbeddedDerby.java
@@ -65,6 +65,10 @@ public class EmbeddedDerby {
     // some reason), but it's easier to just always do this
     new EmbeddedDriver();
     // And initialize by creating a connection
+    connect();
+  }
+
+  public void connect() {
     try {
       conn = DriverManager.getConnection(getUrl());
     } catch (SQLException e) {

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -922,14 +922,14 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     // close the derby DB
     db.close();
 
-    // assert failure by empty response
+    // assert exception by empty response
     List<SourceRecord> records = task.poll();
     assertNull(records);
 
     // reconn
     db.connect();
 
-    // last polled timestamp is 13, poll for records >12, hence repeat of 5
+    // last committed timestamp is 11, poll for records >11, hence repeat of 4
     verifyPoll(3, "id", Arrays.asList(4, 5, 6), true, false, false, TOPIC_PREFIX);
 
     PowerMock.verifyAll();
@@ -944,7 +944,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
   }
 
   private void startTask(String timestampColumn, String incrementingColumn, String query, Long delay, String timeZone) {
-    startTask(timestampColumn, incrementingColumn, query, delay, timeZone, null,null);
+    startTask(timestampColumn, incrementingColumn, query, delay, timeZone, null, null);
   }
 
   private void startTask(String timestampColumn, String incrementingColumn, String query, Long delay, String timeZone, Long timestampInitial) {

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -908,24 +908,16 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
         "user_id", 2);
 
     db.insert(SINGLE_TABLE_NAME,
-        "modified", DateTimeUtils.formatTimestamp(new Timestamp(13L), UTC_TIME_ZONE),
+        "modified", DateTimeUtils.formatTimestamp(new Timestamp(12L), UTC_TIME_ZONE),
         "id", 5,
         "user_id", 2);
 
-    verifyPoll(3, "id", Arrays.asList(2, 3, 4), true, false, false, TOPIC_PREFIX);
-
-    // Repeated timestamp
     db.insert(SINGLE_TABLE_NAME,
         "modified", DateTimeUtils.formatTimestamp(new Timestamp(13L), UTC_TIME_ZONE),
         "id", 6,
         "user_id", 2);
 
-
-    db.insert(SINGLE_TABLE_NAME,
-        "modified", DateTimeUtils.formatTimestamp(new Timestamp(14L), UTC_TIME_ZONE),
-        "id", 7,
-        "user_id", 2);
-
+    verifyPoll(3, "id", Arrays.asList(2, 3, 5), true, false, false, TOPIC_PREFIX);
 
     // close the derby DB
     db.close();
@@ -938,7 +930,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     db.connect();
 
     // last polled timestamp is 13, poll for records >12, hence repeat of 5
-    verifyPoll(3, "id", Arrays.asList(5, 6, 7), true, false, false, TOPIC_PREFIX);
+    verifyPoll(3, "id", Arrays.asList(4, 5, 6), true, false, false, TOPIC_PREFIX);
 
     PowerMock.verifyAll();
   }
@@ -1148,7 +1140,7 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
       Timestamp timestampValue = (Timestamp) ((Struct)record.value()).get("modified");
       Timestamp offsetValue = TimestampIncrementingOffset.fromMap(record.sourceOffset()).getTimestampOffset();
       assertTrue(
-          String.format("Invalid timestamp: {} and offset{} combination.", timestampValue,
+          String.format("Invalid timestamp {} and offset {} combination.", timestampValue,
               offsetValue),
           timestampValue.compareTo(offsetValue) >= 0
       );


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CCDB-5069

## Problem

#1093 provided a fix to avoid data loss, in Timestamp Query mode, when we have multiple rows with the same timestamp in the DB if the connector is shut down after reading at least one such row but before reading all of them. This fix however failed to capture the case in-memory offsets that are used when the connector faces a connectivity error and goes into a retry when the DB has a network partition.

Going back to the example used in #1093 -- if the connector's current timestamp is T0 and it then reads five rows from the current query with timestamps R1(T1), R2(T1), R3(T2), R4(T2), and R5(T3), the records it produces will have timestamps of T0, T1, T1, T2, and T3, respectively. In this case, if the connector sees a transient `SQLException` while seeking, records, say while trying to read R4(T2). We would've flushed an offset of `T1` but we store `T2` as the committed offset in memory. This leads to us missing R4(T2), as we start the next iteration from T3 hence reading R5(T3).

## Solution

The solution here was straightforward, we make sure to keep the offsets in-memory sync with the offsets we have flushed. Note, this would surely lead to data duplication as we re-pross the records having timestamp >T1, i.e. we see R3(T1) twice, but still, adhere to at-least-once semantics. All the other limitations discussed with timestamp mode still hold.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

TODO: Add a test case to replicate the issue.

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Target this to `5.0.x` branch and forward merge to all the branches till master