### PR TITLE
CC-19887: Getting rid of ojdbc8-production-19.7.0.0.pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,18 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc-bom</artifactId>
+                <version>${oracle.jdbc.driver.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -110,17 +122,63 @@
             <version>${postgresql.version}</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!--
+        Instead of depending on artifactId ojdbc8-production of type pom, including the expanded deps for oracle jdbc
+        so that the pom itself (ojdbc8-production-19.7.0.0.pom) is not included in the final package!
+        Ref: https://www.oracle.com/database/technologies/maven-central-guide.html
+        -->
         <dependency>
-            <!--
-            Include all of the production JARs without observability fixes.
-            See https://www.oracle.com/database/technologies/maven-central-guide.html
-            -->
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8-production</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <type>pom</type>
-            <scope>runtime</scope>
+            <artifactId>ojdbc8</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ucp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>oraclepki</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>osdt_cert</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.security</groupId>
+            <artifactId>osdt_core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.ha</groupId>
+            <artifactId>simplefan</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.ha</groupId>
+            <artifactId>ons</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.xml</groupId>
+            <artifactId>xdb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.xml</groupId>
+            <artifactId>xmlparserv2</artifactId>
+        </dependency>
+
+
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>


### PR DESCRIPTION
[CC-19887](https://confluentinc.atlassian.net/browse/CC-19887): Remove non-binary file (.pom file) from the lib folder of JDBC connector.

The dependency "ojdbc8-production" of type pom is a shorthand but it add itself as a dependency (i.e. the pom ojdbc8-production-19.7.0.0.pom itself is packaged). So instead of that shorthand; depending on the actual jar deps. See [this](https://www.oracle.com/database/technologies/maven-central-guide.html) for context.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
IT, UT

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests (docker playground)

[CC-19887]: https://confluentinc.atlassian.net/browse/CC-19887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ