### PR TITLE
[Minor] Fix upstream tests failing due to #1284

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -78,7 +78,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection()).anyTimes();
-    mockCachedConnectionProvider.close();
+    mockCachedConnectionProvider.close(true);
 
     PowerMock.expectLastCall();
 
@@ -132,7 +132,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
 
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
-    mockCachedConnectionProvider.close();
+    mockCachedConnectionProvider.close(true);
 
     PowerMock.expectLastCall();
 


### PR DESCRIPTION
JdbcSourceTaskLifecycleTests were failing due to a change to API introduced as part of #1284