### PR TITLE
CCDB-5077: Fix closin CacheConnectionProvider to close on lifecycle events

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -180,7 +180,7 @@ public class JdbcSourceConnector extends SourceConnector {
       // Ignore, shouldn't be interrupted
     } finally {
       try {
-        cachedConnectionProvider.close();
+        cachedConnectionProvider.close(true);
       } finally {
         try {
           if (dialect != null) {

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -281,7 +281,7 @@ public class JdbcSourceTask extends SourceTask {
     log.info("Closing resources for JDBC source task");
     try {
       if (cachedConnectionProvider != null) {
-        cachedConnectionProvider.close();
+        cachedConnectionProvider.close(true);
       }
     } catch (Throwable t) {
       log.warn("Error while closing the connections", t);

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -122,8 +122,8 @@ public class JdbcSourceConnectorTest {
     // Since we're just testing start/stop, we don't worry about the value here but need to stub
     // something since the background thread will be started and try to lookup metadata.
     EasyMock.expect(conn.getMetaData()).andStubThrow(new SQLException());
-    // Close will be invoked both for the SQLExeption and when the connector is stopped
-    mockCachedConnectionProvider.close();
+    // Close with stopping will be invoked when the connector is stopped
+    mockCachedConnectionProvider.close(true);
     PowerMock.expectLastCall().atLeastOnce();
 
     PowerMock.replayAll();

--- a/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/CachedConnectionProviderTest.java
@@ -27,6 +27,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -70,6 +73,44 @@ public class CachedConnectionProviderTest {
     assertNotNull(connectionProvider.getConnection());
 
     PowerMock.verifyAll();
+  }
+
+  @Test
+  public void retryTillClose() throws SQLException {
+    final CountDownLatch latch = new CountDownLatch(1);
+    CachedConnectionProvider connectionProvider = new CachedConnectionProvider(
+        new ConnectionProvider() {
+          @Override
+          public Connection getConnection() throws SQLException {
+            latch.countDown();
+            throw new SQLException("test");
+          }
+
+          @Override
+          public boolean isConnectionValid(Connection connection, int timeout) throws SQLException {
+            return false;
+          }
+
+          @Override
+          public void close() {
+          }
+        }, Integer.MAX_VALUE, 100L);
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    executorService.execute(() -> {
+      try {
+        latch.await();
+        connectionProvider.close(true);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    });
+
+    try {
+      connectionProvider.getConnection();
+    } catch (ConnectException ce) {
+      assertNotNull(ce);
+    }
   }
 
 }


### PR DESCRIPTION
## Problem

Fixes #1205. Follows up on #1206 to fix the issue on non life-cycle events
While CacheConenctionProvider is trying to get a connection, it is impossible to stop.

## Solution

Add a flag to not go on with connection attempt when a close request has been issued.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- I-->
merge to 5.0.x and further
