### PR TITLE
add replace.null.with.default for JdbcSink

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -536,7 +536,8 @@ public interface DatabaseDialect extends ConnectionProvider {
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      JdbcSinkConfig.InsertMode insertMode
+      JdbcSinkConfig.InsertMode insertMode,
+      boolean replaceNullWithDefault
   );
 
   /**
@@ -560,9 +561,11 @@ public interface DatabaseDialect extends ConnectionProvider {
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
       TableDefinition tableDefinition,
-      JdbcSinkConfig.InsertMode insertMode
+      JdbcSinkConfig.InsertMode insertMode,
+      boolean replaceNullWithDefault
   ) {
-    return statementBinder(statement, pkMode, schemaPair, fieldsMetadata, insertMode);
+    return statementBinder(statement, pkMode, schemaPair, fieldsMetadata, insertMode,
+        replaceNullWithDefault);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1627,7 +1627,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      InsertMode insertMode
+      InsertMode insertMode,
+      boolean replaceNullWithDefault
   ) {
     return new PreparedStatementBinder(
         this,
@@ -1635,7 +1636,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         pkMode,
         schemaPair,
         fieldsMetadata,
-        insertMode
+        insertMode,
+        replaceNullWithDefault
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -97,7 +97,8 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
       TableDefinition tableDefinition,
-      InsertMode insertMode
+      InsertMode insertMode,
+      boolean replaceNullWithDefault
   ) {
     return new PreparedStatementBinder(
         this,
@@ -106,7 +107,8 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
         schemaPair,
         fieldsMetadata,
         tableDefinition,
-        insertMode
+        insertMode,
+        replaceNullWithDefault
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -134,7 +134,8 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
       TableDefinition tableDefinition,
-      InsertMode insertMode
+      InsertMode insertMode,
+      boolean replaceNullWithDefault
   ) {
     return new PreparedStatementBinder(
         this,
@@ -143,7 +144,8 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
         schemaPair,
         fieldsMetadata,
         tableDefinition,
-        insertMode
+        insertMode,
+        replaceNullWithDefault
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialect.java
@@ -152,7 +152,8 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
       TableDefinition tableDefinition,
-      InsertMode insertMode
+      InsertMode insertMode,
+      boolean replaceNullWithDefault
   ) {
     return new PreparedStatementBinder(
         this,
@@ -161,7 +162,8 @@ public class SybaseDatabaseDialect extends GenericDatabaseDialect {
         schemaPair,
         fieldsMetadata,
         tableDefinition,
-        insertMode
+        insertMode,
+        replaceNullWithDefault
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -142,7 +142,8 @@ public class BufferedRecords {
           schemaPair,
           fieldsMetadata,
           dbStructure.tableDefinition(connection, tableId),
-          config.insertMode
+          config.insertMode,
+          config.replaceNullWithDefault
       );
       if (config.deleteEnabled && nonNull(deleteSql)) {
         deletePreparedStatement = dbDialect.createPreparedStatement(connection, deleteSql);
@@ -152,7 +153,8 @@ public class BufferedRecords {
             schemaPair,
             fieldsMetadata,
             dbStructure.tableDefinition(connection, tableId),
-            config.insertMode
+            config.insertMode,
+            config.replaceNullWithDefault
         );
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -144,6 +144,13 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "to be ``record_key``.";
   private static final String DELETE_ENABLED_DISPLAY = "Enable deletes";
 
+  public static final String REPLACE_NULL_WITH_DEFAULT = "replace.null.with.default";
+  private static final String REPLACE_NULL_WITH_DEFAULT_DEFAULT = "true";
+  private static final String REPLACE_NULL_WITH_DEFAULT_DOC =
+      "Whether to replace ``null`` value with default value";
+  private static final String REPLACE_NULL_WITH_DEFAULT_DISPLAY = "Replace null value with "
+      + "default value";
+
   public static final String AUTO_CREATE = "auto.create";
   private static final String AUTO_CREATE_DEFAULT = "false";
   private static final String AUTO_CREATE_DOC =
@@ -405,6 +412,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.MEDIUM,
             TABLE_TYPES_DISPLAY
         )
+        .define(
+            REPLACE_NULL_WITH_DEFAULT,
+            ConfigDef.Type.BOOLEAN,
+            REPLACE_NULL_WITH_DEFAULT_DEFAULT,
+            ConfigDef.Importance.LOW,
+            REPLACE_NULL_WITH_DEFAULT_DOC,
+            WRITES_GROUP,
+            5,
+            ConfigDef.Width.MEDIUM,
+            REPLACE_NULL_WITH_DEFAULT_DISPLAY
+        )
         // Data Mapping
         .define(
             TABLE_NAME_FORMAT,
@@ -561,6 +579,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String tableNameFormat;
   public final int batchSize;
   public final boolean deleteEnabled;
+  public final boolean replaceNullWithDefault;
   public final int maxRetries;
   public final int retryBackoffMs;
   public final boolean autoCreate;
@@ -588,6 +607,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
     deleteEnabled = getBoolean(DELETE_ENABLED);
+    replaceNullWithDefault = getBoolean(REPLACE_NULL_WITH_DEFAULT);
     maxRetries = getInt(MAX_RETRIES);
     retryBackoffMs = getInt(RETRY_BACKOFF_MS);
     autoCreate = getBoolean(AUTO_CREATE);

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -137,7 +137,7 @@ public class JdbcDbWriterTest {
     PreparedStatement mockStatement = mock(PreparedStatement.class);
     when(dialect.parseTableIdentifier(any())).thenReturn(mock(TableId.class));
     when(dialect.createPreparedStatement(any(), any())).thenReturn(mockStatement);
-    when(dialect.statementBinder(any(), any(), any(), any(), any(), any()))
+    when(dialect.statementBinder(any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(mock(PreparedStatementBinder.class));
     when(mockStatement.executeBatch()).thenReturn(new int[3]);
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -178,7 +178,8 @@ public class PreparedStatementBinderTest {
         schemaPair,
         fieldsMetadata,
         tabDef,
-        JdbcSinkConfig.InsertMode.INSERT
+        JdbcSinkConfig.InsertMode.INSERT,
+        true
     );
 
     binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -252,7 +253,8 @@ public class PreparedStatementBinderTest {
               statement,
               pkMode,
               schemaPair,
-              fieldsMetadata, tabDef, JdbcSinkConfig.InsertMode.UPSERT
+              fieldsMetadata, tabDef, JdbcSinkConfig.InsertMode.UPSERT,
+          true
       );
 
       binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -303,7 +305,8 @@ public class PreparedStatementBinderTest {
               statement,
               pkMode,
               schemaPair,
-              fieldsMetadata, tabDef, JdbcSinkConfig.InsertMode.UPDATE
+              fieldsMetadata, tabDef, JdbcSinkConfig.InsertMode.UPDATE,
+          true
       );
 
       binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));


### PR DESCRIPTION
## Problem
When used with Kafka connect, there are cases where null values ​in the record ​are changed to default values.
In kafka-connect library v3.5, [`replace.null.with.default` option was added ](https://issues.apache.org/jira/browse/KAFKA-8713)to prevent null values ​​from always being replaced with default values ​​when converting json.
But, the column constraints related to default values ​​still remain in the record, so null values ​​are entered as default values ​​when building insert/update queries in JdbcSink.



## Solution
Add  `replace.null.with.default` option to choose whether null values should be changed to default values or not.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
