### PR TITLE
Fixed tests

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -366,8 +366,9 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     ).setTimestamp(index, new java.sql.Timestamp(100), utcCalendar);
   }
 
+  @Override
   @Test
-  public void bindNullFieldsToColumnDefinitionTypes() throws SQLException {
+  public void bindFieldNull() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
     // ColumnDefinition is mocked in BaseDialectTest based on schema type
     verifyBindField(++index, Schema.INT8_SCHEMA, null).setObject(index, null, Types.NUMERIC);
@@ -379,6 +380,10 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
     verifyBindField(++index, Schema.FLOAT64_SCHEMA, null).setObject(index, null, 101);
     verifyBindField(++index, Schema.BYTES_SCHEMA, null).setObject(index, null, Types.BLOB);
     verifyBindField(++index, Schema.STRING_SCHEMA, null).setObject(index, null, Types.CLOB);
+    verifyBindField(++index, Decimal.schema(0), null).setObject(index, null, Types.NUMERIC);
+    verifyBindField(++index, Date.SCHEMA, null).setObject(index, null, Types.DATE);
+    verifyBindField(++index, Time.SCHEMA, null).setObject(index, null, Types.DATE);
+    verifyBindField(++index, Timestamp.SCHEMA, null).setObject(index, null, Types.TIMESTAMP);
   }
 
   @Test


### PR DESCRIPTION
## Problem
Test for Null binding was failing for SybaseDialect.

## Solution
Fixed the test.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.confluent.connect.jdbc.dialect.SybaseDatabaseDialectTest
[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.72 s - in io.confluent.connect.jdbc.dialect.SybaseDatabaseDialectTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.049 s
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
