### PR TITLE
CC-25569: add schema and catalog info to the TableID object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,9 @@
         <class.coverage.threshold>0.91</class.coverage.threshold>
         <complexity.coverage.threshold>0.65</complexity.coverage.threshold>
         <line.coverage.threshold>0.80</line.coverage.threshold>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
     </properties>
-
     <repositories>
         <repository>
             <id>confluent</id>
@@ -520,6 +521,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
@@ -527,6 +529,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
                 <executions>
                     <execution>
                         <!--normal integration tests should not run the memory-restricted tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.0</version>
+        <version>7.0.15-20</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -412,7 +412,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                 .addErrorMessage("Isolation mode of `"
                         + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
                         + "` can only be configured with a Sql Server Dialect"
-          );
+            );
       }
     }
 


### PR DESCRIPTION
CC-25569: add schema and catalog info to the TableID object

Raised from base PR. Check here for the discussion - https://github.com/confluentinc/airlock-kafka-connect-jdbc/pull/2