### PR TITLE
Add default array value postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.0</version>
+        <version>7.0.15-20</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -412,7 +412,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
                 .addErrorMessage("Isolation mode of `"
                         + TransactionIsolationMode.SQL_SERVER_SNAPSHOT.name()
                         + "` can only be configured with a Sql Server Dialect"
-          );
+            );
       }
     }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -21,6 +21,7 @@ import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableDefinitionBuilder;
 import io.confluent.connect.jdbc.util.TableId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
 
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -591,6 +592,61 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     when(definition.scale()).thenReturn(5);
 
     assertEquals(5, dialect.decimalScale(definition));
+  }
+  @Test
+  public void testArrayDefaultsFormatting() {
+    PostgreSqlDatabaseDialect dialect = createDialect();
+
+    verifyArrayFormatting(dialect, new ExpressionBuilder(),
+            Collections.emptyList(),
+            "ARRAY[]");
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("simple", "string", "array"),
+            "ARRAY['simple','string','array']");
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("Van'Der Waal", "O'Neill", "l'église"),
+            "ARRAY['Van''Der Waal','O''Neill','l''église']");
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("double''quote", "already''escaped"),
+            "ARRAY['double''''quote','already''''escaped']");
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("contains \"quotes\"", "and 'apostrophes'"),
+            "ARRAY['contains \"quotes\"','and ''apostrophes''']");
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("backslash\\test", "percent%sign"),
+            "ARRAY['backslash\\test','percent%sign']");
+
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("newline\ntest", "tab\ttest", "return\rtest"),
+            "ARRAY['newline\ntest','tab\ttest','return\rtest']");
+
+    verifyArrayFormatting(dialect,  new ExpressionBuilder(),
+            Arrays.asList("mixed", "array", null, "with", "null"),
+            "ARRAY['mixed','array',NULL,'with','null']");
+
+    verifyArrayFormatting(dialect, new ExpressionBuilder(),
+            Arrays.asList("1", "2", "3", "4", "5"),
+            "ARRAY['1','2','3','4','5']");
+
+    verifyArrayFormatting(dialect, new ExpressionBuilder(),
+            Arrays.asList(1, 2, 3, 4, 5),
+            "ARRAY[1,2,3,4,5]");
+
+    verifyArrayFormatting(dialect, new ExpressionBuilder(),
+            Arrays.asList(true, false, true),
+            "ARRAY[TRUE,FALSE,TRUE]");
+  }
+
+  private <T> void verifyArrayFormatting(PostgreSqlDatabaseDialect dialect, ExpressionBuilder builder,
+                                         List<T> input, String expected) {
+    dialect.formatColumnValue(builder, null, null, Schema.Type.ARRAY, input);
+    assertEquals(expected, builder.toString());
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -24,6 +24,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -336,6 +337,58 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
           assertTrue(rs.next());
           assertEquals(secondStruct.getString("firstname"), rs.getString("firstname"));
           assertEquals(secondStruct.getString("lastname"), rs.getString("lastname"));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testTableCreatedWithArrayDefaults() throws Exception {
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC_NAME);
+    props.put(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+            .field("firstname", Schema.STRING_SCHEMA)
+            .field("lastname", Schema.STRING_SCHEMA)
+            .field("hobbies", SchemaBuilder.array(Schema.STRING_SCHEMA).defaultValue(Arrays.asList("Fencing","Horse Riding")).build())
+            .build();
+    final Struct firstStruct = new Struct(schema)
+            .put("firstname", "Christina")
+            .put("lastname", "Brams")
+            .put("hobbies", Arrays.asList("Skiing","Swimming"));
+    final Struct secondStruct = new Struct(schema)
+            .put("firstname", "Jerry")
+            .put("lastname", "Mcguire");
+
+    produceRecord(schema, firstStruct);
+    produceRecord(schema, secondStruct);
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
+            TimeUnit.MINUTES.toMillis(2));
+
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+      try (Statement s = c.createStatement()) {
+        try (ResultSet rs = s.executeQuery("SELECT * FROM " + tableName + " ORDER BY firstname")) {
+          assertTrue(rs.next());
+          assertEquals(firstStruct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(firstStruct.getString("lastname"), rs.getString("lastname"));
+
+          Array sqlArray = rs.getArray("hobbies");
+          List<String> actualHobbies = Arrays.asList((String[]) sqlArray.getArray());
+          assertEquals(firstStruct.getArray("hobbies"), actualHobbies);
+
+          // test the case where default values for array column should be picked
+          assertTrue(rs.next());
+          assertEquals(secondStruct.getString("firstname"), rs.getString("firstname"));
+          assertEquals(secondStruct.getString("lastname"), rs.getString("lastname"));
+
+          sqlArray = rs.getArray("hobbies");
+          actualHobbies = Arrays.asList((String[]) sqlArray.getArray());
+          assertEquals(Arrays.asList("Fencing", "Horse Riding"), actualHobbies);
         }
       }
     }


### PR DESCRIPTION
## Problem
Currently if auto create is on and postgres tries to create a table where the array has some default value in the schema it fails.

## Solution
Handle the ARRAY case separately in PostgresSQLDialect



<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
E2E tested on Docker Playgound.
```bash
#!/bin/bash
set -e

DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
source ${DIR}/../../scripts/utils.sh

PLAYGROUND_ENVIRONMENT=${PLAYGROUND_ENVIRONMENT:-"plaintext"}
playground start-environment --environment "${PLAYGROUND_ENVIRONMENT}" --docker-compose-override-file "${PWD}/docker-compose.plaintext.yml"

playground topic produce -t sometopic --nb-messages 1 --forced-value '{"timedate": 1699456838,"quantity": 1,"someEnum": "A","receiveFrequency": [1118420,1118419]}' << 'EOF'
{
  "fields": [
  {
    "name": "timedate",
      "type": "long"
  },
    {
    "default": 1,
      "name": "quantity",
        "type": "int"
    },
  {
    "name": "someEnum",
    "type": {
      "name": "FwdActiveChain",
      "symbols": [
	"A",
      "B",
      "Both"
      ],
      "type": "enum"
    }
  },
  {
    "default": [1,5],
    "name": "receiveFrequency",
    "type": {
      "items": "int",
      "type": "array"
    }
  }
  ],
  "name": "TerminalBaseStatistic",
  "namespace": "com.satcom.avro.terminalbasestatistic",
  "type": "record"
}
EOF



log "Creating JDBC PostgreSQL sink connector that should break"
playground connector create-or-update --connector postgres-sink-b << EOF
{
  "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
  "tasks.max": "1",
  "connection.url": "jdbc:postgresql://postgres/postgres?user=myuser&password=mypassword&ssl=false",
  "topics": "sometopic",
  "auto.create": "true",
  "dialect.name":"PostgreSqlDatabaseDialect"
}
EOF

sleep 5


playground topic produce -t sometopic --nb-messages 1 --forced-value '{"timedate": 1699456838,"quantity": 1,"someEnum": "A"}' << 'EOF'
{
  "fields": [
  {
    "name": "timedate",
      "type": "long"
  },
    {
    "default": 1,
      "name": "quantity",
        "type": "int"
    },
  {
    "name": "someEnum",
    "type": {
      "name": "FwdActiveChain",
      "symbols": [
	"A",
      "B",
      "Both"
      ],
      "type": "enum"
    }
  }
  ],
  "name": "TerminalBaseStatistic",
  "namespace": "com.satcom.avro.terminalbasestatistic",
  "type": "record"
}
EOF

log "Show content of ORDERS table:"
docker exec postgres bash -c "psql -U myuser -d postgres -c 'SELECT * FROM sometopic'" > /tmp/result.log  2>&1
cat /tmp/result.log
grep "foo" /tmp/result.log
```

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
