### PR TITLE
[CCDB-2031] Fix quote.sql.identifiers=never not working for Oracle and Postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>io.zonky.test</groupId>
             <artifactId>embedded-postgres</artifactId>
-            <version>1.2.6</version>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -149,7 +149,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected final Set<String> tableTypes;
   protected final String jdbcUrl;
   protected final DatabaseDialectProvider.JdbcUrlInfo jdbcUrlInfo;
-  private final QuoteMethod quoteSqlIdentifiers;
+  protected final QuoteMethod quoteSqlIdentifiers;
   private final IdentifierRules defaultIdentifierRules;
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();
   private final Queue<Connection> connections = new ConcurrentLinkedQueue<>();

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -22,6 +22,7 @@ import io.confluent.connect.jdbc.sink.PreparedStatementBinder;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import java.io.ByteArrayInputStream;
 import java.io.StringReader;
@@ -363,5 +364,18 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     return super.sanitizedUrl(url)
                 .replaceAll("(:thin:[^/]*)/([^@]*)@", "$1/****@")
                 .replaceAll("(:oci[^:]*:[^/]*)/([^@]*)@", "$1/****@");
+  }
+
+  @Override
+  public TableId parseTableIdentifier(String fqn) {
+    TableId tableId = super.parseTableIdentifier(fqn);
+    if (quoteSqlIdentifiers == QuoteMethod.NEVER) {
+      tableId = new TableId(
+          tableId.catalogName(),
+          tableId.schemaName(),
+          tableId.tableName().toUpperCase()
+      );
+    }
+    return tableId;
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -23,6 +23,7 @@ import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
 import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -157,6 +158,13 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           result.catalogName(),
           result.schemaName(),
           newTableName
+      );
+    }
+    if (quoteSqlIdentifiers == QuoteMethod.NEVER) {
+      result = new TableId(
+          result.catalogName(),
+          result.schemaName(),
+          result.tableName().toLowerCase()
       );
     }
     return result;

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/OracleDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/OracleDatatypeIT.java
@@ -258,10 +258,12 @@ public class OracleDatatypeIT extends BaseConnectorIT {
         final Schema schema = SchemaBuilder.struct().name("com.example.Person")
             .field("firstname", Schema.STRING_SCHEMA)
             .field("lastname", Schema.STRING_SCHEMA)
+            .field("KEY", Schema.INT32_SCHEMA)
             .build();
         final Struct struct = new Struct(schema)
             .put("firstname", "Christina")
-            .put("lastname", "Brams");
+            .put("lastname", "Brams")
+            .put("KEY", 1);
 
         String kafkaValue = new String(jsonConverter.fromConnectData(mixedCaseTopicName, schema, struct));
         connect.kafka().produce(mixedCaseTopicName, null, kafkaValue);
@@ -295,10 +297,12 @@ public class OracleDatatypeIT extends BaseConnectorIT {
         final Schema schema = SchemaBuilder.struct().name("com.example.Person")
             .field("firstname", Schema.STRING_SCHEMA)
             .field("lastname", Schema.STRING_SCHEMA)
+            .field("KEY", Schema.INT32_SCHEMA)
             .build();
         final Struct struct = new Struct(schema)
             .put("firstname", "Christina")
-            .put("lastname", "Brams");
+            .put("lastname", "Brams")
+            .put("KEY", 1);
 
         String kafkaValue = new String(jsonConverter.fromConnectData(mixedCaseTopicName, schema, struct));
         connect.kafka().produce(mixedCaseTopicName, null, kafkaValue);

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/OracleDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/OracleDatatypeIT.java
@@ -242,6 +242,43 @@ public class OracleDatatypeIT extends BaseConnectorIT {
         testShortAndLongString("update");
     }
 
+    @Test
+    public void testQuoteIdentifierNeverConfig() throws Exception {
+        String mixedCaseTopicName = "TestTopic";
+
+        connect.kafka().createTopic(mixedCaseTopicName, 1);
+
+        props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+        props.put(JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG, "NEVER");
+        props.put("topics", mixedCaseTopicName);
+        connect.configureConnector("jdbc-sink-connector", props);
+
+        waitForConnectorToStart("jdbc-sink-connector", 1);
+
+        final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+            .field("firstname", Schema.STRING_SCHEMA)
+            .field("lastname", Schema.STRING_SCHEMA)
+            .build();
+        final Struct struct = new Struct(schema)
+            .put("firstname", "Christina")
+            .put("lastname", "Brams");
+
+        String kafkaValue = new String(jsonConverter.fromConnectData(mixedCaseTopicName, schema, struct));
+        connect.kafka().produce(mixedCaseTopicName, null, kafkaValue);
+
+        waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(mixedCaseTopicName), 1, 1,
+            TimeUnit.MINUTES.toMillis(2));
+
+        String autoCreatedTableName = mixedCaseTopicName.toUpperCase();
+        try (Statement s = connection.createStatement()) {
+            ResultSet rs = s.executeQuery(
+                String.format("SELECT * FROM \"%s\" ORDER BY KEY DESC FETCH FIRST 1 ROWS ONLY", autoCreatedTableName));
+            assertTrue(rs.next());
+            assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+            assertEquals(struct.getString("lastname"), rs.getString("lastname"));
+        }
+    }
+
     private void createShortAndLongStringTable() throws SQLException {
         try (Statement s = connection.createStatement()) {
             s.execute("CREATE TABLE " + tableName + "("

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -48,10 +48,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.MAX_RETRIES;
+import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -335,6 +337,45 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
           assertTrue(rs.next());
           assertEquals(secondStruct.getString("firstname"), rs.getString("firstname"));
           assertEquals(secondStruct.getString("lastname"), rs.getString("lastname"));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testQuoteIdentifierNeverConfig() throws Exception {
+    String mixedCaseTopicName = "TestTopic";
+
+    connect.kafka().createTopic(mixedCaseTopicName, 1);
+
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG, "NEVER");
+    props.put("topics", mixedCaseTopicName);
+    connect.configureConnector("jdbc-sink-connector", props);
+
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstname", Schema.STRING_SCHEMA)
+        .field("lastname", Schema.STRING_SCHEMA)
+        .build();
+    final Struct struct = new Struct(schema)
+        .put("firstname", "Christina")
+        .put("lastname", "Brams");
+
+    String kafkaValue = new String(jsonConverter.fromConnectData(mixedCaseTopicName, schema, struct));
+    connect.kafka().produce(mixedCaseTopicName, null, kafkaValue);
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(mixedCaseTopicName), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    String autoCreatedTableName = mixedCaseTopicName.toLowerCase();
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery(String.format("SELECT * FROM \"%s\"", autoCreatedTableName))) {
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(struct.getString("lastname"), rs.getString("lastname"));
         }
       }
     }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -48,12 +48,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.MAX_RETRIES;
-import static io.confluent.connect.jdbc.sink.JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -351,6 +349,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     props.put(JdbcSinkConfig.AUTO_CREATE, "true");
     props.put(JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG, "NEVER");
     props.put("topics", mixedCaseTopicName);
+
     connect.configureConnector("jdbc-sink-connector", props);
 
     waitForConnectorToStart("jdbc-sink-connector", 1);
@@ -373,6 +372,45 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
       try (Statement s = c.createStatement()) {
         try (ResultSet rs = s.executeQuery(String.format("SELECT * FROM \"%s\"", autoCreatedTableName))) {
+          assertTrue(rs.next());
+          assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(struct.getString("lastname"), rs.getString("lastname"));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testQuoteIdentifierAlwaysConfig() throws Exception {
+    String mixedCaseTopicName = "TestTopic";
+
+    connect.kafka().createTopic(mixedCaseTopicName, 1);
+
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG, "ALWAYS");
+    props.put("topics", mixedCaseTopicName);
+
+    connect.configureConnector("jdbc-sink-connector", props);
+
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstname", Schema.STRING_SCHEMA)
+        .field("lastname", Schema.STRING_SCHEMA)
+        .build();
+    final Struct struct = new Struct(schema)
+        .put("firstname", "Christina")
+        .put("lastname", "Brams");
+
+    String kafkaValue = new String(jsonConverter.fromConnectData(mixedCaseTopicName, schema, struct));
+    connect.kafka().produce(mixedCaseTopicName, null, kafkaValue);
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(mixedCaseTopicName), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery(String.format("SELECT * FROM \"%s\"", mixedCaseTopicName))) {
           assertTrue(rs.next());
           assertEquals(struct.getString("firstname"), rs.getString("firstname"));
           assertEquals(struct.getString("lastname"), rs.getString("lastname"));


### PR DESCRIPTION
## Problem
[CCDB-2031](https://confluentinc.atlassian.net/browse/CCDB-2031)
When a user has configured the `quote.sql.identifiers` property to `NEVER`, then current implementation of the connector does not honor it in all cases. Method calls which build the SQL statement in code are using the `ExpressionBuilder` class to correctly quote the table names. However, method calls that directly invoke a jdbc method with the table name do not take this into account. They are case sensitive

## Solution
Overrided parseTableIdentifier method for oracle and postgres dialect, to check for config value and make the whole table name uppercase in case of Oracle and lowercase in case of Postgres.
Note: This issue might be prevalent in other dialects as well but this PR is only addressing these 2 dialects for now.

Also bumped postgres-embedding library version used in integration tests to make it compatible with m1 macs.
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CCDB-2031]: https://confluentinc.atlassian.net/browse/CCDB-2031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ