### PR TITLE
Jorgerojasdev/sink null control

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -150,6 +150,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected final String jdbcUrl;
   protected final DatabaseDialectProvider.JdbcUrlInfo jdbcUrlInfo;
   protected final QuoteMethod quoteSqlIdentifiers;
+  protected boolean enabledSinkNullKeyProtection;
   private final IdentifierRules defaultIdentifierRules;
   private final AtomicReference<IdentifierRules> identifierRules = new AtomicReference<>();
   private final Queue<Connection> connections = new ConcurrentLinkedQueue<>();
@@ -190,6 +191,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       quoteSqlIdentifiers = QuoteMethod.get(
           config.getString(JdbcSinkConfig.QUOTE_SQL_IDENTIFIERS_CONFIG)
       );
+      enabledSinkNullKeyProtection = config.getBoolean(JdbcSinkConfig.ENABLE_NULL_KEY_PROTECTION);
     } else {
       catalogPattern = config.getString(JdbcSourceTaskConfig.CATALOG_PATTERN_CONFIG);
       schemaPattern = config.getString(JdbcSourceTaskConfig.SCHEMA_PATTERN_CONFIG);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -166,6 +166,13 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "the connector, e.g. ``UPDATE``.";
   private static final String INSERT_MODE_DISPLAY = "Insert Mode";
 
+  public static final String ENABLE_NULL_KEY_PROTECTION = "enable.null.key.protection";
+  private static final String ENABLE_NULL_KEY_PROTECTION_DEFAULT = "false";
+  private static final String ENABLE_NULL_KEY_PROTECTION_DOC =
+      "If upsert mode is enabled (Only in OracleDialect), the system will protect \n"
+          + "<table.column>=<incoming.column> to prevent 0 row results in nullable keys.";
+  private static final String ENABLE_NULL_KEY_PROTECTION_DISPLAY = "Enable Null Key Protection";
+
   public static final String PK_FIELDS = "pk.fields";
   private static final String PK_FIELDS_DEFAULT = "";
   private static final String PK_FIELDS_DOC =
@@ -388,6 +395,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.MEDIUM,
             TABLE_TYPES_DISPLAY
         )
+        .define(
+            ENABLE_NULL_KEY_PROTECTION,
+            ConfigDef.Type.BOOLEAN,
+            ENABLE_NULL_KEY_PROTECTION_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            ENABLE_NULL_KEY_PROTECTION_DOC,
+            WRITES_GROUP,
+            5,
+            ConfigDef.Width.MEDIUM,
+            ENABLE_NULL_KEY_PROTECTION_DISPLAY
+        )
         // Data Mapping
         .define(
             TABLE_NAME_FORMAT,
@@ -545,6 +563,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final boolean useHoldlockInMerge;
 
   public final boolean trimSensitiveLogsEnabled;
+  public final boolean enableNullKeyProtection;
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
@@ -575,6 +594,7 @@ public class JdbcSinkConfig extends AbstractConfig {
           "Primary key mode must be 'record_key' when delete support is enabled");
     }
     tableTypes = TableType.parse(getList(TABLE_TYPES_CONFIG));
+    enableNullKeyProtection = getBoolean(ENABLE_NULL_KEY_PROTECTION);
   }
 
   private String getPasswordValue(String key) {


### PR DESCRIPTION
## Problem
In different insertion, upsert, and deletion queries, there is a need to reimplement the WHERE clause in Sink connectors to ensure that when a null value in a key is received, if the record exists in the database, it is correctly detected. For example: UPDATE <TABLE> SET EXAMPLE=1 WHERE KEY_1=2 AND KEY_2 = NULL. In this case, the clause KEY_2 = NULL does not return results, however, KEY_2 IS NULL does return them correctly.

## Solution
A new optional version is implemented (initially with the upsert mode of OracleDatabaseDialect) to address this issue. In this case, in the ON clause of:
MERGE INTO <TABLE> using (SELECT...) incoming ON (KEY_1=incoming."KEY_1" AND KEY_2=incoming."KEY_2")

Since the type cannot be inferred, it is converted with the boolean parameter enable.null.key.protection into the following query:
MERGE INTO <TABLE> using (SELECT...) incoming ON ((KEY_1=incoming."KEY_1" OR (KEY_1 IS NULL AND incoming."KEY_1" IS NULL)) AND (KEY_2=incoming."KEY_2" OR (KEY_2 IS NULL AND incoming."KEY_2" IS NULL)))

This way, we protect the use case where the key is null. I have implemented it through an additional parameter to avoid sacrificing performance if it's not really necessary.

Is it interesting to continue this process for all upsert, update, and delete operations?

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests
