### PR TITLE
[CC-20628] Updated sqlite dependency to CVE-2023-32697 to RCE vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <derby.version>10.14.2.0</derby.version>
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>8.4.1.jre8</mssqlserver.jdbc.driver.version>
         <postgresql.version>42.4.3</postgresql.version>


### PR DESCRIPTION
## Problem
[CC-20628](https://confluentinc.atlassian.net/browse/CC-20628)
RCE vulnerability in SQLITE jdbc package

## Solution
Upgrade package version to 3.41.2.2.
This PR was already created by Jan [here](https://github.com/confluentinc/kafka-connect-jdbc/pull/1344) but it was for 10.6.x. Seeing how many customers use older versions as well and this is a critical vulnerability, I created this PR to target older branch 10.0.x
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
kafka-docker-playground doesn't have sqlite option available. Ran connector locally in both sink and source mode for sqlite with basic configs to test.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-20628]: https://confluentinc.atlassian.net/browse/CC-20628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ