### PR TITLE
Microsecond Precision timestamp support for JDBC Connectors

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -967,7 +967,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
     MICROS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         (timestamp, tz) -> DateTimeUtils.toEpochMicros(timestamp),
-        (epochMicros, tz) -> DateTimeUtils.toTimestamp((Long) epochMicros)),
+        (epochMicros, tz) -> DateTimeUtils.toMicrosTimestamp((Long) epochMicros)),
 
     NANOS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         (timestamp, tz) -> DateTimeUtils.toEpochNanos(timestamp),

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -210,6 +210,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       "Define the granularity of the Timestamp column. Options include: \n"
           + "  * connect_logical (default): represents timestamp values using Kafka Connect's "
           + "built-in representations \n"
+          + "  * micros_long: represents timestamp values as micros since epoch\n"
           + "  * nanos_long: represents timestamp values as nanos since epoch\n"
           + "  * nanos_string: represents timestamp values as nanos since epoch in string\n"
           + "  * nanos_iso_datetime_string: uses iso format 'yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'\n";
@@ -963,6 +964,10 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         : org.apache.kafka.connect.data.Timestamp.builder().build(),
         (timestamp, tz) -> timestamp,
         (timestamp, tz) -> (Timestamp) timestamp),
+
+    MICROS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
+     (timestamp, tz) -> DateTimeUtils.toEpochMicros(timestamp),
+     (epochMicros, tz) -> DateTimeUtils.toTimestamp((Long) epochMicros)),
 
     NANOS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         (timestamp, tz) -> DateTimeUtils.toEpochNanos(timestamp),

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -211,6 +211,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           + "  * connect_logical (default): represents timestamp values using Kafka Connect's "
           + "built-in representations \n"
           + "  * micros_long: represents timestamp values as micros since epoch\n"
+          + "  * micros_string: represents timestamp values as micros since epoch in string\n"
+          + "  * micros_iso_datetime_string: uses iso format 'yyyy-MM-dd'T'HH:mm:ss.SSSSSS'\n"
           + "  * nanos_long: represents timestamp values as nanos since epoch\n"
           + "  * nanos_string: represents timestamp values as nanos since epoch in string\n"
           + "  * nanos_iso_datetime_string: uses iso format 'yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'\n";

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -319,7 +319,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public static final String QUERY_SUFFIX_CONFIG = "query.suffix";
   public static final String QUERY_SUFFIX_DEFAULT = "";
-  public static final String QUERY_SUFFIX_DOC = 
+  public static final String QUERY_SUFFIX_DOC =
       "Suffix to append at the end of the generated query.";
   public static final String QUERY_SUFFIX_DISPLAY = "Query suffix";
 
@@ -968,6 +968,25 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
     MICROS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         (timestamp, tz) -> DateTimeUtils.toEpochMicros(timestamp),
         (epochMicros, tz) -> DateTimeUtils.toMicrosTimestamp((Long) epochMicros)),
+
+    MICROS_STRING(optional -> optional ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA,
+        (timestamp, tz) -> DateTimeUtils.toEpochMicrosString(timestamp),
+        (epochMicrosString, tz) -> {
+          try {
+            return DateTimeUtils.toMicrosTimestamp((String) epochMicrosString);
+          } catch (NumberFormatException e) {
+            throw new ConnectException(
+                "Invalid value for timestamp column with micros-string granularity: "
+                    + epochMicrosString
+                    + e.getMessage());
+          }
+        }),
+
+    MICROS_ISO_DATETIME_STRING(optional -> optional
+        ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA,
+        DateTimeUtils::toIsoDateMicrosTimeString,
+        (toIsoDateMicrosTimeString, tz) ->
+            DateTimeUtils.toTimestampFromIsoDateMicrosTime((String) toIsoDateMicrosTimeString, tz)),
 
     NANOS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         (timestamp, tz) -> DateTimeUtils.toEpochNanos(timestamp),

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -966,8 +966,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         (timestamp, tz) -> (Timestamp) timestamp),
 
     MICROS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
-     (timestamp, tz) -> DateTimeUtils.toEpochMicros(timestamp),
-     (epochMicros, tz) -> DateTimeUtils.toTimestamp((Long) epochMicros)),
+        (timestamp, tz) -> DateTimeUtils.toEpochMicros(timestamp),
+        (epochMicros, tz) -> DateTimeUtils.toTimestamp((Long) epochMicros)),
 
     NANOS_LONG(optional -> optional ? Schema.OPTIONAL_INT64_SCHEMA : Schema.INT64_SCHEMA,
         (timestamp, tz) -> DateTimeUtils.toEpochNanos(timestamp),

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -197,7 +197,9 @@ public class TimestampIncrementingCriteria {
   ) {
     Timestamp extractedTimestamp = null;
     if (hasTimestampColumns()) {
+      System.out.println("Timestamp in Record :" + record);
       extractedTimestamp = extractOffsetTimestamp(schema, record, timestampGranularity);
+      System.out.println("Extracted timestamp: " + extractedTimestamp);
       assert previousOffset == null || (previousOffset.getTimestampOffset() != null
                                         && previousOffset.getTimestampOffset().compareTo(
           extractedTimestamp) <= 0

--- a/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteria.java
@@ -197,9 +197,7 @@ public class TimestampIncrementingCriteria {
   ) {
     Timestamp extractedTimestamp = null;
     if (hasTimestampColumns()) {
-      System.out.println("Timestamp in Record :" + record);
       extractedTimestamp = extractOffsetTimestamp(schema, record, timestampGranularity);
-      System.out.println("Extracted timestamp: " + extractedTimestamp);
       assert previousOffset == null || (previousOffset.getTimestampOffset() != null
                                         && previousOffset.getTimestampOffset().compareTo(
           extractedTimestamp) <= 0

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 public class DateTimeUtils {
 
   static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
+  static final long MICROSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toMicros(1);
+  static final long MICROSECONDS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
   static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
   static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
   static final DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT =
@@ -79,8 +81,7 @@ public class DateTimeUtils {
 
   private static Long convertToEpochMicros(Timestamp t) {
     Long epochMillis = TimeUnit.SECONDS.toMicros(t.getTime() / MILLISECONDS_PER_SECOND);
-    Long nanosInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos());
-    Long microsInSecond = nanosInSecond / 1000;
+    Long microsInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos() / MILLISECONDS_PER_SECOND);
     return epochMillis + microsInSecond;
   }
 
@@ -139,6 +140,24 @@ public class DateTimeUtils {
         .map(Timestamp::toInstant)
         .map(t -> t.atZone(tz.toZoneId()))
         .map(t -> t.format(ISO_DATE_TIME_NANOS_FORMAT))
+        .orElse(null);
+  }
+
+  /**
+   * Get {@link Timestamp} from epoch with micro precision
+   *
+   * @param micros epoch micro in long
+   * @return the equivalent java sql Timestamp
+   */
+  public static Timestamp toMicrosTimestamp(Long micros) {
+    return Optional.ofNullable(micros)
+        .map(
+            n -> {
+              Timestamp ts = new Timestamp(micros / MICROSECONDS_PER_MILLISECOND);
+              ts.setNanos(
+                  (int) ((micros % MICROSECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND));
+              return ts;
+            })
         .orElse(null);
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -155,8 +155,8 @@ public class DateTimeUtils {
         .map(
             m -> {
               Timestamp ts = new Timestamp(micros / MICROSECONDS_PER_MILLISECOND);
-              long remainderMicros = micros % MICROSECONDS_PER_MILLISECOND;
-              ts.setNanos((int)(remainderMicros * NANOSECONDS_PER_MICROSECOND));
+              ts.setNanos(
+                  (int) ((micros % MICROSECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND));
               return ts;
             })
         .orElse(null);

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -265,6 +265,7 @@ public class DateTimeUtils {
         .map(Timestamp::from)
         .orElse(null);
   }
+
   private DateTimeUtils() {
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -79,7 +79,8 @@ public class DateTimeUtils {
 
   private static Long convertToEpochMicros(Timestamp t) {
     Long epochMillis = TimeUnit.SECONDS.toMicros(t.getTime() / MILLISECONDS_PER_SECOND);
-    Long microsInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos())/1000;
+    Long nanosInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos());
+    Long microsInSecond = nanosInSecond/1000;
     return epochMillis + microsInSecond;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -155,8 +155,8 @@ public class DateTimeUtils {
         .map(
             m -> {
               Timestamp ts = new Timestamp(micros / MICROSECONDS_PER_MILLISECOND);
-              ts.setNanos(
-                  (int) ((micros % MICROSECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND));
+              long remainderMicros = micros % MICROSECONDS_PER_MILLISECOND;
+              ts.setNanos((int)(remainderMicros * NANOSECONDS_PER_MICROSECOND));
               return ts;
             })
         .orElse(null);

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -36,6 +36,7 @@ public class DateTimeUtils {
   static final long MICROSECONDS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
   static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
   static final long NANOSECONDS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+  static final long NANOSECONDS_PER_MICROSECOND = TimeUnit.MICROSECONDS.toNanos(1);
   static final DateTimeFormatter ISO_DATE_TIME_NANOS_FORMAT =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS");
 
@@ -81,8 +82,8 @@ public class DateTimeUtils {
 
   private static Long convertToEpochMicros(Timestamp t) {
     Long epochMillis = TimeUnit.SECONDS.toMicros(t.getTime() / MILLISECONDS_PER_SECOND);
-    Long microsInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos() / MILLISECONDS_PER_SECOND);
-    return epochMillis + microsInSecond;
+    Long microsComponent = t.getNanos() / NANOSECONDS_PER_MICROSECOND;
+    return epochMillis + microsComponent;
   }
 
   /**
@@ -152,7 +153,7 @@ public class DateTimeUtils {
   public static Timestamp toMicrosTimestamp(Long micros) {
     return Optional.ofNullable(micros)
         .map(
-            n -> {
+            m -> {
               Timestamp ts = new Timestamp(micros / MICROSECONDS_PER_MILLISECOND);
               ts.setNanos(
                   (int) ((micros % MICROSECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND));

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -54,9 +54,6 @@ public class DateTimeUtils {
   private static final ThreadLocal<Map<TimeZone, SimpleDateFormat>> TIMEZONE_TIMESTAMP_FORMATS =
       ThreadLocal.withInitial(HashMap::new);
 
-  private DateTimeUtils() {
-  }
-
   public static Calendar getTimeZoneCalendar(final TimeZone timeZone) {
     return TIMEZONE_CALENDARS.get().computeIfAbsent(timeZone, GregorianCalendar::new);
   }
@@ -188,8 +185,8 @@ public class DateTimeUtils {
         .map(
             m -> {
               Timestamp ts = new Timestamp(micros / MICROSECONDS_PER_MILLISECOND);
-              ts.setNanos(
-                  (int) ((micros % MICROSECONDS_PER_SECOND) * MICROSECONDS_PER_MILLISECOND));
+              long remainderMicros = micros % MICROSECONDS_PER_MILLISECOND;
+              ts.setNanos(ts.getNanos() + (int)(remainderMicros * NANOSECONDS_PER_MICROSECOND));
               return ts;
             })
         .orElse(null);
@@ -238,7 +235,7 @@ public class DateTimeUtils {
   }
 
   /**
-   * Get {@link Timestamp} from epoch with nano precision
+   * Get {@link Timestamp} from epoch with micro precision
    *
    * @param isoDT iso dateTime format "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"
    * @param tz the timezone of the source database

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -237,7 +237,7 @@ public class DateTimeUtils {
   /**
    * Get {@link Timestamp} from epoch with micro precision
    *
-   * @param isoDT iso dateTime format "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"
+   * @param isoDT iso dateTime format "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
    * @param tz the timezone of the source database
    * @return the equivalent java sql Timestamp
    */
@@ -264,5 +264,7 @@ public class DateTimeUtils {
         .map(ChronoZonedDateTime::toInstant)
         .map(Timestamp::from)
         .orElse(null);
+  }
+  private DateTimeUtils() {
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -80,7 +80,7 @@ public class DateTimeUtils {
   private static Long convertToEpochMicros(Timestamp t) {
     Long epochMillis = TimeUnit.SECONDS.toMicros(t.getTime() / MILLISECONDS_PER_SECOND);
     Long nanosInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos());
-    Long microsInSecond = nanosInSecond/1000;
+    Long microsInSecond = nanosInSecond / 1000;
     return epochMillis + microsInSecond;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -77,6 +77,24 @@ public class DateTimeUtils {
     }).format(date);
   }
 
+  private static Long convertToEpochMicros(Timestamp t) {
+    Long epochMillis = TimeUnit.SECONDS.toMicros(t.getTime() / MILLISECONDS_PER_SECOND);
+    Long microsInSecond = TimeUnit.MICROSECONDS.toMicros(t.getNanos())/1000;
+    return epochMillis + microsInSecond;
+  }
+
+  /**
+   * Get the number of microseconds past epoch of the given {@link Timestamp}.
+   *
+   * @param timestamp the Java timestamp value
+   * @return the epoch nanoseconds
+   */
+  public static Long toEpochMicros(Timestamp timestamp) {
+    return Optional.ofNullable(timestamp)
+            .map(DateTimeUtils::convertToEpochMicros)
+            .orElse(null);
+  }
+
   private static Long convertToEpochNanos(Timestamp t) {
     Long epochMillis = TimeUnit.SECONDS.toNanos(t.getTime() / MILLISECONDS_PER_SECOND);
     Long nanosInSecond = TimeUnit.NANOSECONDS.toNanos(t.getNanos());

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -242,6 +242,19 @@ public class TimestampIncrementingCriteriaTest {
   }
 
   @Test
+  public void extractWithTsColumnIsoDateMicrosTimeString() throws Exception {
+    schema = SchemaBuilder.struct()
+              .field(TS1_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
+              .field(TS2_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
+              .build();
+    record = new Struct(schema)
+              .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateMicrosTimeString(TS1, utcTimeZone))
+              .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateMicrosTimeString(TS2, utcTimeZone));
+    assertExtractedOffset(-1, TS1, schema, record,
+     TimestampGranularity.MICROS_ISO_DATETIME_STRING);
+  }
+
+  @Test
   public void extractWithTsColumnIsoDateTimeString() throws Exception {
     schema = SchemaBuilder.struct()
         .field(TS1_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
@@ -305,6 +318,19 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS2_COLUMN.name(), null);
     assertExtractedOffset(-1, TS0, schema, record,
         TimestampGranularity.NANOS_STRING);
+  }
+
+  @Test
+  public void extractWithTsColumnIsoDateMicrosTimeStringNull() throws Exception {
+    schema = SchemaBuilder.struct()
+              .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+              .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+              .build();
+    record = new Struct(schema)
+              .put(TS1_COLUMN.name(), null)
+              .put(TS2_COLUMN.name(), null);
+    assertExtractedOffset(-1, TS0, schema, record,
+     TimestampGranularity.MICROS_ISO_DATETIME_STRING);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -215,6 +215,20 @@ public class TimestampIncrementingCriteriaTest {
   }
 
   @Test
+  public void extractWithTsColumnMicrosString() throws Exception {
+    schema =
+        SchemaBuilder.struct()
+            .field(TS1_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
+            .field(TS2_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
+            .build();
+    record =
+        new Struct(schema)
+            .put(TS1_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochNanos(TS1)))
+            .put(TS2_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochNanos(TS2)));
+    assertExtractedOffset(-1, TS1, schema, record, TimestampGranularity.MICROS_STRING);
+  }
+
+  @Test
   public void extractWithTsColumnNanosString() throws Exception {
     schema = SchemaBuilder.struct()
         .field(TS1_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
@@ -241,7 +255,7 @@ public class TimestampIncrementingCriteriaTest {
   }
 
   @Test
-  public void extractWithTsColumnNanosMicrosNull() throws Exception {
+  public void extractWithTsColumnMicrosLongNull() throws Exception {
     schema = SchemaBuilder.struct()
               .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_INT64_SCHEMA)
               .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_INT64_SCHEMA)
@@ -264,6 +278,20 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS2_COLUMN.name(), null);
     assertExtractedOffset(-1, TS0, schema, record,
         TimestampGranularity.NANOS_LONG);
+  }
+
+  @Test
+  public void extractWithTsColumnMicrosStringNull() throws Exception {
+    schema =
+        SchemaBuilder.struct()
+            .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .build();
+    record = new Struct(schema)
+              .put(TS1_COLUMN.name(), null)
+              .put(TS2_COLUMN.name(), null);
+    assertExtractedOffset(-1, TS0, schema, record,
+     TimestampGranularity.MICROS_STRING);
   }
 
   @Test
@@ -290,6 +318,19 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS2_COLUMN.name(), null);
     assertExtractedOffset(-1, TS0, schema, record,
         TimestampGranularity.NANOS_ISO_DATETIME_STRING);
+  }
+
+  @Test(expected = ConnectException.class)
+  public void extractWithTsColumnIsoDateTimeStringMicrosConfig() throws Exception {
+    schema = SchemaBuilder.struct()
+              .field(TS1_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
+              .field(TS2_COLUMN.name(), SchemaBuilder.STRING_SCHEMA)
+              .build();
+    record = new Struct(schema)
+              .put(TS1_COLUMN.name(), DateTimeUtils.toIsoDateMicrosTimeString(TS1, utcTimeZone))
+              .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateMicrosTimeString(TS2, utcTimeZone));
+    assertExtractedOffset(-1, TS1, schema, record,
+     TimestampGranularity.MICROS_STRING);
   }
 
   @Test(expected = ConnectException.class)

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -189,6 +189,19 @@ public class TimestampIncrementingCriteriaTest {
   }
 
   @Test
+  public void extractWithTsColumnMicrosLong() throws Exception {
+    schema = SchemaBuilder.struct()
+              .field(TS1_COLUMN.name(), SchemaBuilder.INT64_SCHEMA)
+              .field(TS2_COLUMN.name(), SchemaBuilder.INT64_SCHEMA)
+              .build();
+    record = new Struct(schema)
+              .put(TS1_COLUMN.name(), DateTimeUtils.toEpochMicros(TS1))
+              .put(TS2_COLUMN.name(), DateTimeUtils.toEpochMicros(TS2));
+    assertExtractedOffset(-1, TS1, schema, record,
+     TimestampGranularity.MICROS_LONG);
+  }
+
+  @Test
   public void extractWithTsColumnNanosLong() throws Exception {
     schema = SchemaBuilder.struct()
         .field(TS1_COLUMN.name(), SchemaBuilder.INT64_SCHEMA)
@@ -225,6 +238,19 @@ public class TimestampIncrementingCriteriaTest {
         .put(TS2_COLUMN.name(), DateTimeUtils.toIsoDateTimeString(TS2, utcTimeZone));
     assertExtractedOffset(-1, TS1, schema, record,
         TimestampGranularity.NANOS_ISO_DATETIME_STRING);
+  }
+
+  @Test
+  public void extractWithTsColumnNanosMicrosNull() throws Exception {
+    schema = SchemaBuilder.struct()
+              .field(TS1_COLUMN.name(), SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+              .field(TS2_COLUMN.name(), SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+              .build();
+    record = new Struct(schema)
+              .put(TS1_COLUMN.name(), null)
+              .put(TS2_COLUMN.name(), null);
+    assertExtractedOffset(-1, TS0, schema, record,
+     TimestampGranularity.MICROS_LONG);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/TimestampIncrementingCriteriaTest.java
@@ -223,8 +223,8 @@ public class TimestampIncrementingCriteriaTest {
             .build();
     record =
         new Struct(schema)
-            .put(TS1_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochNanos(TS1)))
-            .put(TS2_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochNanos(TS2)));
+            .put(TS1_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochMicros(TS1)))
+            .put(TS2_COLUMN.name(), String.valueOf(DateTimeUtils.toEpochMicros(TS2)));
     assertExtractedOffset(-1, TS1, schema, record, TimestampGranularity.MICROS_STRING);
   }
 


### PR DESCRIPTION
## Problem
CC-31131 : Microsecond Precision timestamp support for JDBC Connectors.

Currently Microsecond Precision is not supported in the JDBC Connectors without the nanos_long config in timestamp granularity. 
REF - https://confluentinc.atlassian.net/wiki/spaces/~63a167967cde7bff9d76a990/pages/4128737414/Micro+Nanoprecision+Time+support+in+JDBC+Connectors

## Solution
This PR introduces a new mode i.e. MICROS_LONG in the timestamp.granularity config which when configured only the microsecond precision timestamp will be produced in kafka records.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
Test cases have been included in this doc - https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/4243293217/Microprecision+Large+Dates+support+in+JDBC+Connectors


## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
