### PR TITLE
DP-13727 Add CodeArtifact package paths to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,3 +13,7 @@ semaphore:
   extra_build_args: "-Dcloud -Pjenkins"
   run_pint_merge: true
   generate_connect_changelogs: true
+code_artifact:
+  enable: true
+  package_paths:
+    - maven-snapshots/maven/io.confluent/kafka-connect-jdbc


### PR DESCRIPTION
One of the Capsaicin requirements requires that all artifacts uploaded to CodeArtifacts come from specific Semaphore jobs.
This PR adds package_paths to service.yml so that each GitHub repo can declare the path of the CodeArtifact packages that it writes to.
For newer GitHub repos, the package_paths needs to be added to the service.yml file manually before it can write to CodeArtifact in the Semaphore pipeline.
For more information about this, see https://confluent.slack.com/archives/C038ZJ00P/p1708464192287999
