### PR TITLE
[CC-25311] Bump postgres driver version to 42.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>8.4.1.jre8</mssqlserver.jdbc.driver.version>
-        <postgresql.version>42.4.3</postgresql.version>
+        <postgresql.version>42.4.4</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -139,6 +139,8 @@ public class JdbcSourceConnectorTest {
     // Close with stopping will be invoked when the connector is stopped
     mockCachedConnectionProvider.close(true);
     PowerMock.expectLastCall().atLeastOnce();
+    mockCachedConnectionProvider.close();
+    PowerMock.expectLastCall().anyTimes();
 
     PowerMock.replayAll();
 


### PR DESCRIPTION
## Problem
[CC-25311](https://confluentinc.atlassian.net/browse/CC-25311)

## Solution
Bumped postgres driver version from 42.4.3 -> 42.4.4

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-25311]: https://confluentinc.atlassian.net/browse/CC-25311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ