### PR TITLE
support regex replacement for sink table naming

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -30,6 +30,8 @@ import io.confluent.connect.jdbc.util.TableId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.confluent.connect.jdbc.util.NameUtils.toTableName;
+
 public class JdbcDbWriter {
   private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
 
@@ -97,7 +99,7 @@ public class JdbcDbWriter {
   }
 
   TableId destinationTable(String topic) {
-    final String tableName = config.tableNameFormat.replace("${topic}", topic);
+    final String tableName = toTableName(config.tableNameFormat, topic);
     if (tableName.isEmpty()) {
       throw new ConnectException(String.format(
           "Destination table name for topic '%s' is empty using the format string '%s'",

--- a/src/main/java/io/confluent/connect/jdbc/util/NameUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/NameUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+public class NameUtils {
+
+  private static final String TOPIC_PREFIX = "${topic";
+  private static final String TOPIC_POSTFIX = "}";
+
+  public static String toTableName(String rawName, String topic) {
+    int topicStartPos = rawName.indexOf(TOPIC_PREFIX);
+    int topicEndPos = rawName.lastIndexOf(TOPIC_POSTFIX);
+    if (topicStartPos >= 0) {
+      if (topicEndPos == topicStartPos + TOPIC_PREFIX.length()) {
+        return rawName.replace(TOPIC_PREFIX + TOPIC_POSTFIX, topic);
+      } else if (topicEndPos > topicStartPos + TOPIC_PREFIX.length()) {
+        int subStartPos = topicStartPos + TOPIC_PREFIX.length() + 1;
+        String splitter = rawName.substring(subStartPos - 1, subStartPos);
+        int subMidPos = rawName.indexOf(splitter, subStartPos);
+        int subEndPos = rawName.indexOf(splitter, subMidPos + 1);
+        if (subMidPos > 0 && subEndPos > 0) {
+          return rawName.substring(0, topicStartPos)
+            + topic.replaceAll(rawName.substring(subStartPos, subMidPos),
+                            rawName.substring(subMidPos + 1, subEndPos))
+            + rawName.substring(topicEndPos + 1);
+        }
+      }
+    }
+    return rawName;
+  }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/NameUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/NameUtilsTest.java
@@ -1,0 +1,25 @@
+package io.confluent.connect.jdbc.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NameUtilsTest {
+
+  @Test
+  public void testToTableName() {
+    // No replacement
+    assertEquals("kafka_connect",
+            NameUtils.toTableName("kafka_connect", "anything"));
+    // Replace topic name
+    assertEquals("kafka_connect",
+            NameUtils.toTableName("${topic}", "kafka_connect"));
+    assertEquals("pre_kafka_connect_post",
+            NameUtils.toTableName("pre_${topic}_post", "kafka_connect"));
+    // Replace topic name with regex
+    assertEquals("pre_kafka_connect_post",
+            NameUtils.toTableName("${topic/^.+\\.ao_/pre_/}_post", "io.confluent.connect.jdbc.ao_kafka_connect"));
+    assertEquals("pre_kafka_connect_post",
+            NameUtils.toTableName("pre_${topic#^.+\\.ao_##}_post", "io.confluent.connect.jdbc.ao_kafka_connect"));
+  }
+}


### PR DESCRIPTION
## Problem

Currently this jdbc connect can only sink data to a table with fixed name or use the whole topic name as part of the table name, but in many cases, people may need a more flexible way to named their target tables.

For example, while using debezium source connect, the kafka topic would be named in a format of `<server-id>.<source-database>.<source-table>`, which is not suitable to be use as part of the sink table name.

## Solution

One of the most flexible way for user to specify a table naming rule is **regular expression replacement**, which mean take the kafka topic name and modify it via a regular expression before put it into the final sink table name.

In this PR, an expression of ${topic/**Pattern**/**Replacement**/} is supported for advanced sink table naming. This expression format is inspired by `sed` and `bash`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?

`bash` support a very similar variable value replacement format as ${var/Pattern/Replacement}, and `sed` support a more regular expression friendly replacement format as '/Pattern/Replacement/', while the char `/` can be substitute by any other symbol such as '#'.

## Test Strategy

Unit test case is included in this PR.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
