### PR TITLE
Adds config to conditionally mask SQL statements

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -254,7 +254,7 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "view definition does not match the records' schemas (regardless of ``"
       + AUTO_EVOLVE + "``).";
 
-  public static final String TRIM_SENSITIVE_LOG_ENABLED = "trim.sensitive.log.enabled";
+  public static final String TRIM_SENSITIVE_LOG_ENABLED = "trim.sensitive.log";
   private static final String TRIM_SENSITIVE_LOG_ENABLED_DEFAULT = "false";
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
@@ -498,7 +498,7 @@ public class JdbcSinkConfig extends AbstractConfig {
             TRIM_SENSITIVE_LOG_ENABLED,
             ConfigDef.Type.BOOLEAN,
             TRIM_SENSITIVE_LOG_ENABLED_DEFAULT,
-            ConfigDef.Importance.HIGH
+            ConfigDef.Importance.LOW
         );
 
   public final String connectorName;

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -254,6 +254,8 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "view definition does not match the records' schemas (regardless of ``"
       + AUTO_EVOLVE + "``).";
 
+  public static final String TRIM_SENSITIVE_LOG_ENABLED = "trim.sensitive.log.enabled";
+  private static final String TRIM_SENSITIVE_LOG_ENABLED_DEFAULT = "false";
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -491,6 +493,12 @@ public class JdbcSinkConfig extends AbstractConfig {
             2,
             ConfigDef.Width.SHORT,
             RETRY_BACKOFF_MS_DISPLAY
+        )
+        .defineInternal(
+            TRIM_SENSITIVE_LOG_ENABLED,
+            ConfigDef.Type.BOOLEAN,
+            TRIM_SENSITIVE_LOG_ENABLED_DEFAULT,
+            ConfigDef.Importance.HIGH
         );
 
   public final String connectorName;
@@ -514,6 +522,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final TimeZone timeZone;
   public final EnumSet<TableType> tableTypes;
 
+  public final boolean trimSensitiveLogsEnabled;
+
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
     connectorName = ConfigUtils.connectorName(props);
@@ -536,7 +546,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
     String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
     timeZone = TimeZone.getTimeZone(ZoneId.of(dbTimeZone));
-
+    trimSensitiveLogsEnabled = getBoolean(TRIM_SENSITIVE_LOG_ENABLED);
     if (deleteEnabled && pkMode != PrimaryKeyMode.RECORD_KEY) {
       throw new ConfigException(
           "Primary key mode must be 'record_key' when delete support is enabled");

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -44,12 +44,15 @@ public class JdbcSinkTask extends SinkTask {
   JdbcDbWriter writer;
   int remainingRetries;
 
+  boolean shouldTrimSensitiveLogs;
+
   @Override
   public void start(final Map<String, String> props) {
     log.info("Starting JDBC Sink task");
     config = new JdbcSinkConfig(props);
     initWriter();
     remainingRetries = config.maxRetries;
+    shouldTrimSensitiveLogs = config.trimSensitiveLogsEnabled;
     try {
       reporter = context.errantRecordReporter();
     } catch (NoSuchMethodError | NoClassDefFoundError e) {
@@ -90,7 +93,8 @@ public class JdbcSinkTask extends SinkTask {
         throw tace;
       }
     } catch (SQLException sqle) {
-      SQLException trimmedException = LogUtil.trimSensitiveData(sqle);
+      SQLException trimmedException = shouldTrimSensitiveLogs
+              ? LogUtil.trimSensitiveData(sqle) : sqle;
       log.warn(
           "Write of {} records failed, remainingRetries={}",
           records.size(),
@@ -146,7 +150,8 @@ public class JdbcSinkTask extends SinkTask {
 
   private SQLException getAllMessagesException(SQLException sqle) {
     String sqleAllMessages = "Exception chain:" + System.lineSeparator();
-    SQLException trimmedException = LogUtil.trimSensitiveData(sqle);
+    SQLException trimmedException = shouldTrimSensitiveLogs
+            ? LogUtil.trimSensitiveData(sqle) : sqle;
     for (Throwable e : trimmedException) {
       sqleAllMessages += e + System.lineSeparator();
     }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.BatchUpdateException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
@@ -80,15 +83,15 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       0
   );
 
-  @Before
-  public void setUp() throws IOException, SQLException {
-    sqliteHelper.setUp();
-  }
+//  @Before
+//  public void setUp() throws IOException, SQLException {
+//    sqliteHelper.setUp();
+//  }
 
-  @After
-  public void tearDown() throws IOException, SQLException {
-    sqliteHelper.tearDown();
-  }
+//  @After
+//  public void tearDown() throws IOException, SQLException {
+//    sqliteHelper.tearDown();
+//  }
 
   @Test
   public void putPropagatesToDbWithAutoCreateAndPkModeKafka() throws Exception {
@@ -474,7 +477,40 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     task.put(records);
     verifyAll();
   }
+  @Test
+  public void testGetAllMessagesExceptionWithoutTrim() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    JdbcSinkTask task = new JdbcSinkTask();
+    SQLException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
+            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
+            new int[0]);
+    String exceptedExceptionMessage = "Exception chain:" + System.lineSeparator() + exception + System.lineSeparator();
+    Method privateMethod = JdbcSinkTask.class.getDeclaredMethod("getAllMessagesException", SQLException.class);
+    task.shouldTrimSensitiveLogs = false;
+    privateMethod.setAccessible(true);
 
+    SQLException result = (SQLException) privateMethod.invoke(task, exception);
+    assertEquals(exceptedExceptionMessage, result.getMessage());
+
+    privateMethod.setAccessible(false);
+  }
+
+  @Test
+  public void testGetAllMessagesExceptionTrimmed() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    JdbcSinkTask task = new JdbcSinkTask();
+    SQLException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
+            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
+            new int[0]);
+    Method privateMethod = JdbcSinkTask.class.getDeclaredMethod("getAllMessagesException", SQLException.class);
+    privateMethod.setAccessible(true);
+    task.shouldTrimSensitiveLogs = true;
+
+    SQLException result = (SQLException) privateMethod.invoke(task, exception);
+    assertTrue(!result.getLocalizedMessage().contains("VALUES"));
+
+    privateMethod.setAccessible(false);
+  }
   private List<SinkRecord> createRecordsList(int batchSize) {
     List<SinkRecord> records = new ArrayList<>();
     for (int i = 0; i < batchSize; i++) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -83,15 +83,15 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
       0
   );
 
-//  @Before
-//  public void setUp() throws IOException, SQLException {
-//    sqliteHelper.setUp();
-//  }
+  @Before
+  public void setUp() throws IOException, SQLException {
+    sqliteHelper.setUp();
+  }
 
-//  @After
-//  public void tearDown() throws IOException, SQLException {
-//    sqliteHelper.tearDown();
-//  }
+  @After
+  public void tearDown() throws IOException, SQLException {
+    sqliteHelper.tearDown();
+  }
 
   @Test
   public void putPropagatesToDbWithAutoCreateAndPkModeKafka() throws Exception {


### PR DESCRIPTION
## Problem
Reverts changes done in [CCDB-5222](https://confluentinc.atlassian.net/browse/CCDB-5222)
Find more details on why this is being done [here] (https://confluent.slack.com/archives/C04JV6U2HU2)
## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CCDB-5222]: https://confluentinc.atlassian.net/browse/CCDB-5222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ