### PR TITLE
[CCDB-5300] Upgrade postgresql to 42.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>8.4.1.jre8</mssqlserver.jdbc.driver.version>
-        <postgresql.version>42.4.1</postgresql.version>
+        <postgresql.version>42.4.3</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>


### PR DESCRIPTION
## Problem

Vulnerable dependency "postgresql" for kafka-connect-jdbc
CVE: https://confluentinc.atlassian.net/browse/CCDB-5300

## Solution
Upgrade postgresql to 42.4.3 as per [here](https://mvnrepository.com/artifact/org.postgresql/postgresql)

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
`mvn dependency:tree` output
```
[INFO] +- org.xerial:sqlite-jdbc:jar:3.25.2:runtime
[INFO] +- org.postgresql:postgresql:jar:42.4.3:runtime
[INFO] |  \- org.checkerframework:checker-qual:jar:3.5.0:runtime
[INFO] +- com.oracle.database.jdbc:ojdbc8-production:pom:19.7.0.0:runtime
[INFO] |  +- com.oracle.database.jdbc:ojdbc8:jar:19.7.0.0:runtime
```


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
