### PR TITLE
[CCDB-5302] Added length parameter to setCharacterStream for oracle database CLOB column

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -58,7 +58,8 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
   @Test
   public void bindFieldStringValue() throws SQLException {
     int index = ThreadLocalRandom.current().nextInt();
-    verifyBindField(++index, Schema.STRING_SCHEMA, "yep").setCharacterStream(eq(index), any(StringReader.class));
+    String value = "yep";
+    verifyBindField(++index, Schema.STRING_SCHEMA, value).setCharacterStream(eq(index), any(StringReader.class), eq((long)value.length()));
   }
 
   @Override
@@ -344,7 +345,7 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     verify(stmtNvarchar, times(1)).setNString(index, value);
 
     dialect.bindField(stmtClob, index, schema, value, colDefClob);
-    verify(stmtClob, times(1)).setCharacterStream(eq(index), any(StringReader.class));
+    verify(stmtClob, times(1)).setCharacterStream(eq(index), any(StringReader.class), eq((long) value.length()));
   }
 
   @Test


### PR DESCRIPTION
## Problem
[CCDB-5302](https://confluentinc.atlassian.net/browse/CCDB-5302?atlOrigin=eyJpIjoiY2IxNjM4YzU1MDM1NDBiMTk1YjRjMjc0NzA3MmY0Y2QiLCJwIjoiaiJ9)
Writes to CLOB datatype columns were performing extremely poorly

## Solution
Issue was caused by how oracle driver was binding the insert value. If length parameter is not passed to setCharacterStream method then the driver does LOB binding by default which is the slowest form. By passing the length parameter, the driver picks the most appropriate form of binding based on length.
One exception to this is the UPSERT mode which uses MERGE statement. In that case the driver does not handle the binding correctly and requires LOB binding for all values above length 4000. This issue is further described in this [RCCA-4323](https://confluentinc.atlassian.net/browse/RCCA-4323)


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CCDB-5302]: https://confluentinc.atlassian.net/browse/CCDB-5302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCDB-5302]: https://confluentinc.atlassian.net/browse/CCDB-5302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RCCA-4323]: https://confluentinc.atlassian.net/browse/RCCA-4323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RCCA-4323]: https://confluentinc.atlassian.net/browse/RCCA-4323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ