### PR TITLE
MINOR: Reduce repetitive logs on large queries by adjusting connection logging

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -56,12 +56,13 @@ public class CachedConnectionProvider implements ConnectionProvider {
         log.info("The database connection is invalid. Reconnecting...");
         close();
         newConnection();
+      } else {
+        log.debug("Using existing database connection.");
       }
     } catch (SQLException sqle) {
       log.debug("Could not establish connection with database.", sqle);
       throw new ConnectException(sqle);
     }
-    log.debug("Database connection established.");
     return connection;
   }
 
@@ -82,6 +83,7 @@ public class CachedConnectionProvider implements ConnectionProvider {
         ++count;
         log.debug("Attempting to open connection #{} to {}", count, provider);
         connection = provider.getConnection();
+        log.info("Database connection established.");
         onConnect(connection);
         return;
       } catch (SQLException sqle) {


### PR DESCRIPTION
## Problem

Connectors produce too many (100+/s) repetitive connection logs when querying a large number of rows.

A message is logged by the [CachedConnectionProvider](https://github.com/confluentinc/kafka-connect-jdbc/blob/master/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java#L64) for each fetching of rows regardless of whether a new connection is created or the existing connection is used:

> Database connection established

See #1493

## Solution

The repetitive log has been moved to the [CachedConnectionProvider.newConnection()](https://github.com/confluentinc/kafka-connect-jdbc/blob/master/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java#L78C16-L78C31) method to only record new connections.

Access to the CachedConnectionProvider is logged as DEBUG when an existing Connection is used.
