### PR TITLE
Implementing new config variable poll.sleep.ms

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -100,13 +100,24 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                                                      + "each table.";
   public static final int POLL_INTERVAL_MS_DEFAULT = 5000;
   private static final String POLL_INTERVAL_MS_DISPLAY = "Poll Interval (ms)";
-
+  
   public static final String BATCH_MAX_ROWS_CONFIG = "batch.max.rows";
   private static final String BATCH_MAX_ROWS_DOC =
       "Maximum number of rows to include in a single batch when polling for new data. This "
       + "setting can be used to limit the amount of data buffered internally in the connector.";
   public static final int BATCH_MAX_ROWS_DEFAULT = 100;
   private static final String BATCH_MAX_ROWS_DISPLAY = "Max Rows Per Batch";
+
+  public static final String POLL_SLEEP_MS_CONFIG = "poll.sleep.ms";
+  private static final String POLL_SLEEP_MS_DOC =
+		  "Time to sleep after the whole table result set has been consumed. The batch result set is "
+		  + "read internally without sending an next SQL query, whereas " + BATCH_MAX_ROWS_CONFIG + ""
+		  + "are consumed during each poll interval (" + POLL_INTERVAL_MS_CONFIG +")"
+		  + "This setting can be used to limit the frequency at which the SQL server is being queried"
+		  + "without limiting the processing speed of already obtained result sets.\n\n"
+		  + "This is especially useful with mode=bulk.";
+  public static final int POLL_SLEEP_MS_DEFAULT = 0;
+  private static final String POLL_SLEEP_MS_DISPLAY = "Sleep between table queries (ms)";
 
   public static final String NUMERIC_PRECISION_MAPPING_CONFIG = "numeric.precision.mapping";
   private static final String NUMERIC_PRECISION_MAPPING_DOC =
@@ -704,7 +715,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         BATCH_MAX_ROWS_DISPLAY
-    ).defineInternal(
+    ).define(
+        POLL_SLEEP_MS_CONFIG,
+        Type.INT,
+        POLL_SLEEP_MS_DEFAULT,
+        Importance.LOW,
+        POLL_SLEEP_MS_DOC,
+        CONNECTOR_GROUP,
+        ++orderInGroup,
+        Width.SHORT,
+        POLL_SLEEP_MS_DISPLAY
+     ).defineInternal(
         TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_CONFIG,
         Type.LONG,
         TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_DEFAULT,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -69,6 +69,7 @@ public class JdbcSourceTask extends SourceTask {
   //Visible for Testing
   CachedConnectionProvider cachedConnectionProvider;
   PriorityQueue<TableQuerier> tableQueue = new PriorityQueue<>();
+  private Map<TableQuerier, Integer> tableQuerierSleepTimes = new HashMap<>();
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final AtomicLong taskThreadId = new AtomicLong(0);
 
@@ -394,13 +395,23 @@ public class JdbcSourceTask extends SourceTask {
     while (running.get()) {
       final TableQuerier querier = tableQueue.peek();
 
-      if (!querier.querying()) {
+      int pollSleepMs;
+	if (!querier.querying()) {
         // If not in the middle of an update, wait for next update time
         final long nextUpdate = querier.getLastUpdate()
             + config.getInt(JdbcSourceTaskConfig.POLL_INTERVAL_MS_CONFIG);
         final long now = time.milliseconds();
         final long sleepMs = Math.min(nextUpdate - now, 100);
 
+        if (tableQuerierSleepMs(querier) > 0) {
+        	pollSleepMs = tableQuerierSleepMs(querier);
+            log.debug("TableQuerier is requested to sleep {} ms before sending next query {}",
+          		  pollSleepMs, querier.toString());
+            time.sleep(pollSleepMs);
+            tableQuerierSleepTimes.remove(querier);
+            continue; // Re-check stop flag before continuing
+          }
+        
         if (sleepMs > 0) {
           log.trace("Waiting {} ms to poll {} next", nextUpdate - now, querier.toString());
           time.sleep(sleepMs);
@@ -424,6 +435,10 @@ public class JdbcSourceTask extends SourceTask {
           // If we finished processing the results from the current query, we can reset and send
           // the querier to the tail of the queue
           resetAndRequeueHead(querier, false);
+          pollSleepMs = config.getInt(JdbcSourceTaskConfig.POLL_SLEEP_MS_CONFIG);
+          tableQuerierSleepTimes.put(querier, pollSleepMs);
+          log.debug("Processing current query to be finished. Registering sleep of {} ms before sending next query {}",
+          		  pollSleepMs, querier.toString());
         }
 
         if (results.isEmpty()) {
@@ -553,4 +568,13 @@ public class JdbcSourceTask extends SourceTask {
                                  + " NULL", e);
     }
   }
+  
+  public int tableQuerierSleepMs(TableQuerier querier) {
+	  if(tableQuerierSleepTimes.containsKey(querier)) {
+		  return tableQuerierSleepTimes.get(querier);
+	  } else {
+		  return 0;
+	  }
+  }
+
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -407,7 +407,7 @@ public class JdbcSourceTask extends SourceTask {
         	pollSleepMs = tableQuerierSleepMs(querier);
             log.debug("TableQuerier is requested to sleep {} ms before sending next query {}",
           		  pollSleepMs, querier.toString());
-            time.sleep(pollSleepMs);
+            Thread.sleep(pollSleepMs);
             tableQuerierSleepTimes.remove(querier);
             continue; // Re-check stop flag before continuing
           }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskUpdateTest.java
@@ -47,6 +47,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import io.confluent.connect.jdbc.util.DateTimeUtils;
+import scala.Unit;
 
 // Tests of polling that return data updates, i.e. verifies the different behaviors for getting
 // incremental data updates from the database
@@ -94,6 +95,41 @@ public class JdbcSourceTaskUpdateTest extends JdbcSourceTaskTestBase {
     records = task.poll();
     assertEquals(Collections.singletonMap(2, 1), countIntValues(records, "id"));
     assertRecordsTopic(records, TOPIC_PREFIX + SINGLE_TABLE_NAME);
+  }
+  
+  @Test
+  public void testBulkPeriodicLoadWithPollSleep() throws Exception {
+    
+    db.createTable(SINGLE_TABLE_NAME, "id", "INT NOT NULL");
+    db.insert(SINGLE_TABLE_NAME, "id", 1);
+    db.insert(SINGLE_TABLE_NAME, "id", 2);
+
+    // Bulk periodic load is currently the default
+    Map<String, String> config = singleTableConfig();
+    // pause 1 second after batch was completed
+    long sleepMs = 1000;
+    // must be much smaller for this test 
+    long intervalMs = 10;
+    config.put(JdbcSourceConnectorConfig.POLL_SLEEP_MS_CONFIG, Long.toString(sleepMs));
+    config.put(JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG, Long.toString(intervalMs));
+    
+    Map<Integer, Integer> twoRecords = new HashMap<>();
+    twoRecords.put(1, 1);
+    twoRecords.put(2, 1);
+
+    long start= System.currentTimeMillis();
+
+    task.start(config);
+    List<SourceRecord> records = task.poll();
+    long stopWatchTime = System.currentTimeMillis() - start;    
+	assertTrue("task slept " + stopWatchTime +" ms", stopWatchTime < sleepMs);
+    assertEquals(twoRecords, countIntValues(records, "id"));
+    assertRecordsTopic(records, TOPIC_PREFIX + SINGLE_TABLE_NAME);
+    // polling again should cause the task to sleep for sleepMs
+    records = task.poll();
+    stopWatchTime = System.currentTimeMillis() - start;
+    assertTrue("task slept " + stopWatchTime +" ms", stopWatchTime >= sleepMs);
+
   }
 
   @Test(expected = ConnectException.class)


### PR DESCRIPTION
## Problem

When running the jdbc source connector in bulk mode (`mode=bulk`) the `JdbcSourceTask` fetches the whole table in one go `SELECT * FROM {table}`. `poll.interval.ms` determines the speed by which the records are sent to the target topic. 
Once all records a committed to the topic  the next SELECT query is sent to the data base system. There is no other option to reduce the frequency of requests being send to the DB than increasing `poll.interval.ms`  which slows down the process of committing the messages to the target topic. 

This leads to a paradox situation if you want to poll a table only once day for example.

## Solution

With this pull request is suggest adding a `poll.sleep.ms` setting that allows the `JdbcSourceTask` to sleep after the whole table result set has been consumed. 

This setting can be used to limit the frequency at which the SQL server is being queried
without limiting the processing speed of already obtained result sets. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ x] no

##### If yes, where?


## Test Strategy

Test implemented : `io.confluent.connect.jdbc.source.JdbcSourceTaskUpdateTest.testBulkPeriodicLoadWithPollSleep()`

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
