### PR TITLE
Add support for Custom Credentials Provider Class in JDBC connectors

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -34,13 +34,19 @@ import io.confluent.connect.jdbc.util.ConfigUtils;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.DeleteEnabledRecommender;
 import io.confluent.connect.jdbc.util.EnumRecommender;
+import io.confluent.connect.jdbc.util.JdbcCredentialsProvider;
+import io.confluent.connect.jdbc.util.JdbcCredentialsProviderValidator;
 import io.confluent.connect.jdbc.util.PrimaryKeyModeRecommender;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.StringUtils;
 import io.confluent.connect.jdbc.util.TableType;
 import io.confluent.connect.jdbc.util.TimeZoneValidator;
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 
@@ -288,6 +294,24 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String MSSQL_USE_MERGE_HOLDLOCK_DISPLAY =
       "SQL Server - Use HOLDLOCK in MERGE";
 
+  /**
+   * The properties that begin with this prefix will be used to configure a class, specified by
+   * {@code jdbc.credentials.provider.class} if it implements {@link Configurable}.
+   */
+  public static final String CREDENTIALS_PROVIDER_CONFIG_PREFIX =
+      JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
+  public static final String CREDENTIALS_PROVIDER_CLASS_CONFIG =
+      JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG;
+  public static final Class<? extends JdbcCredentialsProvider> CREDENTIALS_PROVIDER_CLASS_DEFAULT =
+      JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_DEFAULT;
+
+  public static final String CREDENTIALS_PROVIDER_CLASS_DISPLAY =
+      JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_DISPLAY;
+
+  public static final String CREDENTIALS_PROVIDER_CLASS_DOC =
+      JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_DOC;
+
+
   public static final ConfigDef CONFIG_DEF = new ConfigDef()
         // Connection
         .define(
@@ -322,8 +346,18 @@ public class JdbcSinkConfig extends AbstractConfig {
             3,
             ConfigDef.Width.MEDIUM,
             CONNECTION_PASSWORD_DISPLAY
-        )
-        .define(
+        ).define(
+            CREDENTIALS_PROVIDER_CLASS_CONFIG,
+            Type.CLASS,
+            CREDENTIALS_PROVIDER_CLASS_DEFAULT,
+            new JdbcCredentialsProviderValidator(),
+            Importance.LOW,
+            CREDENTIALS_PROVIDER_CLASS_DOC,
+            CONNECTION_GROUP,
+            4,
+            Width.LONG,
+            CREDENTIALS_PROVIDER_CLASS_DISPLAY
+      ).define(
             DIALECT_NAME_CONFIG,
             ConfigDef.Type.STRING,
             DIALECT_NAME_DEFAULT,
@@ -331,7 +365,7 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             DIALECT_NAME_DOC,
             CONNECTION_GROUP,
-            4,
+            5,
             ConfigDef.Width.LONG,
             DIALECT_NAME_DISPLAY,
             DatabaseDialectRecommender.INSTANCE
@@ -344,7 +378,7 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             CONNECTION_ATTEMPTS_DOC,
             CONNECTION_GROUP,
-            5,
+            6,
             ConfigDef.Width.SHORT,
             CONNECTION_ATTEMPTS_DISPLAY
         ).define(
@@ -354,7 +388,7 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             CONNECTION_BACKOFF_DOC,
             CONNECTION_GROUP,
-            6,
+            7,
             ConfigDef.Width.SHORT,
             CONNECTION_BACKOFF_DISPLAY
         )

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -32,7 +32,10 @@ import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.util.DatabaseDialectRecommender;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.DefaultJdbcCredentialsProvider;
 import io.confluent.connect.jdbc.util.EnumRecommender;
+import io.confluent.connect.jdbc.util.JdbcCredentialsProvider;
+import io.confluent.connect.jdbc.util.JdbcCredentialsProviderValidator;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TimeZoneValidator;
 
@@ -40,6 +43,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
@@ -324,6 +328,23 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           "Number of times to retry SQL exceptions encountered when executing queries.";
   public static final String QUERY_RETRIES_DISPLAY = "Query Retry Attempts";
 
+  /**
+   * The properties that begin with this prefix will be used to configure a class, specified by
+   * {@code jdbc.credentials.provider.class} if it implements {@link Configurable}.
+   */
+  public static final String CREDENTIALS_PROVIDER_CONFIG_PREFIX = "jdbc.credentials.provider.";
+
+  public static final String CREDENTIALS_PROVIDER_CLASS_CONFIG = CREDENTIALS_PROVIDER_CONFIG_PREFIX
+      + "class";
+  public static final Class<? extends JdbcCredentialsProvider> CREDENTIALS_PROVIDER_CLASS_DEFAULT =
+      DefaultJdbcCredentialsProvider.class;
+
+  public static final String CREDENTIALS_PROVIDER_CLASS_DISPLAY = "JDBC Credentials Provider Class";
+
+  public static final String CREDENTIALS_PROVIDER_CLASS_DOC = "Credentials provider or provider "
+      + "chain to use for authentication to database. By default the connector uses ``"
+      + DefaultJdbcCredentialsProvider.class.getName() + "``.";
+
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -455,6 +476,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.SHORT,
         CONNECTION_PASSWORD_DISPLAY
+    ).define(
+        CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        Type.CLASS,
+        CREDENTIALS_PROVIDER_CLASS_DEFAULT,
+        new JdbcCredentialsProviderValidator(),
+        Importance.LOW,
+        CREDENTIALS_PROVIDER_CLASS_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.LONG,
+        CREDENTIALS_PROVIDER_CLASS_DISPLAY
     ).define(
         CONNECTION_ATTEMPTS_CONFIG,
         Type.INT,

--- a/src/main/java/io/confluent/connect/jdbc/util/BasicJdbcCredentials.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/BasicJdbcCredentials.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+public class BasicJdbcCredentials implements JdbcCredentials {
+
+  String username;
+  String password;
+
+  public BasicJdbcCredentials(String user, String password) {
+    this.username = user;
+    this.password = password;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/DefaultJdbcCredentialsProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DefaultJdbcCredentialsProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
+
+public class DefaultJdbcCredentialsProvider implements JdbcCredentialsProvider, Configurable {
+
+  private static final String DB_USERNAME_CONFIG = "connection.user";
+  private static final String DB_PASSWORD_CONFIG = "connection.password";
+  String username;
+  String password;
+
+  @Override
+  public JdbcCredentials getJdbcCredentials() {
+    return new BasicJdbcCredentials(username, password);
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+    username = (String) map.get(DB_USERNAME_CONFIG);
+    password = (String) map.get(DB_PASSWORD_CONFIG);
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcCredentials.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcCredentials.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+public interface JdbcCredentials {
+
+  /**
+   * @return Username to use for authentication to database
+   */
+  String getUsername();
+
+  /**
+   *
+   * @return Password/Token to use for authentication to database
+   */
+  String getPassword();
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcCredentialsProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcCredentialsProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+public interface JdbcCredentialsProvider {
+
+  /**
+   * @return JdbcCredentials which caller can use for authentication purpose
+   */
+  JdbcCredentials getJdbcCredentials();
+
+  /**
+   * Instructs the provider to refresh or renew credentials.
+   * Default behavior is no-op.
+   */
+  default void refresh() {
+    // no need to refresh anything by default
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/JdbcCredentialsProviderValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/JdbcCredentialsProviderValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class JdbcCredentialsProviderValidator implements ConfigDef.Validator {
+  @Override
+  public void ensureValid(String name, Object provider) {
+    if (provider != null && provider instanceof Class
+        && JdbcCredentialsProvider.class.isAssignableFrom((Class<?>) provider)) {
+      return;
+    }
+    throw new ConfigException(
+        name,
+        provider,
+        "Class must extend: " + JdbcCredentialsProvider.class
+    );
+  }
+
+  @Override
+  public String toString() {
+    return "Any class implementing: " + JdbcCredentialsProvider.class;
+  }
+}
+

--- a/src/main/java/io/confluent/connect/jdbc/util/StringUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/StringUtils.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.jdbc.util;
 
+import static org.apache.kafka.common.utils.Utils.isBlank;
+
 import org.apache.kafka.connect.data.Schema;
 
 /**
@@ -71,5 +73,9 @@ public class StringUtils {
       default:
         return schema.type().getName();
     }
+  }
+
+  public static boolean isNotBlank(String string) {
+    return !isBlank(string);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -133,6 +133,14 @@ public class JdbcSinkConfigTest {
     assertTableTypes(TableType.TABLE);
   }
 
+  @Test(expected = ConfigException.class)
+  public void shouldFailToCreateConfigWithInvalidCredentialsProviderClass() {
+    // Configuring SqliteHelper Class here which does not extends JdbcCredentialsProvider Interface
+    props.put(JdbcSinkConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        SqliteHelper.class.getName());
+    createConfig();
+  }
+
   protected void createConfig() {
     config = new JdbcSinkConfig(props);
   }

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigTest.java
@@ -14,6 +14,7 @@
  */
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.util.DefaultJdbcCredentialsProvider;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Recommender;
 import org.apache.kafka.common.config.ConfigValue;
@@ -251,6 +252,31 @@ public class JdbcSourceConnectorConfigTest {
         validatedConfig.get(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG);
     assertNotNull(connectionAttemptsConfig);
     assertFalse(connectionAttemptsConfig.errorMessages().isEmpty());
+  }
+
+  @Test
+  public void testCredentialsProviderClassConfig() {
+    // Configuring MockTime Class here which does not extends JdbcCredentialsProvider Interface
+    props.put(JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        MockTime.class.getName());
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    ConfigValue credentialsProviderConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG);
+
+    assertNotNull(credentialsProviderConfig);
+    assertFalse(credentialsProviderConfig.errorMessages().isEmpty());
+
+    // Configuring DefaultJdbcCredentialsProvider Class here which extends JdbcCredentialsProvider
+    // Interface
+    props.put(JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        DefaultJdbcCredentialsProvider.class.getName());
+    validatedConfig =
+        JdbcSourceConnectorConfig.baseConfigDef().validateAll(props);
+    credentialsProviderConfig =
+        validatedConfig.get(JdbcSourceConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG);
+    assertNotNull(credentialsProviderConfig);
+    assertTrue(credentialsProviderConfig.errorMessages().isEmpty());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/io/confluent/connect/jdbc/util/DefaultJdbcCredentialsProviderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DefaultJdbcCredentialsProviderTest.java
@@ -1,0 +1,46 @@
+package io.confluent.connect.jdbc.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultJdbcCredentialsProviderTest {
+
+  DefaultJdbcCredentialsProvider defaultCredentialsProvider;
+  String testUsername = "username";
+  String testPassword = "password";
+
+  @Before
+  public void setup() {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put("connection.user", testUsername);
+    configMap.put("connection.password", testPassword);
+
+    defaultCredentialsProvider = new DefaultJdbcCredentialsProvider();
+    defaultCredentialsProvider.configure(configMap);
+
+  }
+  @Test
+  public void testDatabaseCredsAreConfigurable() {
+    // Assert username and password are configured to test values which is configured in setup method
+    assertEquals(testUsername, defaultCredentialsProvider.getJdbcCredentials().getUsername());
+    assertEquals(testPassword, defaultCredentialsProvider.getJdbcCredentials().getPassword());
+  }
+
+  // Test Default Refresh Functionality (which is NoOp)
+  @Test
+  public void testDefaultRefreshFunctionality() {
+
+    assertEquals(testUsername, defaultCredentialsProvider.getJdbcCredentials().getUsername());
+    assertEquals(testPassword, defaultCredentialsProvider.getJdbcCredentials().getPassword());
+
+    defaultCredentialsProvider.refresh();
+
+    // Assert username and password are same
+    assertEquals(testUsername, defaultCredentialsProvider.getJdbcCredentials().getUsername());
+    assertEquals(testPassword, defaultCredentialsProvider.getJdbcCredentials().getPassword());
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/TestConfigurableJdbcCredentialsProvider.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TestConfigurableJdbcCredentialsProvider.java
@@ -1,0 +1,26 @@
+package io.confluent.connect.jdbc.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
+
+/**
+ * This is a test class for JdbcCredentialsProvider Interface which is created to test the
+ * configurable functionality
+ */
+public class TestConfigurableJdbcCredentialsProvider implements JdbcCredentialsProvider,
+    Configurable {
+
+  Map<String, ?> configMap = new HashMap<>();
+
+  @Override
+  public void configure(Map<String, ?> map) {
+    configMap = new HashMap<>(map);
+  }
+
+  @Override
+  public JdbcCredentials getJdbcCredentials() {
+    return new BasicJdbcCredentials((String) configMap.get("username"),
+        (String) configMap.get("password"));
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/TestRefreshJdbcCredentialsProvider.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TestRefreshJdbcCredentialsProvider.java
@@ -1,0 +1,29 @@
+package io.confluent.connect.jdbc.util;
+
+/**
+ * This is a test Class for JdbcCredentialsProvider Interface which is created to test the refresh
+ * functionality. The password is updated everytime credentials are fetched through
+ * 'getJdbcCredentials()' method.
+ */
+public class TestRefreshJdbcCredentialsProvider implements JdbcCredentialsProvider {
+
+  String username = "test-user";
+  String password;
+  private int numRotations;
+
+  public TestRefreshJdbcCredentialsProvider() {
+    numRotations = 0;
+  }
+
+  @Override
+  public JdbcCredentials getJdbcCredentials() {
+    refresh();
+    return new BasicJdbcCredentials(username, password);
+  }
+
+  @Override
+  public void refresh() {
+    password = "test-password-" + numRotations;
+    numRotations++;
+  }
+}


### PR DESCRIPTION
## Problem
- Add support to configure Custom Credentials Provider Class in the connector to fetch database credentials. 
- Currently to update db credentials, users needs to manually update the credential configs which leads to connector restart or incase they are using ConfigProviders -> require a restart to pull in new credentials. 

## Solution
- Introducing the following interfaces in connector which users can use to implement their custom class. 
```
public interface JdbcCredentialsProvider {

  /**
   * @return JdbcCredentials which caller can use for authentication purpose
   */
  JdbcCredentials getJdbcCredentials();

  /**
   * Instructs the provider to refresh or renew credentials.
   * Default behavior is no-op.
   */
  default void refresh() {
    // no need to refresh anything by default
  }
}
```
```
public interface JdbcCredentials {

  /**
   * @return Username to use for authentication to database
   */
  String getUsername();

  /**
   *
   * @return Password/Token to use for authentication to database
   */
  String getPassword();

}
```
- A new config - `jdbc.credentials.provider.class` is added which users can use to configure their custom class in the connector. Default value for this config is `io.confluent.connect.jdbc.util.DefaultJdbcCredentialsProvider`.
- Class `DefaultJdbcCredentialsProvider` and `BasicJdbcCredentials` are added as part of this PR to provide basic implementation of these interface and to use as default value for above config to ensure backward compatibility with existing credentials flow. 
- Connector uses `getJdbcCredentials()` method to fetch the database credentials to create a connection object. 
- `refresh` method in CredentialsProvider interface is not called within connector life-cycle. This method is part of interface to concretise that credentials refresh could be triggered within custom class logic.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
- Added relevant UTs to test the credentials provider functionality and ensure that behaviour is backward compatible. 
- Manual testing is done with AWS RDS instance for MySQL and PostgreSQL db where password refresh functionality was tested for AWS IAM user.  

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Plan is to merge this change to master and cut a minor release branch for this backward-compatible feature. 