### PR TITLE
Added zero-retries in JDBC source and unit test.

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -464,7 +464,10 @@ public class JdbcSourceTask extends SourceTask {
         if (maxRetriesPerQuerier > 0
                 && querier.getAttemptedRetryCount() >= maxRetriesPerQuerier) {
           closeResources();
-          throw new ConnectException("Failed to Query table after retries", sqle);
+          throw new ConnectException("Failed to query table after retries", sqle);
+        } else if (maxRetriesPerQuerier == 0) {
+          closeResources();
+          throw new ConnectException("Failed to query table, no retries configured !", sqle);
         }
         querier.incrementRetryCount();
         return null;

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -320,6 +320,24 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
   }
 
   @Test(expected = ConnectException.class)
+  public void testTransientSQLExceptionNoRetries() throws Exception {
+
+    TableQuerier bulkTableQuerier = EasyMock.createMock(BulkTableQuerier.class);
+
+    expect(bulkTableQuerier.querying()).andReturn(true);
+    bulkTableQuerier.maybeStartQuery(anyObject());
+    expectLastCall().andThrow(new SQLException("This is a transient exception"));
+
+    expect(bulkTableQuerier.getAttemptedRetryCount()).andReturn(0);
+    expectLastCall().once();
+    bulkTableQuerier.reset(anyLong(), anyBoolean());
+    replay(bulkTableQuerier);
+
+    JdbcSourceTask mockedTask = setUpMockedTask(bulkTableQuerier, 0);
+    mockedTask.poll();
+  }
+
+  @Test(expected = ConnectException.class)
   public void testTransientSQLExceptionRetries() throws Exception {
 
     int retryMax = 2; //max times to retry


### PR DESCRIPTION
## Problem
JDBC source does not respect `query.retry.attempts = 0`, also see https://github.com/confluentinc/kafka-connect-jdbc/issues/1340


## Solution
Added handling for the case with zero retries to fail without retries and added a unit test.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Added unit test and did local integration testing as well as testing with customers in their system.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
