### PR TITLE
RCCA-100001: fix null field issue with sybase dialect

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.List;
@@ -363,6 +364,21 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
       Timestamp.SCHEMA,
       new java.util.Date(100)
     ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
+  }
+
+  @Test
+  public void bindNullFieldsToColumnDefinitionTypes() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    // ColumnDefinition is mocked in BaseDialectTest based on schema type
+    verifyBindField(++index, Schema.INT8_SCHEMA, null).setObject(index, null, Types.NUMERIC);
+    verifyBindField(++index, Schema.INT16_SCHEMA, null).setObject(index, null, Types.NUMERIC);
+    verifyBindField(++index, Schema.INT32_SCHEMA, null).setObject(index, null, Types.NUMERIC);
+    verifyBindField(++index, Schema.INT64_SCHEMA, null).setObject(index, null, Types.NUMERIC);
+    verifyBindField(++index, Schema.BOOLEAN_SCHEMA, null).setObject(index, null, Types.NUMERIC);
+    verifyBindField(++index, Schema.FLOAT32_SCHEMA, null).setObject(index, null, 100);
+    verifyBindField(++index, Schema.FLOAT64_SCHEMA, null).setObject(index, null, 101);
+    verifyBindField(++index, Schema.BYTES_SCHEMA, null).setObject(index, null, Types.BLOB);
+    verifyBindField(++index, Schema.STRING_SCHEMA, null).setObject(index, null, Types.CLOB);
   }
 
   @Test


### PR DESCRIPTION
## Problem
When trying to insert a record with null field into Sybase DB (with jtds driver), in some cases the connector was failing with the following exception:
```
Write of 1 records failed, remainingRetries=1 (io.confluent.connect.jdbc.sink.JdbcSinkTask)
java.sql.BatchUpdateException: Implicit conversion from datatype 'VARCHAR' to 'TINYINT' is not allowed.  Use the CONVERT function to run this query.
	at net.sourceforge.jtds.jdbc.JtdsStatement.executeBatch(JtdsStatement.java:1069)
	at io.confluent.connect.jdbc.sink.BufferedRecords.executeUpdates(BufferedRecords.java:196)
	at io.confluent.connect.jdbc.sink.BufferedRecords.flush(BufferedRecords.java:186)
	at io.confluent.connect.jdbc.sink.JdbcDbWriter.write(JdbcDbWriter.java:80)
	at io.confluent.connect.jdbc.sink.JdbcSinkTask.put(JdbcSinkTask.java:84)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:581)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:333)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:234)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:203)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:188)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:243)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

## Solution
The driver was inferring the null value to be of type VARCHAR. Explicitly setting the type based on the column definition to prevent type mismatch.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
