### PR TITLE
Add JDBC Driver for MySQL database in the package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <derby.version>10.14.2.0</derby.version>
         <commons-io.version>2.14.0</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
+        <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
         <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>8.4.1.jre8</mssqlserver.jdbc.driver.version>
@@ -107,6 +108,12 @@
             <scope>provided</scope>
         </dependency>
          <!-- JDBC drivers, only included in runtime so they get packaged -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql-jdbc.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>


### PR DESCRIPTION
## Problem
The JDBC connector provided by Confluent does not come with a JDBC driver for MySQL.

## Solution
Add the JDBC driver for the MySQL database to the JDBC connector package.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
