### PR TITLE
Replacing \u0000 with nothing for PostgreSqlDatabaseDialect

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -449,6 +449,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   ) throws SQLException {
 
     switch (schema.type()) {
+      case STRING: {
+        String newValue = ((String) value).replace("\u0000", "");
+        statement.setString(index, newValue);
+        return true;
+      }
       case ARRAY: {
         Class<?> valueClass = value.getClass();
         Object newValue = null;

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -463,6 +463,13 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
+  public void bindFieldStringValueWithNulls() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.STRING_SCHEMA, "y\u0000ep\u0000\u0000").setString(index, "yep");
+    verifyBindField(++index, Schema.STRING_SCHEMA, null).setObject(index, null);
+  }
+
+  @Test
   public void shouldGracefullyHandleErrorWhenComputingMaxTableNameLength() throws Exception {
     Statement statement = mock(Statement.class);
     when(statement.executeQuery("SELECT length(repeat('1234567890', 1000)::NAME);"))


### PR DESCRIPTION
## Problem

\u0000 UFT character is not supported by Postgres text field. An attempt to insert fails with error:

`org.postgresql.util.PSQLException:` ERROR: invalid byte sequence for encoding "UTF8": 0x00`

## Solution

We are replacing \u0000 character with nothing

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
