### PR TITLE
[CC-24497] Added validation for column check

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceTaskLifecycleTest.java
@@ -148,6 +148,7 @@ public class JdbcSourceTaskLifecycleTest extends JdbcSourceTaskTestBase {
     // Should request a connection, then should close it on stop()
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
     EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
+    EasyMock.expect(mockCachedConnectionProvider.getConnection()).andReturn(db.getConnection());
     mockCachedConnectionProvider.close(true);
 
     PowerMock.expectLastCall();

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
@@ -84,7 +84,7 @@ public class PauseResumeIT {
   @Test
   public void testPauseResume() throws Exception {
     try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {
-      stmt.executeUpdate("CREATE TABLE test_table ( c1 text )");
+      stmt.executeUpdate("CREATE TABLE test_table ( c1 text, id SERIAL PRIMARY KEY )");
     }
 
     connect.configureConnector(CONNECTOR_NAME, props);


### PR DESCRIPTION
## Problem
Ref: [CC-24497](https://confluentinc.atlassian.net/browse/CC-24497)

## Solution
Added a check that sees if column names supplied as part of configuration do exist in at least one table. This prevents misuse of these configuration which can be used for SQL injection.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-24497]: https://confluentinc.atlassian.net/browse/CC-24497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ