### PR TITLE
Implement provision to use new java date time APIs

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -119,6 +119,16 @@ public class JdbcSinkConfig extends AbstractConfig {
   public static final long CONNECTION_BACKOFF_DEFAULT =
       JdbcSourceConnectorConfig.CONNECTION_BACKOFF_DEFAULT;
 
+  public static final String USE_MODERN_DATE_CONVERSION_CONFIG = "use.modern.date.conversion";
+  private static final String USE_MODERN_DATE_CONVERSION_DOC =
+      "When enabled, uses modern java.time API calculations for DATE and TIMESTAMP columns "
+      + "instead of legacy java.sql.* calculations. This addresses genuine drift between legacy "
+      + "and modern date handling for historical dates (particularly pre-1582 dates). "
+      + "When false (default), maintains backward compatibility with legacy behavior. "
+      + "Note: This does not affect TIME columns as timezone offsets are expected behavior.";
+  public static final boolean USE_MODERN_DATE_CONVERSION_DEFAULT = false;
+  private static final String USE_MODERN_DATE_CONVERSION_DISPLAY = "Use Modern Date Conversion";
+
   public static final String TABLE_NAME_FORMAT = "table.name.format";
   private static final String TABLE_NAME_FORMAT_DEFAULT = "${topic}";
   private static final String TABLE_NAME_FORMAT_DOC =
@@ -578,6 +588,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             TIMESTAMP_PRECISION_MODE_CONFIG_DISPLAY,
             TIMESTAMP_PRECISION_MODE_RECOMMENDER
         )
+        .define(
+            USE_MODERN_DATE_CONVERSION_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+            USE_MODERN_DATE_CONVERSION_DEFAULT,
+            ConfigDef.Importance.LOW,
+            USE_MODERN_DATE_CONVERSION_DOC,
+            DATAMAPPING_GROUP,
+            9,
+            ConfigDef.Width.MEDIUM,
+            USE_MODERN_DATE_CONVERSION_DISPLAY
+        )
         // DDL
         .define(
             AUTO_CREATE,
@@ -681,6 +702,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final boolean useHoldlockInMerge;
 
   public final boolean trimSensitiveLogsEnabled;
+  public final boolean useModernDateConversion;
 
   public JdbcSinkConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
@@ -714,6 +736,7 @@ public class JdbcSinkConfig extends AbstractConfig {
         TimestampPrecisionMode.valueOf(getString(TIMESTAMP_PRECISION_MODE_CONFIG).toUpperCase());
     useHoldlockInMerge = getBoolean(MSSQL_USE_MERGE_HOLDLOCK);
     trimSensitiveLogsEnabled = getBoolean(TRIM_SENSITIVE_LOG_ENABLED);
+    useModernDateConversion = getBoolean(USE_MODERN_DATE_CONVERSION_CONFIG);
     if (deleteEnabled && pkMode != PrimaryKeyMode.RECORD_KEY) {
       throw new ConfigException(
           "Primary key mode must be 'record_key' when delete support is enabled");

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -309,6 +309,16 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final boolean VALIDATE_NON_NULL_DEFAULT = true;
   private static final String VALIDATE_NON_NULL_DISPLAY = "Validate Non Null";
 
+  public static final String USE_MODERN_DATE_CONVERSION_CONFIG = "use.modern.date.conversion";
+  private static final String USE_MODERN_DATE_CONVERSION_DOC =
+      "When enabled, uses modern java.time API calculations for DATE and TIMESTAMP columns "
+      + "instead of legacy java.sql.* calculations. This addresses genuine drift between legacy "
+      + "and modern date handling for historical dates (particularly pre-1582 dates). "
+      + "When false (default), maintains backward compatibility with legacy behavior. "
+      + "Note: This does not affect TIME columns as timezone offsets are expected behavior.";
+  public static final boolean USE_MODERN_DATE_CONVERSION_DEFAULT = false;
+  private static final String USE_MODERN_DATE_CONVERSION_DISPLAY = "Use Modern Date Conversion";
+
   public static final String TIMESTAMP_DELAY_INTERVAL_MS_CONFIG = "timestamp.delay.interval.ms";
   private static final String TIMESTAMP_DELAY_INTERVAL_MS_DOC =
       "How long to wait after a row with certain timestamp appears before we include it in the "
@@ -598,7 +608,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.LONG,
         DIALECT_NAME_DISPLAY,
-        DatabaseDialectRecommender.INSTANCE);
+        DatabaseDialectRecommender.INSTANCE
+    ).define(
+        USE_MODERN_DATE_CONVERSION_CONFIG,
+        Type.BOOLEAN,
+        USE_MODERN_DATE_CONVERSION_DEFAULT,
+        Importance.LOW,
+        USE_MODERN_DATE_CONVERSION_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.SHORT,
+        USE_MODERN_DATE_CONVERSION_DISPLAY);
   }
 
   private static final void addModeOptions(ConfigDef config) {
@@ -865,6 +885,10 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public String topicPrefix() {
     return getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG).trim();
+  }
+
+  public boolean useModernDateTime() {
+    return getBoolean(USE_MODERN_DATE_CONVERSION_CONFIG);
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/DateTimeUtilsTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.jdbc.util;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
@@ -23,6 +25,10 @@ import java.time.Month;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -30,6 +36,19 @@ import static org.junit.Assert.assertNull;
 public class DateTimeUtilsTest {
 
   private ZoneId utcZoneId = ZoneOffset.UTC;
+  private TimeZone originalDefaultTimeZone;
+
+  @Before
+  public void setUp() {
+    // Store original default timezone to restore it after tests
+    originalDefaultTimeZone = TimeZone.getDefault();
+  }
+
+  @After
+  public void tearDown() {
+    // Restore original default timezone
+    TimeZone.setDefault(originalDefaultTimeZone);
+  }
 
   @Test
   public void testTimestampToNanosLong() {
@@ -114,5 +133,216 @@ public class DateTimeUtilsTest {
     assertNull(isoDateTime);
     Timestamp timestamp = DateTimeUtils.toTimestampFromIsoDateTime(null, utcZoneId);
     assertNull(timestamp);
+  }
+
+  @Test
+  public void testLegacyModernRoundTripAcrossJvmAndInputTimezones() {
+    String[] jvmZones = new String[] {
+        "UTC",
+        "Etc/GMT+7",
+        "UTC+14",
+        "Etc/GMT-7",
+        "UTC-14",
+    };
+
+    String[] inputZones = jvmZones;
+
+    for (String jvmZoneId : jvmZones) {
+      TimeZone.setDefault(TimeZone.getTimeZone(jvmZoneId));
+
+      for (String inputZoneId : inputZones) {
+        ZoneId zin = ZoneId.of(inputZoneId);
+
+        // 1) Create Timestamp1 representing 0001-01-01 12:34:56.789 in Zin using legacy hybrid calendar
+        GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone(zin), Locale.ROOT);
+        cal.setLenient(false);
+        cal.clear();
+        cal.set(Calendar.ERA, GregorianCalendar.AD);
+        cal.set(Calendar.YEAR, 1);
+        cal.set(Calendar.MONTH, Calendar.JANUARY);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 12);
+        cal.set(Calendar.MINUTE, 34);
+        cal.set(Calendar.SECOND, 56);
+        cal.set(Calendar.MILLISECOND, 789);
+        Timestamp timestamp1 = new Timestamp(cal.getTimeInMillis());
+        timestamp1.setNanos(789_000_000);
+
+        // 2) convertToModernTimestamp(Timestamp1, Zin) -> Timestamp2
+        Timestamp timestamp2 = DateTimeUtils.convertToModernTimestamp(timestamp1, zin);
+
+        // 3) Construct LocalDateTime from Timestamp2's instant in Zin; must equal original fields
+        LocalDateTime ldtInZin = LocalDateTime.ofInstant(timestamp2.toInstant(), zin);
+        assertEquals("Year mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 1, ldtInZin.getYear());
+        assertEquals("Month mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 1, ldtInZin.getMonthValue());
+        assertEquals("Day mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 1, ldtInZin.getDayOfMonth());
+        assertEquals("Hour mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 12, ldtInZin.getHour());
+        assertEquals("Minute mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 34, ldtInZin.getMinute());
+        assertEquals("Second mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 56, ldtInZin.getSecond());
+        assertEquals("Nanos mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 789_000_000, ldtInZin.getNano());
+
+        // 4) convertToLegacyTimestamp(Timestamp2, Zin) -> should equal Timestamp1
+        Timestamp backToLegacy = DateTimeUtils.convertToLegacyTimestamp(timestamp2, zin);
+        assertEquals("Round-trip legacy mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId,
+            timestamp1.getTime(), backToLegacy.getTime());
+        assertEquals("Round-trip nanos mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId,
+            timestamp1.getNanos(), backToLegacy.getNanos());
+      }
+    }
+  }
+
+  @Test
+  public void testLegacyModernRoundTripAcrossJvmAndInputTimezones_BC() {
+    String[] jvmZones = new String[] {
+        "UTC",
+        "Etc/GMT+7",
+        "UTC+14",
+        "Etc/GMT-7",
+        "UTC-14",
+    };
+
+    String[] inputZones = jvmZones;
+
+    for (String jvmZoneId : jvmZones) {
+      TimeZone.setDefault(TimeZone.getTimeZone(jvmZoneId));
+
+      for (String inputZoneId : inputZones) {
+        ZoneId zin = ZoneId.of(inputZoneId);
+
+        // 1) Create Timestamp1 representing 0001-12-30 12:34:56.789 BC in Zin using legacy hybrid calendar
+        GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone(zin), Locale.ROOT);
+        cal.setLenient(false);
+        cal.clear();
+        cal.set(Calendar.ERA, GregorianCalendar.BC);
+        cal.set(Calendar.YEAR, 1);
+        cal.set(Calendar.MONTH, Calendar.DECEMBER);
+        cal.set(Calendar.DAY_OF_MONTH, 30);
+        cal.set(Calendar.HOUR_OF_DAY, 12);
+        cal.set(Calendar.MINUTE, 34);
+        cal.set(Calendar.SECOND, 56);
+        cal.set(Calendar.MILLISECOND, 789);
+        Timestamp timestamp1 = new Timestamp(cal.getTimeInMillis());
+        timestamp1.setNanos(789_000_000);
+
+        // 2) convertToModernTimestamp(Timestamp1, Zin) -> Timestamp2
+        Timestamp timestamp2 = DateTimeUtils.convertToModernTimestamp(timestamp1, zin);
+
+        // 3) Construct LocalDateTime from Timestamp2's instant in Zin; must equal original fields (proleptic)
+        LocalDateTime ldtInZin = LocalDateTime.ofInstant(timestamp2.toInstant(), zin);
+        // For 1 BC in legacy, proleptic ISO year is 0
+        assertEquals("Year mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 0, ldtInZin.getYear());
+        assertEquals("Month mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 12, ldtInZin.getMonthValue());
+        assertEquals("Day mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 30, ldtInZin.getDayOfMonth());
+        assertEquals("Hour mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 12, ldtInZin.getHour());
+        assertEquals("Minute mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 34, ldtInZin.getMinute());
+        assertEquals("Second mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 56, ldtInZin.getSecond());
+        assertEquals("Nanos mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 789_000_000, ldtInZin.getNano());
+
+        // 4) convertToLegacyTimestamp(Timestamp2, Zin) -> should equal Timestamp1
+        Timestamp backToLegacy = DateTimeUtils.convertToLegacyTimestamp(timestamp2, zin);
+        assertEquals("Round-trip legacy mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId,
+            timestamp1.getTime(), backToLegacy.getTime());
+        assertEquals("Round-trip nanos mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId,
+            timestamp1.getNanos(), backToLegacy.getNanos());
+      }
+    }
+  }
+
+  @Test
+  public void testConvertToModernDateAcrossJvmAndInputTimezones() {
+    String[] jvmZones = new String[] {
+        "UTC",
+        "Etc/GMT+7",
+        "UTC+14",
+        "Etc/GMT-7",
+        "UTC-14",
+    };
+
+    String[] inputZones = jvmZones;
+
+    for (String jvmZoneId : jvmZones) {
+      TimeZone.setDefault(TimeZone.getTimeZone(jvmZoneId));
+
+      for (String inputZoneId : inputZones) {
+        ZoneId zin = ZoneId.of(inputZoneId);
+
+        // Build a legacy java.sql.Date representing 0001-01-01 in Zin using hybrid calendar
+        GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone(zin), Locale.ROOT);
+        cal.setLenient(false);
+        cal.clear();
+        cal.set(Calendar.ERA, GregorianCalendar.AD);
+        cal.set(Calendar.YEAR, 1);
+        cal.set(Calendar.MONTH, Calendar.JANUARY);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        java.sql.Date legacyDate = new java.sql.Date(cal.getTimeInMillis());
+
+        // Convert to modern date (proleptic behavior)
+        java.sql.Date modernDate = DateTimeUtils.convertToModernDate(legacyDate, zin);
+
+        // Validate by interpreting modernDate epoch millis at Zin start-of-day
+        LocalDateTime ldtInZin = LocalDateTime.ofInstant(
+            java.time.Instant.ofEpochMilli(modernDate.getTime()), zin);
+        assertEquals("Year mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 1, ldtInZin.getYear());
+        assertEquals("Month mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 1, ldtInZin.getMonthValue());
+        assertEquals("Day mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 1, ldtInZin.getDayOfMonth());
+        // Time portion should reflect midnight for a Date (00:00:00.000) in that zone
+        assertEquals("Hour mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 0, ldtInZin.getHour());
+        assertEquals("Minute mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 0, ldtInZin.getMinute());
+        assertEquals("Second mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 0, ldtInZin.getSecond());
+        assertEquals("Nano mismatch for JVM timezone: " + jvmZoneId + ", input timezone: " + inputZoneId, 0, ldtInZin.getNano());
+      }
+    }
+  }
+
+  @Test
+  public void testConvertToModernDateAcrossJvmAndInputTimezones_BC() {
+    String[] jvmZones = new String[]{
+        "UTC",
+        "Etc/GMT+7",
+        "UTC+14",
+        "Etc/GMT-7",
+        "UTC-14",
+    };
+
+    String[] inputZones = jvmZones;
+
+    for (String jvmZoneId : jvmZones) {
+      TimeZone.setDefault(TimeZone.getTimeZone(jvmZoneId));
+
+      for (String inputZoneId : inputZones) {
+        ZoneId zin = ZoneId.of(inputZoneId);
+
+        // Build a legacy java.sql.Date representing 0001-01-01 BC in Zin using hybrid calendar
+        GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone(zin), Locale.ROOT);
+        cal.setLenient(false);
+        cal.clear();
+        cal.set(Calendar.ERA, GregorianCalendar.BC);
+        cal.set(Calendar.YEAR, 1);
+        cal.set(Calendar.MONTH, Calendar.JANUARY);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        java.sql.Date legacyDate = new java.sql.Date(cal.getTimeInMillis());
+
+        // Convert to modern date (proleptic behavior)
+        java.sql.Date modernDate = DateTimeUtils.convertToModernDate(legacyDate, zin);
+
+        // Validate by interpreting modernDate epoch millis at Zin start-of-day
+        LocalDateTime ldtInZin = LocalDateTime.ofInstant(
+            java.time.Instant.ofEpochMilli(modernDate.getTime()), zin);
+        // For 1 BC in legacy, proleptic ISO year is 0
+        assertEquals("Year mismatch for JVM timezone: " + jvmZoneId + ", input timezone: "
+                     + inputZoneId, 0, ldtInZin.getYear());
+        assertEquals("Month mismatch for JVM timezone: " + jvmZoneId + ", input timezone: "
+                     + inputZoneId, 1, ldtInZin.getMonthValue());
+        assertEquals("Day mismatch for JVM timezone: " + jvmZoneId + ", input timezone: "
+                     + inputZoneId, 1, ldtInZin.getDayOfMonth());
+        // Time portion should reflect midnight for a Date (00:00:00.000) in that zone
+        assertEquals("Hour mismatch for JVM timezone: " + jvmZoneId + ", input timezone: "
+                     + inputZoneId, 0, ldtInZin.getHour());
+        assertEquals("Minute mismatch for JVM timezone: " + jvmZoneId + ", input timezone: "
+                     + inputZoneId, 0, ldtInZin.getMinute());
+        assertEquals("Second mismatch for JVM timezone: " + jvmZoneId + ", input timezone: "
+                     + inputZoneId, 0, ldtInZin.getSecond());
+      }
+    }
   }
 }


### PR DESCRIPTION
## Problem
Details in -- https://confluentinc.atlassian.net/wiki/spaces/~635b68551cc605b1fd16afeb/pages/4734518130/New+Time+API+migration

- Introduce a user facing config `use.modern.date.conversion` which when set, the new java date time APIs would be used and customer facing benefits would include, 1) micro/nano seconds precision support 2) Ability to run sink connector with kafka topic data produced using some other source connector which used new date time APIs

## Solution
Details in -- https://confluentinc.atlassian.net/wiki/spaces/~635b68551cc605b1fd16afeb/pages/4734518130/New+Time+API+migration

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
