### PR TITLE
Rename method releaseLocksQuietly to commitQuietly

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -114,14 +114,14 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
   public void reset(long now, boolean resetOffset) {
     closeResultSetQuietly();
     closeStatementQuietly();
-    releaseLocksQuietly();
+    commitQuietly();
     // TODO: Can we cache this and quickly check that it's identical for the next query
     //     instead of constructing from scratch since it's almost always the same
     schemaMapping = null;
     lastUpdate = now;
   }
 
-  private void releaseLocksQuietly() {
+  private void commitQuietly() {
     if (db != null) {
       try {
         db.commit();


### PR DESCRIPTION
## Problem
The method name was confusing. We are only calling the commit method inside releaseLocksQuietly. Releasing the acquired locks is a side-effect of commit call.

## Solution
Renamed the method to commitQuietly.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
