### PR TITLE
feat: adding pollingtimestamp metadata in bulk mode

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/BulkTableQuerier.java
@@ -27,6 +27,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
@@ -79,6 +80,15 @@ public class BulkTableQuerier extends TableQuerier {
     return stmt.executeQuery();
   }
 
+  /**
+ * adding polling timestamp in metadata
+ */
+  private Map<String, Object> sourceOffset(){
+    Map <String, Object> offset = new HashMap<>();
+    offset.put("polling.timestamp", System.currentTimeMillis());
+    return offset;
+  }
+
   @Override
   public SourceRecord extractRecord() throws SQLException {
     Struct record = new Struct(schemaMapping.schema());
@@ -111,7 +121,7 @@ public class BulkTableQuerier extends TableQuerier {
       default:
         throw new ConnectException("Unexpected query mode: " + mode);
     }
-    return new SourceRecord(partition, null, topic, record.schema(), record);
+    return new SourceRecord(partition, sourceOffset(), topic, record.schema(), record);
   }
 
   @Override


### PR DESCRIPTION
## Problem
While using bulk mode in JDBC source connector, polling time is not sent to the records metadata.
Hence insert field smt does not work to add polling time in the records.

Also whenever the jdbc is restarted polling is started again results in reading the table again or duplicate data and make difficult to bifurcate data which is added in the queue at each poll. 

## Solution
adding timestamp helps in the bifurcation.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
end to end dataflow check

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
