### PR TITLE
CC-19887 & CC-19797: Reverting ORA dependencies due to false FOSSA license alart & Updating holdlock UI message.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
     <packaging>jar</packaging>
-    <version>10.6.4-SNAPSHOT</version>
+    <version>10.7.0-SNAPSHOT</version>
     <name>kafka-connect-jdbc</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -110,83 +110,17 @@
             <version>${postgresql.version}</version>
             <scope>runtime</scope>
         </dependency>
-
-        <!--
-        Instead of depending on artifactId ojdbc8-production of type pom, including the expanded deps for oracle jdbc
-        so that the pom itself (ojdbc8-production-19.7.0.0.pom) is not included in the final package!
-        Ref: https://www.oracle.com/database/technologies/maven-central-guide.html
-        -->
         <dependency>
+            <!--
+            Include all of the production JARs without observability fixes.
+            See https://www.oracle.com/database/technologies/maven-central-guide.html
+            -->
             <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
+            <artifactId>ojdbc8-production</artifactId>
             <version>${oracle.jdbc.driver.version}</version>
+            <type>pom</type>
             <scope>runtime</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.security</groupId>
-            <artifactId>oraclepki</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.security</groupId>
-            <artifactId>osdt_cert</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.security</groupId>
-            <artifactId>osdt_core</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.ha</groupId>
-            <artifactId>simplefan</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.ha</groupId>
-            <artifactId>ons</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.nls</groupId>
-            <artifactId>orai18n</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.xml</groupId>
-            <artifactId>xdb</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.oracle.database.xml</groupId>
-            <artifactId>xmlparserv2</artifactId>
-            <version>${oracle.jdbc.driver.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -267,7 +267,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String MSSQL_USE_MERGE_HOLDLOCK_DEFAULT = "true";
   private static final String MSSQL_USE_MERGE_HOLDLOCK_DOC =
       "Whether to use HOLDLOCK when performing a MERGE INTO upsert statement. "
-      + "Note that it is only applicable to SQL Server";
+      + "Note that it is only applicable to SQL Server.";
   private static final String MSSQL_USE_MERGE_HOLDLOCK_DISPLAY =
       "SQL Server - Use HOLDLOCK in MERGE";
 


### PR DESCRIPTION
See these for refs:

https://github.com/confluentinc/kafka-connect-jdbc/pull/1322
https://github.com/confluentinc/kafka-connect-jdbc/pull/1323

W.r.t https://confluentinc.atlassian.net/browse/CC-19797; fixing display message
W.r.t https://confluentinc.atlassian.net/browse/CC-19887; reverting the previous fix (as FOSSA is incorrectly flagging error - [ref](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfluentinc%2Fkafka-connect-jdbc/refs/branch/master/45b6a8a4868289c41fe0a188278e01f47f4459d3/issues/licensing?page=1&count=20&sort=created_at_desc&status=active&filter%5Btype%5D%5B0%5D=unlicensed_dependency&revisionScanId=38358462))