### PR TITLE
MINOR: Correct the display name of the catalog.pattern config property

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -266,7 +266,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "  * ``\"\"`` retrieves those without a catalog \n"
       + "  * null (default) indicates that the schema name is not used to narrow the search and "
         + "that all table metadata is fetched, regardless of the catalog.";
-  private static final String CATALOG_PATTERN_DISPLAY = "Schema pattern";
+  private static final String CATALOG_PATTERN_DISPLAY = "Catalog pattern";
   public static final String CATALOG_PATTERN_DEFAULT = null;
 
   public static final String QUERY_CONFIG = "query";


### PR DESCRIPTION
## Problem
The catalog.pattern config option incorrectly sets the display name to  "Schema pattern".  

## Solution
Correct the property

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests