### PR TITLE
[MINOR] Fix sensitive data trimming from exceptions

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -90,11 +90,12 @@ public class JdbcSinkTask extends SinkTask {
         throw tace;
       }
     } catch (SQLException sqle) {
+      SQLException trimmedException = LogUtil.trimSensitiveData(sqle);
       log.warn(
           "Write of {} records failed, remainingRetries={}",
           records.size(),
           remainingRetries,
-          LogUtil.trimSensitiveData(sqle)
+          trimmedException
       );
       int totalExceptions = 0;
       for (Throwable e :sqle) {
@@ -117,7 +118,7 @@ public class JdbcSinkTask extends SinkTask {
                   + "For complete details on each exception, please enable DEBUG logging.",
               totalExceptions);
           int exceptionCount = 1;
-          for (Throwable e : sqle) {
+          for (Throwable e : trimmedException) {
             log.debug("Exception {}:", exceptionCount++, LogUtil.trimSensitiveData(e));
           }
           throw new ConnectException(sqlAllMessagesException);
@@ -145,11 +146,12 @@ public class JdbcSinkTask extends SinkTask {
 
   private SQLException getAllMessagesException(SQLException sqle) {
     String sqleAllMessages = "Exception chain:" + System.lineSeparator();
-    for (Throwable e : sqle) {
-      sqleAllMessages += LogUtil.trimSensitiveData(e) + System.lineSeparator();
+    SQLException trimmedException = LogUtil.trimSensitiveData(sqle);
+    for (Throwable e : trimmedException) {
+      sqleAllMessages += e + System.lineSeparator();
     }
     SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
-    sqlAllMessagesException.setNextException(LogUtil.trimSensitiveData(sqle));
+    sqlAllMessagesException.setNextException(trimmedException);
     return sqlAllMessagesException;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -119,7 +119,7 @@ public class JdbcSinkTask extends SinkTask {
               totalExceptions);
           int exceptionCount = 1;
           for (Throwable e : trimmedException) {
-            log.debug("Exception {}:", exceptionCount++, LogUtil.trimSensitiveData(e));
+            log.debug("Exception {}:", exceptionCount++, e);
           }
           throw new ConnectException(sqlAllMessagesException);
         }

--- a/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
@@ -167,6 +167,7 @@ public class LogUtilTest {
     SQLException actualTrimmed = LogUtil.trimSensitiveData(e1);
     assertEqualsSQLException(expectedTrimmed, actualTrimmed);
   }
+
   private static void assertEqualsSQLException(SQLException expected, SQLException actual) {
     if (expected == actual) {
       return;

--- a/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
@@ -167,8 +167,6 @@ public class LogUtilTest {
     SQLException actualTrimmed = LogUtil.trimSensitiveData(e1);
     assertEqualsSQLException(expectedTrimmed, actualTrimmed);
   }
-
-
   private static void assertEqualsSQLException(SQLException expected, SQLException actual) {
     if (expected == actual) {
       return;


### PR DESCRIPTION
## Problem

#1266 added a feature to trim sensitive data, but it missed hadling individual exceptions and only handled Nested

## Solution

Trim sensitive data before iterating over the individual exceptions


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
