### PR TITLE
Fixing log message

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -126,7 +126,7 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
       try {
         db.commit();
       } catch (SQLException e) {
-        log.warn("Error while committing read transaction, database locks may still be held", e);
+        log.warn("Error while committing read transaction", e);
       }
     }
     db = null;


### PR DESCRIPTION
## Problem
Log message is slightly confusing. We don't acquire a lock on reads.

## Solution
Changed the log message.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
