### PR TITLE
Query timeout

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,5 +22,5 @@
               files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
 
     <suppress checks="ParameterNumber"
-              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|TimestampIncrementingTableQuerier).java"/>
+              files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect|TimestampIncrementingTableQuerier|TimestampTableQuerier).java"/>
 </suppressions>

--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -44,9 +44,10 @@ public class BulkTableQuerier extends TableQuerier {
       QueryMode mode,
       String name,
       String topicPrefix,
-      String suffix
+      String suffix,
+      int queryTimeout
   ) {
-    super(dialect, mode, name, topicPrefix, suffix);
+    super(dialect, mode, name, topicPrefix, suffix, queryTimeout);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -366,6 +366,13 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                   + "  * SERIALIZABLE\n"
                   + "  * SQL_SERVER_SNAPSHOT\n";
   private static final String TRANSACTION_ISOLATION_MODE_DISPLAY = "Transaction Isolation Mode";
+  
+  public static final String QUERY_TIMEOUT_S_CONFIG = "query.timeout";
+  public static final int QUERY_TIMEOUT_S_DEFAULT = 0;
+  public static final String QUERY_TIMEOUT_S_DOC = 
+      "Query timeout in seconds."
+      + "For backward compatibility, the default is 0. 0 means there is no timeout";
+  private static final String QUERY_TIMEOUT_S_DISPLAY = "Query timeout (s)";
 
   private static final EnumRecommender TRANSACTION_ISOLATION_MODE_RECOMMENDER =
           EnumRecommender.in(TransactionIsolationMode.values());
@@ -669,6 +676,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         QUERY_RETRIES_DISPLAY
+    ).define(
+        QUERY_TIMEOUT_S_CONFIG,
+        Type.INT,
+        QUERY_TIMEOUT_S_DEFAULT,
+        Importance.LOW,
+        QUERY_TIMEOUT_S_DOC,
+        MODE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        QUERY_TIMEOUT_S_DISPLAY
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -230,6 +230,8 @@ public class JdbcSourceTask extends SourceTask {
       String topicPrefix = config.topicPrefix();
       JdbcSourceConnectorConfig.TimestampGranularity timestampGranularity
           = JdbcSourceConnectorConfig.TimestampGranularity.get(config);
+      
+      int queryTimeout = config.getInt(JdbcSourceTaskConfig.QUERY_TIMEOUT_S_CONFIG);
 
       if (mode.equals(JdbcSourceTaskConfig.MODE_BULK)) {
         tableQueue.add(
@@ -238,7 +240,8 @@ public class JdbcSourceTask extends SourceTask {
                 queryMode, 
                 tableOrQuery, 
                 topicPrefix, 
-                suffix
+                suffix,
+                queryTimeout
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_INCREMENTING)) {
@@ -254,7 +257,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampDelayInterval,
                 timeZone,
                 suffix,
-                timestampGranularity
+                timestampGranularity,
+                queryTimeout
             )
         );
       } else if (mode.equals(JdbcSourceTaskConfig.MODE_TIMESTAMP)) {
@@ -269,7 +273,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampDelayInterval,
                 timeZone,
                 suffix,
-                timestampGranularity
+                timestampGranularity,
+                queryTimeout
             )
         );
       } else if (mode.endsWith(JdbcSourceTaskConfig.MODE_TIMESTAMP_INCREMENTING)) {
@@ -285,7 +290,8 @@ public class JdbcSourceTask extends SourceTask {
                 timestampDelayInterval,
                 timeZone,
                 suffix,
-                timestampGranularity
+                timestampGranularity,
+                queryTimeout
             )
         );
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -47,6 +47,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   protected final String topicPrefix;
   protected final TableId tableId;
   protected final String suffix;
+  protected final int queryTimeout;
 
   // Mutable state
 
@@ -64,7 +65,8 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       QueryMode mode,
       String nameOrQuery,
       String topicPrefix,
-      String suffix
+      String suffix,
+      int queryTimeout
   ) {
     this.dialect = dialect;
     this.mode = mode;
@@ -74,6 +76,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     this.lastUpdate = 0;
     this.suffix = suffix;
     this.attemptedRetries = 0;
+    this.queryTimeout = queryTimeout;
   }
 
   public long getLastUpdate() {
@@ -85,6 +88,9 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       return stmt;
     }
     createPreparedStatement(db);
+    if (queryTimeout > 0) {
+      stmt.setQueryTimeout(queryTimeout);
+    }
     return stmt;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -83,8 +83,9 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
                                            TimeZone timeZone, String suffix,
-                                           TimestampGranularity timestampGranularity) {
-    super(dialect, mode, name, topicPrefix, suffix);
+                                           TimestampGranularity timestampGranularity,
+                                           int queryTimeout) {
+    super(dialect, mode, name, topicPrefix, suffix, queryTimeout);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
         ? timestampColumnNames : Collections.emptyList();

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -64,7 +64,8 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
       Long timestampDelay,
       TimeZone timeZone,
       String suffix,
-      TimestampGranularity timestampGranularity
+      TimestampGranularity timestampGranularity,
+      int queryTimeout
   ) {
     super(
         dialect,
@@ -77,7 +78,8 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
         timestampDelay,
         timeZone,
         suffix,
-        timestampGranularity
+        timestampGranularity,
+        queryTimeout
     );
 
     this.latestCommittableTimestamp = this.offset.getTimestampOffset();

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -100,7 +100,8 @@ public class TimestampIncrementingTableQuerierTest {
         10211197100L, // Timestamp delay
         TimeZone.getTimeZone("UTC"),
         "",
-        JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
+        JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL,
+        JdbcSourceConnectorConfig.QUERY_TIMEOUT_S_DEFAULT
     );
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampTableQuerierTest.java
@@ -97,7 +97,8 @@ public class TimestampTableQuerierTest {
         10211197100L, // Timestamp delay
         TimeZone.getTimeZone("UTC"),
         "",
-        JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
+        JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL,
+        JdbcSourceConnectorConfig.QUERY_TIMEOUT_S_DEFAULT
     );
   }
 


### PR DESCRIPTION
## Problem
No way to provide query timeout for source tasks

## Solution
Add an option to invoke java.sql.Statement.setQueryTimeout(int seconds) with configured value in TableQuerier implementations.

For backwards compatibility, default value will be 0 (no timeout).

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
