### PR TITLE
CCDB-5222: For JDBC Sink connector; removing sensitive data from BatchUpdateException.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import io.confluent.connect.jdbc.util.LogUtil;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -93,7 +94,7 @@ public class JdbcSinkTask extends SinkTask {
           "Write of {} records failed, remainingRetries={}",
           records.size(),
           remainingRetries,
-          sqle
+          LogUtil.trimSensitiveData(sqle)
       );
       int totalExceptions = 0;
       for (Throwable e :sqle) {
@@ -117,7 +118,7 @@ public class JdbcSinkTask extends SinkTask {
               totalExceptions);
           int exceptionCount = 1;
           for (Throwable e : sqle) {
-            log.debug("Exception {}:", exceptionCount++, e);
+            log.debug("Exception {}:", exceptionCount++, LogUtil.trimSensitiveData(e));
           }
           throw new ConnectException(sqlAllMessagesException);
         }
@@ -145,10 +146,10 @@ public class JdbcSinkTask extends SinkTask {
   private SQLException getAllMessagesException(SQLException sqle) {
     String sqleAllMessages = "Exception chain:" + System.lineSeparator();
     for (Throwable e : sqle) {
-      sqleAllMessages += e + System.lineSeparator();
+      sqleAllMessages += LogUtil.trimSensitiveData(e) + System.lineSeparator();
     }
     SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
-    sqlAllMessagesException.setNextException(sqle);
+    sqlAllMessagesException.setNextException(LogUtil.trimSensitiveData(sqle));
     return sqlAllMessagesException;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.sql.BatchUpdateException;
+import java.sql.SQLException;
+
+/**
+ * A stop-gap utility class to find a tradeoff between 2 things: To have reasonably good exception/
+ * error information to investigate incidents while at the same time avoid logging sensitive data.
+ */
+public class LogUtil {
+  public static SQLException trimSensitiveData(SQLException e) {
+    return (SQLException) trimSensitiveData((Throwable)e);
+  }
+
+  public static Throwable trimSensitiveData(Throwable t) {
+    if (!(t instanceof SQLException)) {
+      // t is not a SQLException; return as-is.
+      // This is also the recursion termination condition i.e. when t is null.
+      return t;
+    }
+
+    if (!(t instanceof BatchUpdateException)) {
+      // t is a SQLException, but not BatchUpdateException.
+      SQLException oldSqe = (SQLException)t;
+      SQLException newSqe = new SQLException(oldSqe.getLocalizedMessage());
+      newSqe.setNextException(trimSensitiveData(oldSqe.getNextException()));
+      return newSqe;
+    }
+
+    // At this point t is BatchUpdateException; return a new trimmed version of it.
+    BatchUpdateException e = (BatchUpdateException)t;
+    return new BatchUpdateException(getNonSensitiveErrorMessage(e.getLocalizedMessage()),
+        e.getUpdateCounts());
+  }
+
+  // This implementation assumes it to be Postgres, see toString() of ServerErrorMessage.java
+  // as well as the constructor of PSQLException.java with "boolean detail" flag in
+  // https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/util/
+  // For other JDBC Databases it would not fail but might return the same input string back!
+  private static String getNonSensitiveErrorMessage(String errMsg) {
+    final String sensitiveStartSearchText = ") VALUES (";
+    final String errorStartSearchText = ": ERROR: ";
+    final String errorEndSearchText = "\n  Detail: ";
+
+    if (errMsg == null) {
+      return null;
+    }
+
+    final int trimStartIdx = 0;
+    final int trimEndIdx = errMsg.indexOf(sensitiveStartSearchText);
+    if (trimEndIdx < 0) {
+      return errMsg;
+    }
+
+    String msg1 = errMsg.substring(trimStartIdx, trimEndIdx + 1);
+
+    int errorStartIdx = errMsg.indexOf(errorStartSearchText);
+    int errorEndIdx = errMsg.indexOf(errorEndSearchText);
+    if (errorStartIdx < trimEndIdx || errorEndIdx < trimEndIdx
+            || errorEndIdx < errorStartIdx) {
+      return msg1;
+    }
+
+    String msg2 = errMsg.substring(errorStartIdx, errorEndIdx);
+    return msg1 + msg2;
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.sql.BatchUpdateException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class LogUtilTest {
+
+  @Test
+  public void testNonSqlThrowable() {
+    Throwable t = new Throwable("t");
+    assertEquals(t, LogUtil.trimSensitiveData(t));
+  }
+
+  @Test
+  public void testSqlExceptionNoNested() {
+    SQLException e = new SQLException("e");
+    SQLException trimmed = LogUtil.trimSensitiveData(e);
+    assertEqualsSQLException(e, trimmed);
+  }
+
+  @Test
+  public void testSqlExceptionOneLevelNestedNonBatchUpdate() {
+    SQLException e1 = new SQLException("e1");
+    SQLException e2 = new SQLException("e2");
+    e1.setNextException(e2);
+
+    SQLException trimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(e1, trimmed);
+  }
+
+  @Test
+  public void testSqlExceptionTwoLevelNestedNonBatchUpdate() {
+    SQLException e1 = new SQLException("e1");
+    SQLException e2 = new SQLException("e2");
+    SQLException e3 = new SQLException("e3");
+    e1.setNextException(e2);
+    e2.setNextException(e3);
+
+    SQLException trimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(e1, trimmed);
+  }
+
+  @Test
+  public void testFirstLevelBatchUpdateNoSensitive() {
+    BatchUpdateException e1 = new BatchUpdateException("Hello World", new int[0]);
+    SQLException trimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(e1, trimmed);
+  }
+
+  @Test
+  public void testFirstLevelBatchUpdateSensitive() {
+    BatchUpdateException e1 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
+            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
+            new int[0]);
+
+    BatchUpdateException expectedTrimmed = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\"): " +
+            "ERROR: null value in column \"c4\" violates not-null constraint",
+            new int[0]);
+
+    SQLException actualTrimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(expectedTrimmed, actualTrimmed);
+  }
+
+  @Test
+  public void testSecondLevelNestedBatchUpdateNoSensitive() {
+    SQLException e1 = new SQLException("e1");
+    BatchUpdateException e2 = new BatchUpdateException("Hello World", new int[0]);
+    e1.setNextException(e2);
+
+    SQLException trimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(e1, trimmed);
+  }
+
+  @Test
+  public void testSecondLevelNestedBatchUpdateSensitive() {
+    SQLException e1 = new SQLException("e1");
+    BatchUpdateException e2 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
+            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
+            new int[0]);
+    e1.setNextException(e2);
+
+    SQLException expectedTrimmed = new SQLException("e1");
+    BatchUpdateException e3 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\"): " +
+            "ERROR: null value in column \"c4\" violates not-null constraint",
+            new int[0]);
+    expectedTrimmed.setNextException(e3);
+
+    SQLException actualTrimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(expectedTrimmed, actualTrimmed);
+  }
+
+  @Test
+  public void testSecondLevelNestedBatchUpdateSensitiveNoError() {
+    SQLException e1 = new SQLException("e1");
+    BatchUpdateException e2 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted.",
+            new int[0]);
+    e1.setNextException(e2);
+
+    SQLException expectedTrimmed = new SQLException("e1");
+    BatchUpdateException e3 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\")",
+            new int[0]);
+    expectedTrimmed.setNextException(e3);
+
+    SQLException actualTrimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(expectedTrimmed, actualTrimmed);
+  }
+
+  @Test
+  public void testSecondLevelNestedBatchUpdateSensitiveNoDetails() {
+    SQLException e1 = new SQLException("e1");
+    BatchUpdateException e2 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint.",
+            new int[0]);
+    e1.setNextException(e2);
+
+    SQLException expectedTrimmed = new SQLException("e1");
+    BatchUpdateException e3 = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\")",
+            new int[0]);
+    expectedTrimmed.setNextException(e3);
+
+    SQLException actualTrimmed = LogUtil.trimSensitiveData(e1);
+    assertEqualsSQLException(expectedTrimmed, actualTrimmed);
+  }
+
+  private static void assertEqualsSQLException(SQLException expected, SQLException actual) {
+    if (expected == actual) {
+      return;
+    }
+
+    if (expected == null || actual == null) {
+      Assert.assertSame(expected, actual);
+    }
+
+    Assert.assertEquals(expected.getClass(), actual.getClass());
+
+    String msg1 = (expected.getLocalizedMessage() == null ? "" : expected.getLocalizedMessage());
+    String msg2 = (actual.getLocalizedMessage() == null ? "" : actual.getLocalizedMessage());
+    Assert.assertEquals(msg1, msg2);
+
+    assertEqualsSQLException(expected.getNextException(), actual.getNextException());
+  }
+}


### PR DESCRIPTION
## Problem
For PostgresDB; a BatchUpdateException might contain sensitive data.

## Solution
Trimming the sensitive data off BatchUpdateException.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
NA

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests