### PR TITLE
[CCDB-5300] Upgrade postgresql to 42.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
-        <postgresql.version>42.4.1</postgresql.version>
+        <postgresql.version>42.4.3</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <licenses.name>Apache License 2.0</licenses.name>
         <licenses.version>${project.version}</licenses.version>


### PR DESCRIPTION
## Problem

Vulnerable dependency "postgresql" for kafka-connect-jdbc
CVE: https://confluentinc.atlassian.net/browse/CCDB-5300

## Solution
Upgrade postgresql to 42.4.3 as per [here](https://mvnrepository.com/artifact/org.postgresql/postgresql).
Checked that postgresql 42.4.x is available from branch 5.0.x onwards
Will do ping merge after PR merge

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
`mvn dependency:tree` output
```
[INFO] +- org.xerial:sqlite-jdbc:jar:3.25.2:runtime
[INFO] +- org.postgresql:postgresql:jar:42.4.3:runtime
[INFO] |  \- org.checkerframework:checker-qual:jar:3.5.0:runtime
[INFO] +- com.oracle.database.jdbc:ojdbc8-production:pom:19.7.0.0:runtime
[INFO] |  +- com.oracle.database.jdbc:ojdbc8:jar:19.7.0.0:runtime
```


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CCDB-5300]: https://confluentinc.atlassian.net/browse/CCDB-5300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ