### PR TITLE
Support Large Dates with Nanos Precision

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -999,7 +999,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         (timestamp, tz) -> DateTimeUtils.toEpochNanosString(timestamp),
         (epochNanosString, tz) -> {
           try {
-            return DateTimeUtils.toTimestamp((String) epochNanosString);
+            return DateTimeUtils.toTimestamp(new BigInteger((String) epochNanosString));
           } catch (NumberFormatException  e) {
             throw new ConnectException(
                 "Invalid value for timestamp column with nanos-string granularity: "

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.Timestamp;
 import java.time.ZoneId;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.jdbc.source;
 
-import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.Timestamp;
 import java.time.ZoneId;
@@ -999,7 +998,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         (timestamp, tz) -> DateTimeUtils.toEpochNanosString(timestamp),
         (epochNanosString, tz) -> {
           try {
-            return DateTimeUtils.toTimestamp(new BigInteger((String) epochNanosString));
+            return DateTimeUtils.toTimestamp((String) epochNanosString);
           } catch (NumberFormatException  e) {
             throw new ConnectException(
                 "Invalid value for timestamp column with nanos-string granularity: "

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -150,9 +150,9 @@ public class DateTimeUtils {
    */
   public static String toEpochNanosString(Timestamp timestamp) {
     return Optional.ofNullable(timestamp)
-            .map(DateTimeUtils::convertToEpochNanosBigInt)
-            .map(String::valueOf)
-            .orElse(null);
+        .map(DateTimeUtils::convertToEpochNanosBigInt)
+        .map(String::valueOf)
+        .orElse(null);
   }
 
   /**
@@ -235,12 +235,11 @@ public class DateTimeUtils {
   /**
    * Get {@link Timestamp} from epoch with nano precision
    *
-   * @param nanos epoch nanos in string
+   * @param nanos epoch nanos BigInteger
    * @return the equivalent java sql Timestamp
    */
-  public static Timestamp toTimestamp(String nanos) {
+  public static Timestamp toTimestamp(BigInteger nanos) {
     return Optional.ofNullable(nanos)
-        .map(BigInteger::new)
         .map(
             n -> {
               long milliseconds =
@@ -251,6 +250,19 @@ public class DateTimeUtils {
               return ts;
             })
         .orElse(null);
+  }
+
+  /**
+   * Get {@link Timestamp} from epoch with nano precision
+   *
+   * @param nanos epoch nanos in string
+   * @return the equivalent java sql Timestamp
+   */
+  public static Timestamp toTimestamp(String nanos) {
+    return Optional.ofNullable(nanos)
+            .map(BigInteger::new)
+            .map(DateTimeUtils::toTimestamp)
+            .orElse(null);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -92,6 +92,15 @@ public class DateTimeUtils {
     return epochMillis + microsComponent;
   }
 
+  private static String convertToEpochNanosBigInt(Timestamp t) {
+    BigInteger seconds = BigInteger.valueOf(t.getTime() / MILLISECONDS_PER_SECOND);
+    BigInteger nanos = BigInteger.valueOf(t.getNanos());
+    BigInteger totalNanos = seconds.multiply(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).add(nanos);
+    return totalNanos.toString();
+  }
+
+
+
   /**
    * Get the number of microseconds past epoch of the given {@link Timestamp}.
    *
@@ -142,13 +151,10 @@ public class DateTimeUtils {
    * @return the epoch nanoseconds string
    */
   public static String toEpochNanosString(Timestamp timestamp) {
-    if (timestamp == null) {
-      return null;
-    }
-    BigInteger seconds = BigInteger.valueOf(timestamp.getTime() / MILLISECONDS_PER_SECOND);
-    BigInteger nanos = BigInteger.valueOf(timestamp.getNanos());
-    BigInteger totalNanos = seconds.multiply(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).add(nanos);
-    return totalNanos.toString();
+    return Optional.ofNullable(timestamp)
+            .map(DateTimeUtils::convertToEpochNanosBigInt)
+            .map(String::valueOf)
+            .orElse(null);
   }
 
   /**
@@ -235,16 +241,10 @@ public class DateTimeUtils {
    * @return the equivalent java sql Timestamp
    */
   public static Timestamp toTimestamp(String nanos) {
-    if (nanos == null) {
-      return null;
-    }
-    BigInteger nanoseconds = new BigInteger(nanos);
-    long milliseconds =
-        nanoseconds.divide(BigInteger.valueOf(NANOSECONDS_PER_MILLISECOND)).longValue();
-    int fractionalNanos = nanoseconds.mod(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).intValue();
-    Timestamp timestamp = new Timestamp(milliseconds);
-    timestamp.setNanos(fractionalNanos);
-    return timestamp;
+    return Optional.ofNullable(nanos)
+            .map(Long::parseLong)
+            .map(DateTimeUtils::toTimestamp)
+            .orElse(null);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -31,6 +31,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 public class DateTimeUtils {
+
   static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
   static final long MICROSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toMicros(1);
   static final long MICROSECONDS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
@@ -102,7 +103,6 @@ public class DateTimeUtils {
             .map(DateTimeUtils::convertToEpochMicros)
             .orElse(null);
   }
-
 
   private static Long convertToEpochNanos(Timestamp t) {
     Long epochMillis = TimeUnit.SECONDS.toNanos(t.getTime() / MILLISECONDS_PER_SECOND);

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -121,12 +121,9 @@ public class DateTimeUtils {
   }
 
   private static BigInteger convertToEpochNanos(Timestamp t) {
-    System.out.println("timestamp in convertToEpochNanos: " + t);
     BigInteger epochMillis =
-     toNanosBigInteger(t.getTime() / MILLISECONDS_PER_SECOND, NANOSECONDS_PER_SECOND);
+        toNanosBigInteger(t.getTime() / MILLISECONDS_PER_SECOND, NANOSECONDS_PER_SECOND);
     BigInteger nanosInSecond = BigInteger.valueOf(t.getNanos());
-    System.out.println("epochMillis in convertToEpochNanos: " + epochMillis);
-    System.out.println("nanosInSecond in convertToEpochNanos:   " + nanosInSecond);
     return epochMillis.add(nanosInSecond);
   }
 
@@ -261,7 +258,7 @@ public class DateTimeUtils {
               return ts;
             })
             .orElse(null);
-}
+  }
 
   /**
    * Get {@link Timestamp} from epoch with nano precision

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -242,9 +242,17 @@ public class DateTimeUtils {
    */
   public static Timestamp toTimestamp(String nanos) {
     return Optional.ofNullable(nanos)
-            .map(Long::parseLong)
-            .map(DateTimeUtils::toTimestamp)
-            .orElse(null);
+        .map(BigInteger::new)
+        .map(
+            n -> {
+              long milliseconds =
+                  n.divide(BigInteger.valueOf(NANOSECONDS_PER_MILLISECOND)).longValue();
+              int nanoseconds = n.mod(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).intValue();
+              Timestamp ts = new Timestamp(milliseconds);
+              ts.setNanos(nanoseconds);
+              return ts;
+            })
+        .orElse(null);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -159,10 +159,10 @@ public class DateTimeUtils {
    * @return the epoch nanoseconds string
    */
   public static String toEpochNanosString(Timestamp timestamp) {
-    return Optional.ofNullable(timestamp)
-        .map(DateTimeUtils::convertToEpochNanos)
-        .map(String::valueOf)
-        .orElse(null);
+    BigInteger seconds = BigInteger.valueOf(timestamp.getTime() / MILLISECONDS_PER_SECOND);
+    BigInteger nanos = BigInteger.valueOf(timestamp.getNanos());
+    BigInteger totalNanos = seconds.multiply(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).add(nanos);
+    return totalNanos.toString();
   }
 
   /**
@@ -245,32 +245,17 @@ public class DateTimeUtils {
   /**
    * Get {@link Timestamp} from epoch with nano precision
    *
-   * @param nanos epoch nanos in BigInteger
-   * @return the equivalent java sql Timestamp
-   */
-  public static Timestamp toTimestamp(BigInteger nanos) {
-    return Optional.ofNullable(nanos)
-            .map(n -> {
-              long millis = n.divide(BigInteger.valueOf(NANOSECONDS_PER_MILLISECOND)).longValue();
-              int nanosPart = n.remainder(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).intValue();
-              Timestamp ts = new Timestamp(millis);
-              ts.setNanos(nanosPart);
-              return ts;
-            })
-            .orElse(null);
-  }
-
-  /**
-   * Get {@link Timestamp} from epoch with nano precision
-   *
    * @param nanos epoch nanos in string
    * @return the equivalent java sql Timestamp
    */
   public static Timestamp toTimestamp(String nanos) throws NumberFormatException {
-    return Optional.ofNullable(nanos)
-     .map(BigInteger::new)
-     .map(DateTimeUtils::toTimestamp)
-     .orElse(null);
+    BigInteger nanoseconds = new BigInteger(nanos);
+    long milliseconds =
+        nanoseconds.divide(BigInteger.valueOf(NANOSECONDS_PER_MILLISECOND)).longValue();
+    int fractionalNanos = nanoseconds.mod(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).intValue();
+    Timestamp timestamp = new Timestamp(milliseconds);
+    timestamp.setNanos(fractionalNanos);
+    return timestamp;
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -142,6 +142,9 @@ public class DateTimeUtils {
    * @return the epoch nanoseconds string
    */
   public static String toEpochNanosString(Timestamp timestamp) {
+    if (timestamp == null) {
+      return null;
+    }
     BigInteger seconds = BigInteger.valueOf(timestamp.getTime() / MILLISECONDS_PER_SECOND);
     BigInteger nanos = BigInteger.valueOf(timestamp.getNanos());
     BigInteger totalNanos = seconds.multiply(BigInteger.valueOf(NANOSECONDS_PER_SECOND)).add(nanos);
@@ -231,7 +234,10 @@ public class DateTimeUtils {
    * @param nanos epoch nanos in string
    * @return the equivalent java sql Timestamp
    */
-  public static Timestamp toTimestamp(String nanos) throws NumberFormatException {
+  public static Timestamp toTimestamp(String nanos) {
+    if (nanos == null) {
+      return null;
+    }
     BigInteger nanoseconds = new BigInteger(nanos);
     long milliseconds =
         nanoseconds.divide(BigInteger.valueOf(NANOSECONDS_PER_MILLISECOND)).longValue();

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -99,8 +99,6 @@ public class DateTimeUtils {
     return totalNanos.toString();
   }
 
-
-
   /**
    * Get the number of microseconds past epoch of the given {@link Timestamp}.
    *

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -31,8 +31,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 public class DateTimeUtils {
-
-  private static final long NANO_SCALE   = 1L;
   static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
   static final long MICROSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toMicros(1);
   static final long MICROSECONDS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
@@ -105,26 +103,11 @@ public class DateTimeUtils {
             .orElse(null);
   }
 
-  /**
-   * Converts the given duration to nanoseconds using BigInteger to support large values.
-   *
-   * @param duration the duration to convert
-   * @param scale the scale factor to use for conversion
-   * @return the duration in nanoseconds as a BigInteger
-   */
-  public static BigInteger toNanosBigInteger(long duration, long scale) {
-    if (scale == NANO_SCALE) {
-      return BigInteger.valueOf(duration);
-    } else {
-      return BigInteger.valueOf(duration).multiply(BigInteger.valueOf(scale));
-    }
-  }
 
-  private static BigInteger convertToEpochNanos(Timestamp t) {
-    BigInteger epochMillis =
-        toNanosBigInteger(t.getTime() / MILLISECONDS_PER_SECOND, NANOSECONDS_PER_SECOND);
-    BigInteger nanosInSecond = BigInteger.valueOf(t.getNanos());
-    return epochMillis.add(nanosInSecond);
+  private static Long convertToEpochNanos(Timestamp t) {
+    Long epochMillis = TimeUnit.SECONDS.toNanos(t.getTime() / MILLISECONDS_PER_SECOND);
+    Long nanosInSecond = TimeUnit.NANOSECONDS.toNanos(t.getNanos());
+    return epochMillis + nanosInSecond;
   }
 
   /**
@@ -133,7 +116,7 @@ public class DateTimeUtils {
    * @param timestamp the Java timestamp value
    * @return the epoch nanoseconds
    */
-  public static BigInteger toEpochNanos(Timestamp timestamp) {
+  public static Long toEpochNanos(Timestamp timestamp) {
     return Optional.ofNullable(timestamp)
         .map(DateTimeUtils::convertToEpochNanos)
         .orElse(null);

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -36,13 +36,13 @@ public class DateTimeUtilsTest {
   public void testTimestampToNanosLong() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
-    BigInteger nanos = DateTimeUtils.toEpochNanos(timestamp);
+    Long nanos = DateTimeUtils.toEpochNanos(timestamp);
     assertEquals(timestamp, DateTimeUtils.toTimestamp(String.valueOf(nanos)));
   }
 
   @Test
   public void testTimestampToNanosLongNull() {
-    BigInteger nanos = DateTimeUtils.toEpochNanos(null);
+    Long nanos = DateTimeUtils.toEpochNanos(null);
     assertNull(nanos);
     Timestamp timestamp = DateTimeUtils.toTimestamp((Long) null);
     assertNull(timestamp);

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -36,8 +36,8 @@ public class DateTimeUtilsTest {
   public void testTimestampToNanosLong() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
-    Long nanos = DateTimeUtils.toEpochNanos(timestamp);
-    assertEquals(timestamp, DateTimeUtils.toTimestamp(String.valueOf(nanos)));
+    long nanos = DateTimeUtils.toEpochNanos(timestamp);
+    assertEquals(timestamp, DateTimeUtils.toTimestamp((nanos)));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -18,9 +18,10 @@ package io.confluent.connect.jdbc.util;
 import org.junit.Test;
 
 import java.math.BigInteger;
-import java.sql.Time;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.Instant;
+import java.time.Month;
+import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.util.TimeZone;
 
@@ -36,7 +37,7 @@ public class DateTimeUtilsTest {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
     BigInteger nanos = DateTimeUtils.toEpochNanos(timestamp);
-    assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
+    assertEquals(timestamp, DateTimeUtils.toTimestamp(String.valueOf(nanos)));
   }
 
   @Test
@@ -61,6 +62,15 @@ public class DateTimeUtilsTest {
     assertNull(nanos);
     Timestamp timestamp = DateTimeUtils.toTimestamp((String) null);
     assertNull(timestamp);
+  }
+
+  @Test
+  public void testTimestampToNanosStringLargeDate() {
+    LocalDateTime localDateTime =
+     LocalDateTime.of(9999, Month.DECEMBER, 31, 23, 59, 59);
+    Timestamp timestamp = Timestamp.valueOf(localDateTime);
+    String nanos = DateTimeUtils.toEpochNanosString(timestamp);
+    assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -37,7 +37,7 @@ public class DateTimeUtilsTest {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
     long nanos = DateTimeUtils.toEpochNanos(timestamp);
-    assertEquals(timestamp, DateTimeUtils.toTimestamp((nanos)));
+    assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.util;
 
 import org.junit.Test;
 
+import java.math.BigInteger;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -34,13 +35,13 @@ public class DateTimeUtilsTest {
   public void testTimestampToNanosLong() {
     Timestamp timestamp = Timestamp.from(Instant.now());
     timestamp.setNanos(141362049);
-    long nanos = DateTimeUtils.toEpochNanos(timestamp);
+    BigInteger nanos = DateTimeUtils.toEpochNanos(timestamp);
     assertEquals(timestamp, DateTimeUtils.toTimestamp(nanos));
   }
 
   @Test
   public void testTimestampToNanosLongNull() {
-    Long nanos = DateTimeUtils.toEpochNanos(null);
+    BigInteger nanos = DateTimeUtils.toEpochNanos(null);
     assertNull(nanos);
     Timestamp timestamp = DateTimeUtils.toTimestamp((Long) null);
     assertNull(timestamp);


### PR DESCRIPTION
## Problem
[CC-31133](https://confluentinc.atlassian.net/browse/CC-31133)
Currently, nanosecond-precision timestamps are capped at the year 2262 due to the limitations of the Long data type's range which is a constraint to support maximum dates up to 9999-12-31.

## Solution
As a solution, we configure the timestamp conversion as a BigInt to accommodate extended date ranges. This approach is currently applied to the nanos_string configuration, which simply converts the nanos_long value to a string. However, for dates beyond the year 2262, their nanosecond representation exceeds the maximum value of a Java Long. Therefore, we are updating nanos_string to correctly represent these extended values.


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
Test cases have been included in this doc - https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/4243293217/Microprecision+Large+Dates+support+in+JDBC+Connectors

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-31133]: https://confluentinc.atlassian.net/browse/CC-31133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ