### PR TITLE
Enhance Trace logging to check race condition in Table Fetch and Task configurations

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -173,6 +173,8 @@ public class JdbcSourceConnector extends SourceConnector {
     } else {
       log.info("No custom query provided, generating task configurations for tables");
       List<TableId> currentTables = tableMonitorThread.tables();
+      log.trace("Current tables from tableMonitorThread: {}", currentTables);
+      
       if (currentTables == null || currentTables.isEmpty()) {
         taskConfigs = new ArrayList<>(1);
         Map<String, String> taskProps = new HashMap<>(configProperties);
@@ -189,11 +191,13 @@ public class JdbcSourceConnector extends SourceConnector {
           log.warn("The connector has not been able to read the "
               + "list of tables from the database yet.");
         } else {
+          log.trace("currentTables is empty - no tables found after fetch");
           taskProps.put(JdbcSourceTaskConfig.TABLES_FETCHED, "true");
           log.warn("No tables were found so there's no work to be done.");
         }
         taskConfigs.add(taskProps);
       } else {
+        log.trace("Found {} tables to process", currentTables.size());
         int numGroups = Math.min(currentTables.size(), maxTasks);
         List<List<TableId>> tablesGrouped =
             ConnectorUtils.groupPartitions(currentTables, numGroups);
@@ -204,6 +208,7 @@ public class JdbcSourceConnector extends SourceConnector {
           builder.appendList().delimitedBy(",").of(taskTables);
           taskProps.put(JdbcSourceTaskConfig.TABLES_CONFIG, builder.toString());
           taskProps.put(JdbcSourceTaskConfig.TABLES_FETCHED, "true");
+          log.trace("Assigned tables {} to task with tablesFetched=true", taskTables);
           taskConfigs.add(taskProps);
         }
         log.info("Current Tables size: {}", currentTables.size());

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -139,6 +139,7 @@ public class JdbcSourceTask extends SourceTask {
 
     cachedConnectionProvider = connectionProvider(maxConnAttempts, retryBackoff);
 
+
     dialect.setConnectionIsolationMode(
             cachedConnectionProvider.getConnection(),
             TransactionIsolationMode

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -139,7 +139,6 @@ public class JdbcSourceTask extends SourceTask {
 
     cachedConnectionProvider = connectionProvider(maxConnAttempts, retryBackoff);
 
-
     dialect.setConnectionIsolationMode(
             cachedConnectionProvider.getConnection(),
             TransactionIsolationMode


### PR DESCRIPTION
## Problem
An issue has occurred where the connector failed to resume processing the records after stopping for a rebalance activity. It has been identified that the table Monitor thread is unable to fetch the tables and hence, the tables_fetched config in task configs is set to false which has made the connector to stall. 
It is only after a resume operation has triggered the connector to restart and then the task thread to fetch the tables and start processing the records. Expecting a race condition which made the tables_fetched config not to get updated, adding few trace logs would help to debug the issue.

## Solution
Enhanced the Trace logging which could be help to debug the issue on why the tables fetch is not being set to true. It could be whether the tables hasn't been fetched from the database, or whitelist and blacklist configs have made the tablesfetched to null.
In **JBDCSourceConnector** class, 
- Added trace logs for table fetching state and tables_fetched flag state
- Added detailed logging for task configuration process and task assignment details.

In **TableMonitorThread** class,

- Added trace logging for the exact state of table fetching at each step and when and why the task reconfigured is requested.
- Added logging for the state of tables_fetched flag and any potential race conditions in table updates.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
