### PR TITLE
[CCDB-5238] Reinitialize writer object during retry to refresh cache to clear invalid state

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -130,6 +130,7 @@ public class JdbcSinkTask extends SinkTask {
 
   private void unrollAndRetry(Collection<SinkRecord> records) {
     writer.closeQuietly();
+    initWriter();
     for (SinkRecord record : records) {
       try {
         writer.write(Collections.singletonList(record));


### PR DESCRIPTION
## Problem
In confluent cloud if someone manually deletes the DB table while the JDBC connector is running, the connector will start failing even if **auto.create** config is set as true. Ideally when auto create is true table should be created again. This happens because the connector maintains a cache for for the tables and if a table is deleted that cache becomes invalid and no new table is created till process restarts.

## Solution
Reinitialise the writer object when the connector goes into final retry state. This resets the cache and the table is created again.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy
Added integration test for the scenario.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Bug fix for mainly confluent cloud releasing to latest version of connector.