### PR TITLE
Update to handling of large records

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -141,7 +141,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
 
     if (schema.type() == Type.STRING) {
       if (colDef.type() == Types.CLOB) {
-        statement.setCharacterStream(index, new StringReader((String) value));
+        statement.setCharacterStream(index, new StringReader((String) value),((String) value).length());
         return true;
       } else if (colDef.type() == Types.NCLOB) {
         statement.setNCharacterStream(index, new StringReader((String) value));


### PR DESCRIPTION
Oracle internally will handle records dynamically based on record size when passed the length in the setCharacterStream method. By doing this, customers on higher latency connections(>300ms round trip) and with record sizes that may vary above or below the varchar2(4000) limit experience a magnitude improvement in larger records. Additionally, small records on both higher latency and lower latency connections both with and without security and compression options enabled experience roughly the same performance as without this change.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
