### PR TITLE
Revert "Allow close() on CachedConnectionProvider while attempting to connect…"

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
@@ -27,9 +27,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -73,44 +70,6 @@ public class CachedConnectionProviderTest {
     assertNotNull(connectionProvider.getConnection());
 
     PowerMock.verifyAll();
-  }
-
-  @Test
-  public void retryTillClose() throws SQLException {
-    final CountDownLatch latch = new CountDownLatch(1);
-    ConnectionProvider connectionProvider = new CachedConnectionProvider(
-            new ConnectionProvider() {
-                @Override
-                public Connection getConnection() throws SQLException {
-                    latch.countDown();
-                    throw new SQLException("test");
-                }
-
-                @Override
-                public boolean isConnectionValid(Connection connection, int timeout) throws SQLException {
-                    return false;
-                }
-
-                @Override
-                public void close() {
-                }
-            }, Integer.MAX_VALUE, 100L);
-
-    ExecutorService executorService = Executors.newSingleThreadExecutor();
-    executorService.execute(() -> {
-        try {
-            latch.await();
-            connectionProvider.close();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    });
-
-    try {
-        connectionProvider.getConnection();
-    } catch (ConnectException ce) {
-        assertNotNull(ce);
-    }
   }
 
 }


### PR DESCRIPTION
## What?

Reverts confluentinc/kafka-connect-jdbc#1206

## Why?

We missed a big part of the fact that the internal retries of the ConnectionProvider also call on `close`.

For example, [JdbcDbWriter#closeQuitely](https://github.com/confluentinc/kafka-connect-jdbc/blob/5.0.x/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java#L79) is called during internal retries [JdbcSinkTask#put](https://github.com/confluentinc/kafka-connect-jdbc/blob/5.0.x/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java#L104). This can cause NPEs as we return a null connection back when a new connection is requested since we have set `isRunning` to false. 

This regression wasn't caught by 5.0.x tests. It failed further down on the pint merge on newer branches.