### PR TITLE
CC-19080: Fix JDBC Source Connector to support Sybase jConnect JDBC 4 Driver

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -488,8 +488,11 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     try (ResultSet rs = metadata.getTableTypes()) {
       while (rs.next()) {
         String tableType = rs.getString(1);
-        if (tableType != null && uppercaseTypes.contains(tableType.toUpperCase(Locale.ROOT))) {
-          matchingTableTypes.add(tableType);
+        if (tableType != null) {
+          tableType = tableType.trim();
+          if (uppercaseTypes.contains(tableType.toUpperCase(Locale.ROOT))) {
+            matchingTableTypes.add(tableType);
+          }
         }
       }
     }


### PR DESCRIPTION
## Context
[CC-19080](https://confluentinc.atlassian.net/browse/CC-19080): Fix JDBC Source Connector to support Sybase jConnect JDBC 4 Driver.

## Problem
The types as returned by `Connection.getMetaData().getTableTypes().getString(int columnIndex)` for Sybase jConnect driver contains extra whitespaces at the end which causes other APIs to fail when those returned values are used as-it-is:

- "TABLE" => "TABLE     "
- "SYSTEM TABLE" => "SYSTEM TABLE "
- "VIEW" => "VIEW     "

## Solution
Trimming the returned values of the aforementioned getTableTypes method. Here is the [reference](https://github.com/ManasjyotiSharma/kafka-connect-jdbc/commit/2d244549b360d4be07c6e135503115a84f1b9b3c) to the previous code change which was tested to be working fine for the jConnect driver.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
NA

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

[CC-19080]: https://confluentinc.atlassian.net/browse/CC-19080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ