### PR TITLE
Add configuration for Keep Interval (ms)

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -298,6 +298,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final long TIMESTAMP_DELAY_INTERVAL_MS_DEFAULT = 0;
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY = "Delay Interval (ms)";
 
+  public static final String TIMESTAMP_KEEP_INTERVAL_MS_CONFIG =
+      "timestamp.keep.interval.ms";
+  private static final String TIMESTAMP_KEEP_INTERVAL_MS_DOC =
+      "How far into the past to query rows with certain timestamp which we fetched last time. "
+      + "You may choose this to allow processing of rows with earlier timestamps for long running "
+      + "transactions where incrementing column is associated with the instant when transaction "
+      + "completed. As opposed to ``timestamp.delay.interval.ms`` this will not cause any fetching "
+      + "delay. Configuration is applicable only in ``timestamp+incrementing`` mode.";
+  public static final long TIMESTAMP_KEEP_INTERVAL_MS_DEFAULT = 0;
+  private static final String TIMESTAMP_KEEP_INTERVAL_MS_DISPLAY = "Keep Interval (ms)";
+
   public static final String DB_TIMEZONE_CONFIG = "db.timezone";
   public static final String DB_TIMEZONE_DEFAULT = "UTC";
   private static final String DB_TIMEZONE_CONFIG_DOC =
@@ -760,6 +771,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         TIMESTAMP_DELAY_INTERVAL_MS_DISPLAY
+    ).define(
+        TIMESTAMP_KEEP_INTERVAL_MS_CONFIG,
+        Type.LONG,
+        TIMESTAMP_KEEP_INTERVAL_MS_DEFAULT,
+        Importance.HIGH,
+        TIMESTAMP_KEEP_INTERVAL_MS_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        TIMESTAMP_KEEP_INTERVAL_MS_DISPLAY
     ).define(
         DB_TIMEZONE_CONFIG,
         Type.STRING,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -181,6 +181,8 @@ public class JdbcSourceTask extends SourceTask {
         = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
     Long timestampDelayInterval
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
+    Long timestampKeepInterval
+        = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_KEEP_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
         = config.getBoolean(JdbcSourceTaskConfig.VALIDATE_NON_NULL_CONFIG);
     TimeZone timeZone = config.timeZone();
@@ -252,6 +254,7 @@ public class JdbcSourceTask extends SourceTask {
                 incrementingColumn,
                 offset,
                 timestampDelayInterval,
+                timestampKeepInterval,
                 timeZone,
                 suffix,
                 timestampGranularity
@@ -283,6 +286,7 @@ public class JdbcSourceTask extends SourceTask {
                 incrementingColumn,
                 offset,
                 timestampDelayInterval,
+                timestampKeepInterval,
                 timeZone,
                 suffix,
                 timestampGranularity

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerier.java
@@ -75,6 +75,7 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
   private final List<ColumnId> timestampColumns;
   private String incrementingColumnName;
   private final long timestampDelay;
+  private final long timestampKeep;
   private final TimeZone timeZone;
 
   public TimestampIncrementingTableQuerier(DatabaseDialect dialect, QueryMode mode, String name,
@@ -82,13 +83,14 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
                                            List<String> timestampColumnNames,
                                            String incrementingColumnName,
                                            Map<String, Object> offsetMap, Long timestampDelay,
-                                           TimeZone timeZone, String suffix,
+                                           Long timestampKeep, TimeZone timeZone, String suffix,
                                            TimestampGranularity timestampGranularity) {
     super(dialect, mode, name, topicPrefix, suffix);
     this.incrementingColumnName = incrementingColumnName;
     this.timestampColumnNames = timestampColumnNames != null
         ? timestampColumnNames : Collections.emptyList();
     this.timestampDelay = timestampDelay;
+    this.timestampKeep = timestampKeep;
     this.committedOffset = this.offset = TimestampIncrementingOffset.fromMap(offsetMap);
 
     this.timestampColumns = new ArrayList<>();
@@ -243,7 +245,8 @@ public class TimestampIncrementingTableQuerier extends TableQuerier implements C
 
   @Override
   public Timestamp beginTimestampValue() {
-    return offset.getTimestampOffset();
+    long offsetTime = offset.getTimestampOffset().getTime() - timestampKeep;
+    return new Timestamp(offsetTime < 0 ? 0L : offsetTime);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampTableQuerier.java
@@ -75,6 +75,7 @@ public class TimestampTableQuerier extends TimestampIncrementingTableQuerier {
         null,
         offsetMap,
         timestampDelay,
+        0L,
         timeZone,
         suffix,
         timestampGranularity

--- a/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TableQuerierTest.java
@@ -38,6 +38,7 @@ public class TableQuerierTest {
   private static final String INCREMENTING_COLUMN_NAME = "column";
   private static final String SUFFIX = "/* SUFFIX */";   
   private static final Long TIMESTAMP_DELAY = 0l;
+  private static final Long TIMESTAMP_KEEP = 0l;
   private static final String QUERY = "SELECT * FROM name";
 
   DatabaseDialect databaseDialectMock;
@@ -69,6 +70,7 @@ public class TableQuerierTest {
                                                     INCREMENTING_COLUMN_NAME, 
                                                     null,
                                                     TIMESTAMP_DELAY,
+                                                    TIMESTAMP_KEEP,
                                                     null,
                                                     SUFFIX,
                                                     JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
@@ -89,8 +91,9 @@ public class TableQuerierTest {
                                                     null, 
                                                     INCREMENTING_COLUMN_NAME, 
                                                     null, 
-                                                    TIMESTAMP_DELAY, 
-                                                    null, 
+                                                    TIMESTAMP_DELAY,
+                                                    TIMESTAMP_KEEP,
+                                                    null,
                                                     SUFFIX,
                                                     JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL
                                                 );

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingTableQuerierTest.java
@@ -98,6 +98,7 @@ public class TimestampIncrementingTableQuerierTest {
         INCREMENTING_COLUMN,
         initialOffset.toMap(),
         10211197100L, // Timestamp delay
+        12511117500L, // Timestamp keep
         TimeZone.getTimeZone("UTC"),
         "",
         JdbcSourceConnectorConfig.TimestampGranularity.CONNECT_LOGICAL


### PR DESCRIPTION
## Problem
We do use `timestamp+incrementing` mode, we have unique incrementing column with every change, but we still need timestamp column for better performance, as we cannot create index on incrementing column because it is only pseudo column - [ORA_ROWSCN ](https://docs.oracle.com/database/121/SQLRF/pseudocolumns007.htm#SQLRF50953). Our transactions are having quite long transaction timeout and we would like to have near realtime streaming therefore we cannot use already existing `timestamp.delay.interval.ms` property. Timestamp column has instant when change happened, but incrementing column is associated with the instant when transaction completed.

## Solution
Extend `WHERE` condition for timestamp column into the past based on configuration property `timestamp.keep.interval.ms`. Applicable only in `timestamp+incrementing` mode.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests - **⚠️ Will do manual integration test, kindly review this PR in the mean time, will let you know when can be merged !**

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
