### PR TITLE
add compaction for batch by primary key fields

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BatchPKCompaction.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BatchPKCompaction.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+
+public class BatchPKCompaction {
+
+  private final JdbcSinkConfig.PrimaryKeyMode pkMode;
+  private final FieldsMetadata fieldsMetadata;
+  private final SchemaPair schemaPair;
+
+  public BatchPKCompaction(
+      JdbcSinkConfig.PrimaryKeyMode pkMode,
+      FieldsMetadata fieldsMetadata,
+      SchemaPair schemaPair) {
+    this.pkMode = pkMode;
+    this.fieldsMetadata = fieldsMetadata;
+    this.schemaPair = schemaPair;
+  }
+
+  List<SinkRecord> applyCompaction(List<SinkRecord> records) {
+    LinkedHashMap<PrimaryKeyValue, SinkRecord> lastValues = new LinkedHashMap<>();
+    for (int i = records.size() - 1; i >= 0; i--) {
+      lastValues.putIfAbsent(getPK(records.get(i)), records.get(i));
+    }
+    List<SinkRecord> result = new ArrayList<>(lastValues.values());
+    Collections.reverse(result);
+    return result;
+  }
+
+  private PrimaryKeyValue getPK(SinkRecord record) {
+    switch (pkMode) {
+      case KAFKA: {
+        return new PrimaryKeyValue(record.topic(), record.kafkaPartition(), record.kafkaOffset());
+      }
+      case RECORD_KEY: {
+        return getPK(schemaPair.keySchema, record.key());
+      }
+      case RECORD_VALUE: {
+        return getPK(schemaPair.valueSchema, record.value());
+      }
+      case NONE: {
+        throw new UnsupportedOperationException("Compaction isn't supported for pkMode NONE");
+      }
+      default:
+        throw new UnsupportedOperationException("Compaction isn't supported for pkMode: " + pkMode);
+    }
+  }
+
+  private PrimaryKeyValue getPK(Schema schema, Object value) {
+    if (schema.type().isPrimitive()) {
+      assert fieldsMetadata.keyFieldNames.size() == 1;
+      return new PrimaryKeyValue(value);
+    } else {
+      return new PrimaryKeyValue(
+          fieldsMetadata.keyFieldNames.stream()
+              .map(fieldName -> ((Struct) value).get(schema.field(fieldName)))
+              .toArray()
+      );
+    }
+  }
+
+  private static class PrimaryKeyValue {
+
+    private final Object[] values;
+
+    private PrimaryKeyValue(Object... values) {
+      this.values = values;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      PrimaryKeyValue that = (PrimaryKeyValue) obj;
+      return Arrays.equals(this.values, that.values);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(values);
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -301,6 +301,13 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String MSSQL_USE_MERGE_HOLDLOCK_DISPLAY =
       "SQL Server - Use HOLDLOCK in MERGE";
 
+  public static final String BATCH_PK_COMPACTION = "batch.pk.compaction";
+  private static final String BATCH_PK_COMPACTION_DEFAULT = "false";
+  private static final String BATCH_PK_COMPACTION_DOC =
+      "Whether to retain only the latest record for each unique key";
+  private static final String BATCH_PK_COMPACTION_DISPLAY =
+      "Retain only the latest record for each unique key";
+
   /**
    * The properties that begin with this prefix will be used to configure a class, specified by
    * {@code jdbc.credentials.provider.class} if it implements {@link Configurable}.
@@ -456,6 +463,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             5,
             ConfigDef.Width.MEDIUM,
             REPLACE_NULL_WITH_DEFAULT_DISPLAY
+        )
+        .define(
+            BATCH_PK_COMPACTION,
+            ConfigDef.Type.BOOLEAN,
+            BATCH_PK_COMPACTION_DEFAULT,
+            ConfigDef.Importance.LOW,
+            BATCH_PK_COMPACTION_DOC,
+            WRITES_GROUP,
+            6,
+            ConfigDef.Width.LONG,
+            BATCH_PK_COMPACTION_DISPLAY
         )
         // Data Mapping
         .define(
@@ -614,6 +632,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final int batchSize;
   public final boolean deleteEnabled;
   public final boolean replaceNullWithDefault;
+  public final boolean batchPkCompactionEnabled;
   public final int maxRetries;
   public final int retryBackoffMs;
   public final boolean autoCreate;
@@ -642,6 +661,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     batchSize = getInt(BATCH_SIZE);
     deleteEnabled = getBoolean(DELETE_ENABLED);
     replaceNullWithDefault = getBoolean(REPLACE_NULL_WITH_DEFAULT);
+    batchPkCompactionEnabled = getBoolean(BATCH_PK_COMPACTION);
     maxRetries = getInt(MAX_RETRIES);
     retryBackoffMs = getInt(RETRY_BACKOFF_MS);
     autoCreate = getBoolean(AUTO_CREATE);

--- a/src/test/java/io/confluent/connect/jdbc/sink/BatchPKCompactionTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BatchPKCompactionTest.java
@@ -1,0 +1,67 @@
+package io.confluent.connect.jdbc.sink;
+
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+
+public class BatchPKCompactionTest {
+
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_VALUE = "value";
+
+    @Test
+    public void test() {
+        final Map<String, SinkRecordField> allFields = new HashMap<>();
+        allFields.put(FIELD_ID, new SinkRecordField(Schema.INT64_SCHEMA, FIELD_ID, true));
+        allFields.put(FIELD_VALUE, new SinkRecordField(Schema.STRING_SCHEMA, FIELD_VALUE, false));
+        BatchPKCompaction compaction = new BatchPKCompaction(
+                JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+                new FieldsMetadata(
+                        new HashSet<>(Arrays.asList(FIELD_ID)),
+                        new HashSet<>(Arrays.asList(FIELD_VALUE)),
+                        allFields
+                ),
+                new SchemaPair(Schema.STRING_SCHEMA, schemaIdValue)
+        );
+
+        final SinkRecord sinkRecord1 = createRecord(1l, "value1");
+        final SinkRecord sinkRecord2 = createRecord(2l, "value2");
+        final SinkRecord sinkRecord3 = createRecord(1l, "value3");
+        List<SinkRecord> result = compaction.applyCompaction(Arrays.asList(sinkRecord1, sinkRecord2, sinkRecord3));
+
+        assertEquals(2, result.size());
+        assertEquals(sinkRecord2, result.get(0));
+        assertEquals(sinkRecord3, result.get(1));
+    }
+
+
+    private final Schema schemaIdValue = SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("value", Schema.STRING_SCHEMA);
+
+    private final AtomicLong kafkaOffset = new AtomicLong(0);
+
+    private SinkRecord createRecord(Long id, String value) {
+        return new SinkRecord(
+                "topic",
+                0,
+                Schema.STRING_SCHEMA,
+                id.toString(),
+                schemaIdValue,
+                new Struct(schemaIdValue)
+                        .put("id", id)
+                        .put("value", value),
+                kafkaOffset.incrementAndGet()
+        );
+    }
+}


### PR DESCRIPTION
## Problem
I'm using jdbc sink task to save data to Postgresql. I wanted to use configuration property of jdbc driver reWriteBatchedInserts=true to optimize saving data. 
This property toggles converting my separate upsert queries to one multi-value upsert. But there is problem when such multi-value query contains updates for same primary key.

## Solution
I think it would be useful to have a feature that, before forming batches of database queries, reduces batches of records by keeping only the most recent record for a primary key.

record(primaryKey,value): (1,1),(2,2),(1,3) -> (2,2),(1,3)

It might be practical not only for my case and potentially could reduce number of queries when there are updates by same primary key.

##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

