### PR TITLE
Change common pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
     <packaging>jar</packaging>
-    <version>10.7.10</version>
+    <version>10.7.11-SNAPSHOT</version>
     <name>kafka-connect-jdbc</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -49,7 +49,7 @@
         <connection>scm:git:git://github.com/confluentinc/kafka-connect-jdbc.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-jdbc.git</developerConnection>
         <url>https://github.com/confluentinc/kafka-connect-jdbc</url>
-        <tag>v10.7.10</tag>
+        <tag>10.7.x</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
Use the same version as [elasticsearchsink](https://github.com/confluentinc/kafka-connect-elasticsearch/blob/88c669db8d3b324265c0418e879fade5bf849693/pom.xml#L8). ie. `7.0.12`.
I have confirmed using the effective pom that the distributionManagement comes from the common in case of `7.0.12` but for some reason it is not there in `7.0.15-20`.

Also the `dependency.check.skip` is true as well in the `7.0.12`.

## Problem
Job was failing with this.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project kafka-connect-jdbc: Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

This is because in the version `7..0.15-20` it doesn't bring the `distributionManagement` transiently, so I had to add that manually.


```
  <distributionManagement>
    <repository>
      <id>aws-release</id>
      <name>AWS Release Repository</name>
      <url>${confluent.release.repo}</url>
    </repository>
    <snapshotRepository>
      <id>aws-snapshot</id>
      <name>AWS Snapshot Repository</name>
      <url>${confluent.snapshot.repo}</url>
    </snapshotRepository>
  </distributionManagement>
```


And these two variables are passed during the build with mvn ... -Dconfluent.release.repo and -Dconfluent.snapshot.repo

I had manually added 
```
    <distributionManagement>
        <repository>
            <id>confluent-codeartifact-internal</id>
            <url>https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-releases</url>
        </repository>
    </distributionManagement>
```

which is wrong.