### PR TITLE
CC-36404: Add table include / exclude list regex and timestamp and incrementing column mapping

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,13 +7,13 @@
 <suppressions>
 
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask|RecordQueue|MySqlConnectionWrapper|TableQuerierProcessor).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|GenericDatabaseDialect|SybaseDatabaseDialect|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread|JdbcSinkTask|RecordQueue|MySqlConnectionWrapper|TableQuerierProcessor|JdbcSourceConnector).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect|RecordQueue).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(BufferedRecords|DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>
+              files="(BufferedRecords|DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect|JdbcSourceConnector).java"/>
 
     <suppress checks="JavaNCSS"
               files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -69,6 +69,7 @@ public class JdbcSourceConnector extends SourceConnector {
   @Override
   public void start(Map<String, String> properties) throws ConnectException {
     log.info("Starting JDBC Source Connector");
+    log.info("Configuration properties: {}", properties);
     try {
       configProperties = properties;
       config = new JdbcSourceConnectorConfig(configProperties);
@@ -76,6 +77,10 @@ public class JdbcSourceConnector extends SourceConnector {
       throw new ConnectException("Couldn't start JdbcSourceConnector due to configuration error",
                                  e);
     }
+    
+    // Log table filtering configuration
+    log.info("Table include list: {}", config.tableIncludeListRegexes());
+    log.info("Table exclude list: {}", config.tableExcludeListRegexes());
 
     final String dbUrl = config.getString(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG);
     final int maxConnectionAttempts = config.getInt(
@@ -252,7 +257,8 @@ public class JdbcSourceConnector extends SourceConnector {
     } else {
       log.info("No custom query provided, generating task configurations for tables");
       List<TableId> currentTables = tableMonitorThread.tables();
-      log.trace("Current tables from tableMonitorThread: {}", currentTables);
+      log.info("Current tables from tableMonitorThread: {}", currentTables);
+      log.info("Number of tables found: {}", currentTables != null ? currentTables.size() : 0);
       
       if (currentTables == null || currentTables.isEmpty()) {
         taskConfigs = new ArrayList<>(1);

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -98,21 +98,29 @@ public class JdbcSourceConnector extends SourceConnector {
     long tablePollMs = config.getLong(JdbcSourceConnectorConfig.TABLE_POLL_INTERVAL_MS_CONFIG);
     long tableStartupLimitMs =
         config.getLong(JdbcSourceConnectorConfig.TABLE_MONITORING_STARTUP_POLLING_LIMIT_MS_CONFIG);
+    
+    // Enhanced table filtering configuration validation
     List<String> whitelist = config.getList(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG);
     Set<String> whitelistSet = whitelist.isEmpty() ? null : new HashSet<>(whitelist);
+    
     List<String> blacklist = config.getList(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
     Set<String> blacklistSet = blacklist.isEmpty() ? null : new HashSet<>(blacklist);
+    
+    List<String> includeList = config.tableIncludeListRegexes();
+    Set<String> includeListSet = includeList.isEmpty() ? null : new HashSet<>(includeList);
+    
+    List<String> excludeList = config.tableExcludeListRegexes();
+    Set<String> excludeListSet = excludeList.isEmpty() ? null : new HashSet<>(excludeList);
 
-    if (whitelistSet != null && blacklistSet != null) {
-      throw new ConnectException(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + " and "
-                                 + JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG + " are "
-                                 + "exclusive.");
-    }
+    // Comprehensive validation of mutually exclusive configurations
+    validateTableFilteringConfigs(whitelistSet, blacklistSet, includeListSet, excludeListSet);
+
     String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
     if (!query.isEmpty()) {
-      if (whitelistSet != null || blacklistSet != null) {
+      if (whitelistSet != null || blacklistSet != null 
+          || includeListSet != null || excludeListSet != null) {
         log.error(
-            "Configuration error: {} is set, but table whitelist or blacklist is also specified."
+            "Configuration error: {} is set, but table filtering options are also specified. "
                 + "These settings cannot be used together.",
             JdbcSourceConnectorConfig.QUERY_CONFIG);
         throw new ConnectException(JdbcSourceConnectorConfig.QUERY_CONFIG + " may not be combined"
@@ -121,16 +129,18 @@ public class JdbcSourceConnector extends SourceConnector {
       // Force filtering out the entire set of tables since the one task we'll generate is for the
       // query.
       whitelistSet = Collections.emptySet();
-
     }
+    
     tableMonitorThread = new TableMonitorThread(
         dialect,
         cachedConnectionProvider,
         context,
         tableStartupLimitMs,
         tablePollMs,
-        whitelistSet,
-        blacklistSet,
+        whitelistSet,      // Legacy
+        blacklistSet,      // Legacy
+        includeListSet,    // New
+        excludeListSet,    // New
         Time.SYSTEM
     );
     if (query.isEmpty()) {
@@ -141,6 +151,75 @@ public class JdbcSourceConnector extends SourceConnector {
 
   protected CachedConnectionProvider connectionProvider(int maxConnAttempts, long retryBackoff) {
     return new CachedConnectionProvider(dialect, maxConnAttempts, retryBackoff);
+  }
+
+  /**
+   * Validate table filtering configurations to ensure they are mutually exclusive.
+   * This method ensures that legacy whitelist/blacklist configurations cannot be used
+   * together with the new include/exclude list configurations.
+   */
+  private void validateTableFilteringConfigs(Set<String> whitelistSet, Set<String> blacklistSet, 
+                                           Set<String> includeListSet, Set<String> excludeListSet) {
+    validateLegacyConfigExclusivity(whitelistSet, blacklistSet);
+    validateLegacyAndNewConfigExclusivity(whitelistSet, blacklistSet, 
+                                          includeListSet, excludeListSet);
+    warnOnEmptyIncludeWithExclude(includeListSet, excludeListSet);
+  }
+
+  private void validateLegacyConfigExclusivity(Set<String> whitelistSet, Set<String> blacklistSet) {
+    if (whitelistSet != null && blacklistSet != null) {
+      throw new ConnectException(
+          "Legacy table filtering configurations are mutually exclusive. Cannot use both "
+          + JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + " and "
+          + JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG + " together."
+      );
+    }
+  }
+
+  private void validateLegacyAndNewConfigExclusivity(Set<String> whitelistSet, 
+                                                    Set<String> blacklistSet,
+                                                    Set<String> includeListSet, 
+                                                    Set<String> excludeListSet) {
+    boolean hasLegacyConfig = whitelistSet != null || blacklistSet != null;
+    boolean hasNewConfig = includeListSet != null || excludeListSet != null;
+    
+    // Exclude list cannot exist without include list
+    if (excludeListSet != null && includeListSet == null) {
+      throw new ConnectException(
+          JdbcSourceConnectorConfig.TABLE_EXCLUDE_LIST_CONFIG 
+          + " cannot be used without " + JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG
+          + ". Exclude list only applies to tables that match the include list."
+      );
+    }
+    
+    if (hasLegacyConfig && hasNewConfig) {
+      List<String> configsUsed = new ArrayList<>();
+      if (whitelistSet != null) {
+        configsUsed.add(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG);
+      }
+      if (blacklistSet != null) {
+        configsUsed.add(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
+      }
+      if (includeListSet != null) {
+        configsUsed.add(JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG);
+      }
+      if (excludeListSet != null) {
+        configsUsed.add(JdbcSourceConnectorConfig.TABLE_EXCLUDE_LIST_CONFIG);
+      }
+      
+      throw new ConnectException(
+          "Table filtering configurations are mutually exclusive. "
+          + "Cannot use legacy whitelist/blacklist with new include/exclude lists. "
+          + "Configured: " + String.join(", ", configsUsed)
+      );
+    }
+  }
+
+  private void warnOnEmptyIncludeWithExclude(Set<String> includeListSet, 
+                                             Set<String> excludeListSet) {
+    if (includeListSet != null && excludeListSet != null && includeListSet.isEmpty()) {
+      log.warn("Include list is empty but exclude list is specified. No tables will be selected.");
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -46,6 +46,7 @@ import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.RecordQueue;
+import io.confluent.connect.jdbc.util.TableCollectionUtils;
 import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.util.Version;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TransactionIsolationMode;
@@ -66,6 +67,8 @@ public class JdbcSourceTask extends SourceTask {
   PriorityQueue<TableQuerier> tableQueue = new PriorityQueue<>();
   protected RecordQueue<SourceRecord> engine;
   private TableQuerierProcessor tableQuerierProcessor;
+  private final Map<String, String> tableToIncrCol = new HashMap<>();
+  private final Map<String, List<String>> tableToTsCols = new HashMap<>();
 
   public JdbcSourceTask() {
     this.time = Time.SYSTEM;
@@ -145,7 +148,7 @@ public class JdbcSourceTask extends SourceTask {
     );
     TableQuerier.QueryMode queryMode = !query.isEmpty() ? TableQuerier.QueryMode.QUERY :
                                        TableQuerier.QueryMode.TABLE;
-    List<String> tablesOrQuery = queryMode == TableQuerier.QueryMode.QUERY
+    final List<String> tablesOrQuery = queryMode == TableQuerier.QueryMode.QUERY
                                  ? Collections.singletonList(query) : tables;
 
     String mode = config.getString(JdbcSourceTaskConfig.MODE_CONFIG);
@@ -179,10 +182,36 @@ public class JdbcSourceTask extends SourceTask {
       log.trace("The partition offsets are {}", offsets);
     }
 
-    String incrementingColumn
+    // Support both legacy and new mapping configurations
+    String legacyIncrementingColumn
         = config.getString(JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
-    List<String> timestampColumns
+    List<String> legacyTimestampColumns
         = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+    List<String> timestampColumnMappings = config.timestampColumnMapping();
+    List<String> incrementingColumnMappings = config.incrementingColumnMapping();
+
+    // Validate mapping configurations
+    if (config.modeUsesTimestampColumn() && !timestampColumnMappings.isEmpty()) {
+      TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
+          config.timestampColMappingRegexes(), tables, java.util.function.Function.identity(),
+          problem -> {
+            throw new ConnectException(
+                "Error while validating timestamp column mappings: " + problem);
+          }
+      );
+      populateTableToTsColsMap(tables, timestampColumnMappings);
+    }
+    if (config.modeUsesIncrementingColumn() && !incrementingColumnMappings.isEmpty()) {
+      TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
+          config.incrementingColMappingRegexes(), tables, java.util.function.Function.identity(),
+          problem -> {
+            throw new ConnectException(
+                "Error while validating incrementing column mappings: " + problem);
+          }
+      );
+      populateTableToIncrementingColMap(tables, incrementingColumnMappings);
+    }
+
     Long timestampDelayInterval
         = config.getLong(JdbcSourceTaskConfig.TIMESTAMP_DELAY_INTERVAL_MS_CONFIG);
     boolean validateNonNulls
@@ -190,16 +219,24 @@ public class JdbcSourceTask extends SourceTask {
     TimeZone timeZone = config.timeZone();
     String suffix = config.getString(JdbcSourceTaskConfig.QUERY_SUFFIX_CONFIG).trim();
 
-    if (queryMode.equals(TableQuerier.QueryMode.TABLE)) {
-      validateColumnsExist(mode, incrementingColumn, timestampColumns, tables.get(0), tableType);
-    }
-
     for (String tableOrQuery : tablesOrQuery) {
       final List<Map<String, String>> tablePartitionsToCheck;
       final Map<String, String> partition;
+      
+      // Get columns for this specific table (either from mapping or legacy config)
+      String incrementingColumn = getIncrementingColumnForTable(tableOrQuery, 
+          legacyIncrementingColumn);
+      List<String> timestampColumns = getTimestampColumnsForTable(tableOrQuery, 
+          legacyTimestampColumns);
+      
       log.trace("Task executing in {} mode",queryMode);
       switch (queryMode) {
         case TABLE:
+          // Validate columns exist for this specific table
+          if (queryMode.equals(TableQuerier.QueryMode.TABLE)) {
+            validateColumnsExist(mode, incrementingColumn, timestampColumns, tableOrQuery, 
+                tableType);
+          }
           if (validateNonNulls) {
             validateNonNullable(
                 mode,
@@ -596,4 +633,44 @@ public class JdbcSourceTask extends SourceTask {
                                  + " NULL", e);
     }
   }
+
+  private void populateTableToIncrementingColMap(List<String> tables, 
+      List<String> tableRegexToIncrCols) {
+    for (String table : tables) {
+      for (String tableRegexToIncrCol : tableRegexToIncrCols) {
+        String[] tableAndIncrCol = tableRegexToIncrCol.split(":", 2);
+        if (table.matches(tableAndIncrCol[0].trim())) {
+          tableToIncrCol.put(table, tableAndIncrCol[1].trim());
+          break;
+        }
+      }
+    }
+  }
+
+  private void populateTableToTsColsMap(List<String> tables, List<String> tableRegexToTsCols) {
+    for (String table : tables) {
+      for (String tableRegexToTsCol : tableRegexToTsCols) {
+        String[] tableAndTsCols = tableRegexToTsCol.split(":", 2);
+        if (table.matches(tableAndTsCols[0].trim())) {
+          String columnsString = tableAndTsCols[1].trim();
+          // Remove brackets and split by pipe
+          String columnsContent = columnsString.substring(1, columnsString.length() - 1);
+          tableToTsCols.put(table, Arrays.asList(columnsContent.split("\\|")));
+          break;
+        }
+      }
+    }
+  }
+
+  private String getIncrementingColumnForTable(String table, String legacyIncrementingColumn) {
+    // Use mapping if available, otherwise fall back to legacy configuration
+    return tableToIncrCol.getOrDefault(table, legacyIncrementingColumn);
+  }
+
+  private List<String> getTimestampColumnsForTable(String table, 
+      List<String> legacyTimestampColumns) {
+    // Use mapping if available, otherwise fall back to legacy configuration
+    return tableToTsCols.getOrDefault(table, legacyTimestampColumns);
+  }
+
 }

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -189,6 +189,10 @@ public class JdbcSourceTask extends SourceTask {
         = config.getList(JdbcSourceTaskConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
     List<String> timestampColumnMappings = config.timestampColumnMapping();
     List<String> incrementingColumnMappings = config.incrementingColumnMapping();
+    
+    log.info("Timestamp column mappings: {}", timestampColumnMappings);
+    log.info("Incrementing column mappings: {}", incrementingColumnMappings);
+    log.info("Mode: {}", config.getString(JdbcSourceTaskConfig.MODE_CONFIG));
 
     // Validate mapping configurations
     if (config.modeUsesTimestampColumn() && !timestampColumnMappings.isEmpty()) {

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -247,9 +247,9 @@ public class TableMonitorThread extends Thread {
   private boolean updateTables() {
     final List<TableId> allTables;
     try {
-      log.trace("Fetching all tables from database");
+      log.info("Fetching all tables from database");
       allTables = dialect.tableIds(connectionProvider.getConnection());
-      log.debug("Retrieved {} tables from database: {}", allTables.size(), allTables);
+      log.info("Retrieved {} tables from database: {}", allTables.size(), allTables);
     } catch (SQLException e) {
       log.error(
           "Error while trying to get updated table list, ignoring and waiting for next table poll"
@@ -264,18 +264,19 @@ public class TableMonitorThread extends Thread {
     
     if (useRegexFiltering) {
       // New regex-based filtering
-      log.trace("Applying regex-based include/exclude filters to tables");
+      log.info("Applying regex-based include/exclude filters to tables");
+      log.info("Include regex patterns: {}", includeListRegex);
+      log.info("Exclude regex patterns: {}", excludeListRegex);
       filteredTables = TableCollectionUtils.filterTables(
           allTables, 
           includeListRegex != null ? includeListRegex : java.util.Collections.emptySet(),
           excludeListRegex != null ? excludeListRegex : java.util.Collections.emptySet()
       );
-      log.debug("Regex filtering resulted in {} tables from {} total tables", 
+      log.info("Regex filtering resulted in {} tables from {} total tables", 
                filteredTables.size(), allTables.size());
-      if (log.isTraceEnabled()) {
-        for (TableId table : filteredTables) {
-          log.trace("Table {} passed regex filters", table);
-        }
+      log.info("Filtered tables: {}", filteredTables);
+      for (TableId table : filteredTables) {
+        log.info("Table {} passed regex filters", table);
       }
     } else {
       // Legacy exact-match filtering

--- a/src/main/java/io/confluent/connect/jdbc/util/TableCollectionUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableCollectionUtils.java
@@ -64,7 +64,15 @@ public class TableCollectionUtils {
     
     for (TableId table : tables) {
       String tableString = table.toString();
-      if (matchesAny(tableString, inclusionRegex) && !matchesAny(tableString, exclusionRegex)) {
+      boolean includeMatch = matchesAny(tableString, inclusionRegex);
+      boolean excludeMatch = matchesAny(tableString, exclusionRegex);
+      
+      // Use System.out for immediate visibility in logs
+      System.out.println("DEBUG: Table " + tableString + " - Include match: " + includeMatch 
+                        + ", Exclude match: " + excludeMatch + ", Final result: " 
+                        + (includeMatch && !excludeMatch));
+      
+      if (includeMatch && !excludeMatch) {
         filteredTables.add(table);
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/util/TableCollectionUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableCollectionUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for filtering collections of tables using regular expression patterns.
+ * This class provides sophisticated table filtering capabilities using include and exclude
+ * regex patterns, which is more powerful than simple exact string matching.
+ */
+public class TableCollectionUtils {
+
+  private TableCollectionUtils() {
+    // Private constructor to prevent instantiation
+  }
+
+  /**
+   * Filter tables using include and exclude regex patterns.
+   * 
+   * <p>The filtering process works as follows:
+   * <ol>
+   *   <li>Apply inclusion patterns first - only tables matching at least one inclusion 
+   *       pattern are kept</li>
+   *   <li>Apply exclusion patterns to the included tables - tables matching any exclusion 
+   *       pattern are removed</li>
+   *   <li>Remove duplicates while preserving order</li>
+   * </ol>
+   * 
+   * <p>If the inclusion regex set is empty, no tables will be included regardless of 
+   * exclusion patterns. If the exclusion regex set is empty, no tables will be excluded 
+   * from the included set.
+   * 
+   * @param tables All available tables from the database
+   * @param inclusionRegex Set of regex patterns for inclusion (empty means include none)
+   * @param exclusionRegex Set of regex patterns for exclusion (empty means exclude none)
+   * @return Filtered and deduplicated list of tables, preserving original order
+   */
+  public static List<TableId> filterTables(
+      List<TableId> tables,
+      Set<String> inclusionRegex,
+      Set<String> exclusionRegex
+  ) {
+    List<TableId> filteredTables = new ArrayList<>();
+    
+    for (TableId table : tables) {
+      String tableString = table.toString();
+      if (matchesAny(tableString, inclusionRegex) && !matchesAny(tableString, exclusionRegex)) {
+        filteredTables.add(table);
+      }
+    }
+    
+    // Remove duplicates while preserving order using LinkedHashSet
+    return new ArrayList<>(new LinkedHashSet<>(filteredTables));
+  }
+
+  /**
+   * Validate that each table matches exactly one regex pattern from the provided list.
+   * This is useful for validating column mapping configurations where each table should
+   * match exactly one mapping rule.
+   * 
+   * @param regexes List of regex patterns to validate against
+   * @param tableIds List of table identifiers to validate
+   * @param tableIdToString Function to convert table ID to string for matching
+   * @param problemReporter Consumer to report validation problems
+   * @param <T> Type of table identifier
+   * @return true if validation passes, false if any table matches zero or more than one
+   */
+  public static <T> boolean validateEachTableMatchesExactlyOneRegex(
+      List<String> regexes,
+      List<T> tableIds,
+      Function<T, String> tableIdToString,
+      Consumer<String> problemReporter
+  ) {
+    for (T tableId : tableIds) {
+      int matchCount = 0;
+      for (String regex : regexes) {
+        if (Pattern.matches(regex, tableIdToString.apply(tableId))) {
+          matchCount++;
+        }
+      }
+      if (matchCount == 0) {
+        problemReporter.accept("Included table '" + tableId.toString()
+            + "' does not match any of the provided regexes");
+        return false;
+      } else if (matchCount > 1) {
+        problemReporter.accept("Included table '" + tableId.toString()
+            + "' matches more than one of the provided regexes");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Check if a table string matches any of the provided regex patterns.
+   * 
+   * @param tableString The table identifier as a string
+   * @param regexSet Set of regex patterns to match against
+   * @return true if the table string matches at least one regex pattern, false otherwise
+   */
+  private static boolean matchesAny(String tableString, Set<String> regexSet) {
+    if (regexSet == null || regexSet.isEmpty()) {
+      return false; // Empty regex set means match nothing
+    }
+    
+    for (String regex : regexSet) {
+      if (Pattern.matches(regex, tableString)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigMappingTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfigMappingTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.source;
+
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcSourceConnectorConfigMappingTest {
+
+  @Test
+  public void testTimestampColumnMappingValidation() {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:test://localhost");
+    props.put(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, "something garbage");
+    
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    ConfigValue validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Invalid format. Expected 'regex:[col1|col2|...]'"));
+
+    props.put(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, ".*):[col1, col2]");
+    validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Invalid regular expression"));
+
+    props.put(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, "abc.*:col1|col2],.*:col3|col4]");
+    validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Columns list must be enclosed in square brackets"));
+
+    props.put(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, "abc.*:[|col2],.*:[col3|col4]");
+    validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Every column name should be non-empty string"));
+
+    props.put(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, "abc.*:[]");
+    validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Columns list cannot be empty"));
+  }
+
+  @Test
+  public void testIncrementingColumnMappingValidation() {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:test://localhost");
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG, "something garbage");
+    
+    Map<String, ConfigValue> validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    ConfigValue validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Invalid format. Expected 'regex:columnName'"));
+
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG, ".*):col1");
+    validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Invalid regular expression"));
+
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG, "abc.*:,.*:col1");
+    validatedConfig =
+        JdbcSourceConnectorConfig.CONFIG_DEF.validateAll(props);
+    validatedValue =
+        validatedConfig.get(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG);
+    assertTrue(validatedValue.errorMessages().get(0).contains("Column name cannot be empty"));
+  }
+
+  @Test
+  public void testModeUsesTimestampColumn() {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:test://localhost");
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_TIMESTAMP);
+    
+    JdbcSourceConnectorConfig config = new JdbcSourceConnectorConfig(props);
+    assertTrue(config.modeUsesTimestampColumn());
+    assertFalse(config.modeUsesIncrementingColumn());
+
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
+    config = new JdbcSourceConnectorConfig(props);
+    assertFalse(config.modeUsesTimestampColumn());
+    assertTrue(config.modeUsesIncrementingColumn());
+
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+    config = new JdbcSourceConnectorConfig(props);
+    assertTrue(config.modeUsesTimestampColumn());
+    assertTrue(config.modeUsesIncrementingColumn());
+
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
+    config = new JdbcSourceConnectorConfig(props);
+    assertFalse(config.modeUsesTimestampColumn());
+    assertFalse(config.modeUsesIncrementingColumn());
+  }
+
+  @Test
+  public void testTimestampColumnMappingAccessors() {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:test://localhost");
+    props.put(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, 
+        "schema1.table1.*:[col1|col2],schema2.table2.*:[col3]");
+    
+    JdbcSourceConnectorConfig config = new JdbcSourceConnectorConfig(props);
+    assertEquals(2, config.timestampColumnMapping().size());
+    assertEquals(2, config.timestampColMappingRegexes().size());
+    assertEquals("schema1.table1.*", config.timestampColMappingRegexes().get(0));
+    assertEquals("schema2.table2.*", config.timestampColMappingRegexes().get(1));
+  }
+
+  @Test
+  public void testIncrementingColumnMappingAccessors() {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, "jdbc:test://localhost");
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG, 
+        "schema1.table1.*:id1,schema2.table2.*:id2");
+    
+    JdbcSourceConnectorConfig config = new JdbcSourceConnectorConfig(props);
+    assertEquals(2, config.incrementingColumnMapping().size());
+    assertEquals(2, config.incrementingColMappingRegexes().size());
+    assertEquals("schema1.table1.*", config.incrementingColMappingRegexes().get(0));
+    assertEquals("schema2.table2.*", config.incrementingColMappingRegexes().get(1));
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/TableCollectionUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableCollectionUtilsTest.java
@@ -17,237 +17,61 @@ package io.confluent.connect.jdbc.util;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TableCollectionUtilsTest {
 
-  private static final String CATALOG = "catalog";
-  private static final String SCHEMA1 = "schema1";
-  private static final String SCHEMA2 = "schema2";
-  private static final String TABLE1 = "users";
-  private static final String TABLE2 = "orders";
-  private static final String TABLE3 = "products";
-  private static final String TABLE4 = "temp_users";
-  private static final String TABLE5 = "staging_orders";
+  private static final String DB1 = "db1";
+  private static final String TABLE1 = "table1";
+  private static final String TABLE2 = "table2";
+  private static final String TABLE3 = "table3";
+  private static final String TABLE_REGEX1 = ".*\"table1\"";
+  private static final String TABLE_REGEX2 = ".*\"table2\"";
+  private static final String TABLE_REGEX_ALL = ".*\"table.*\"";
+
 
   @Test
-  public void testFilterTablesWithIncludeOnly() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1),
-        new TableId(CATALOG, SCHEMA1, TABLE2),
-        new TableId(CATALOG, SCHEMA2, TABLE3)
-    );
-    
-    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*", ".*\"products\""));
-    Set<String> excludeRegex = new HashSet<>();
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(3, result.size());
-    assertTrue(result.stream().anyMatch(t -> TABLE1.equals(t.tableName())));
-    assertTrue(result.stream().anyMatch(t -> TABLE2.equals(t.tableName())));
-    assertTrue(result.stream().anyMatch(t -> TABLE3.equals(t.tableName())));
-  }
-
-  @Test
-  public void testFilterTablesWithIncludeAndExclude() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1),
-        new TableId(CATALOG, SCHEMA1, TABLE2),
-        new TableId(CATALOG, SCHEMA2, TABLE3),
-        new TableId(CATALOG, SCHEMA1, TABLE4),
-        new TableId(CATALOG, SCHEMA2, TABLE5)
-    );
-    
-    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*", ".*\"schema2\".*"));
-    Set<String> excludeRegex = new HashSet<>(Arrays.asList(".*\"temp.*", ".*\"staging.*"));
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(3, result.size());
-    assertTrue(result.stream().anyMatch(t -> TABLE1.equals(t.tableName())));
-    assertTrue(result.stream().anyMatch(t -> TABLE2.equals(t.tableName())));
-    assertTrue(result.stream().anyMatch(t -> TABLE3.equals(t.tableName())));
-    assertFalse(result.stream().anyMatch(t -> TABLE4.equals(t.tableName())));
-    assertFalse(result.stream().anyMatch(t -> TABLE5.equals(t.tableName())));
-  }
-
-  @Test
-  public void testFilterTablesWithExcludeOnly() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1),
-        new TableId(CATALOG, SCHEMA1, TABLE4),
-        new TableId(CATALOG, SCHEMA2, TABLE5)
-    );
-    
-    // Empty include set means no tables will be included
-    Set<String> includeRegex = new HashSet<>();
-    Set<String> excludeRegex = new HashSet<>(Arrays.asList(".*temp.*"));
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  public void testFilterTablesWithEmptyIncludeList() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1),
-        new TableId(CATALOG, SCHEMA1, TABLE2)
-    );
-    
-    Set<String> includeRegex = new HashSet<>();
-    Set<String> excludeRegex = new HashSet<>();
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  public void testFilterTablesRemovesDuplicates() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1),
-        new TableId(CATALOG, SCHEMA1, TABLE1), // Duplicate
-        new TableId(CATALOG, SCHEMA1, TABLE2)
-    );
-    
-    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*"));
-    Set<String> excludeRegex = new HashSet<>();
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(2, result.size());
-    assertTrue(result.stream().anyMatch(t -> TABLE1.equals(t.tableName())));
-    assertTrue(result.stream().anyMatch(t -> TABLE2.equals(t.tableName())));
-  }
-
-  @Test
-  public void testFilterTablesWithComplexRegex() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, "prod_schema", "customer_data"),
-        new TableId(CATALOG, "test_schema", "customer_data"),
-        new TableId(CATALOG, "prod_schema", "order_history"),
-        new TableId(CATALOG, "staging_schema", "temp_data")
-    );
-    
-    Set<String> includeRegex = new HashSet<>(
-            Arrays.asList(".*\"prod_schema\".*\"customer.*", ".*\"prod_schema\".*\"order.*"));
-    Set<String> excludeRegex = new HashSet<>();
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(2, result.size());
-    assertTrue(result.stream().anyMatch(t -> "customer_data".equals(t.tableName())
-            && "prod_schema".equals(t.schemaName())));
-    assertTrue(result.stream().anyMatch(t -> "order_history".equals(t.tableName())
-            && "prod_schema".equals(t.schemaName())));
-  }
-
-  @Test
-  public void testValidateEachTableMatchesExactlyOneRegexWithValidTables() {
-    List<String> regexes = Arrays.asList(".*\"schema1\".*\"users\"", ".*\"schema1\".*\"orders\"");
-    List<TableId> tableIds = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1),
-        new TableId(CATALOG, SCHEMA1, TABLE2)
-    );
-    
-    List<String> problems = new ArrayList<>();
+  public void validateEachTableMatchesExactlyOneRegexWithValidTables() {
+    List<String> regexes = Arrays.asList(TABLE_REGEX1, TABLE_REGEX2);
+    List<TableId> tableIds = Arrays.asList(new TableId(null, DB1, TABLE1),
+                                           new TableId(null, DB1, TABLE2));
     boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
-        regexes, tableIds, TableId::toString, problems::add
-    );
-    
+        regexes, tableIds, TableId::toString, problem -> {});
+
     assertTrue(result);
-    assertTrue(problems.isEmpty());
   }
 
   @Test
-  public void testValidateEachTableMatchesExactlyOneRegexWithNoMatch() {
-    List<String> regexes = Arrays.asList(".*\"schema1\".*\"users\"", ".*\"schema1\".*\"orders\"");
-    List<TableId> tableIds = Arrays.asList(
-        new TableId(CATALOG, SCHEMA2, TABLE3) // Won't match any regex
-    );
-    
-    List<String> problems = new ArrayList<>();
+  public void validateEachTableMatchesExactlyOneRegexWithNoMatch() {
+    List<String> regexes = Arrays.asList(TABLE_REGEX1, TABLE_REGEX2);
+    List<TableId> tableIds = Arrays.asList(new TableId(null, DB1, TABLE3));
     boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
-        regexes, tableIds, TableId::toString, problems::add
-    );
-    
+        regexes, tableIds, TableId::toString, problem -> {});
+
     assertFalse(result);
-    assertEquals(1, problems.size());
-    assertTrue(problems.get(0).contains("does not match any of the provided regexes"));
   }
 
   @Test
-  public void testValidateEachTableMatchesExactlyOneRegexWithMultipleMatches() {
-    List<String> regexes = Arrays.asList(".*\"schema1\".*\"users\"", ".*\"users\""); // Both will match
-    List<TableId> tableIds = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1)
-    );
-    
-    List<String> problems = new ArrayList<>();
+  public void validateEachTableMatchesExactlyOneRegexWithMultipleMatches() {
+    List<String> regexes = Arrays.asList(TABLE_REGEX1, TABLE_REGEX_ALL);
+    List<TableId> tableIds = Arrays.asList(new TableId(null, DB1, TABLE1));
     boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
-        regexes, tableIds, TableId::toString, problems::add
-    );
-    
+        regexes, tableIds, TableId::toString, problem -> {});
+
     assertFalse(result);
-    assertEquals(1, problems.size());
-    assertTrue(problems.get(0).contains("matches more than one of the provided regexes"));
   }
 
   @Test
-  public void testValidateEachTableMatchesExactlyOneRegexWithEmptyRegexList() {
-    List<String> regexes = new ArrayList<>();
-    List<TableId> tableIds = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1)
-    );
-    
-    List<String> problems = new ArrayList<>();
+  public void validateEachTableMatchesExactlyOneRegexWithEmptyRegexList() {
+    List<String> regexes = Arrays.asList();
+    List<TableId> tableIds = Arrays.asList(new TableId(null, DB1, TABLE1));
     boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
-        regexes, tableIds, TableId::toString, problems::add
-    );
-    
+        regexes, tableIds, TableId::toString, problem -> {});
+
     assertFalse(result);
-    assertEquals(1, problems.size());
-    assertTrue(problems.get(0).contains("does not match any of the provided regexes"));
-  }
-
-  @Test
-  public void testFilterTablesWithNullSets() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, TABLE1)
-    );
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables,
-            null, null);
-    
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  public void testFilterTablesPreservesOrder() {
-    List<TableId> tables = Arrays.asList(
-        new TableId(CATALOG, SCHEMA1, "zebra"),
-        new TableId(CATALOG, SCHEMA1, "apple"),
-        new TableId(CATALOG, SCHEMA1, "banana")
-    );
-    
-    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*"));
-    Set<String> excludeRegex = new HashSet<>();
-    
-    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
-    
-    assertEquals(3, result.size());
-    assertEquals("zebra", result.get(0).tableName());
-    assertEquals("apple", result.get(1).tableName());
-    assertEquals("banana", result.get(2).tableName());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/TableCollectionUtilsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableCollectionUtilsTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TableCollectionUtilsTest {
+
+  private static final String CATALOG = "catalog";
+  private static final String SCHEMA1 = "schema1";
+  private static final String SCHEMA2 = "schema2";
+  private static final String TABLE1 = "users";
+  private static final String TABLE2 = "orders";
+  private static final String TABLE3 = "products";
+  private static final String TABLE4 = "temp_users";
+  private static final String TABLE5 = "staging_orders";
+
+  @Test
+  public void testFilterTablesWithIncludeOnly() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1),
+        new TableId(CATALOG, SCHEMA1, TABLE2),
+        new TableId(CATALOG, SCHEMA2, TABLE3)
+    );
+    
+    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*", ".*\"products\""));
+    Set<String> excludeRegex = new HashSet<>();
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(3, result.size());
+    assertTrue(result.stream().anyMatch(t -> TABLE1.equals(t.tableName())));
+    assertTrue(result.stream().anyMatch(t -> TABLE2.equals(t.tableName())));
+    assertTrue(result.stream().anyMatch(t -> TABLE3.equals(t.tableName())));
+  }
+
+  @Test
+  public void testFilterTablesWithIncludeAndExclude() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1),
+        new TableId(CATALOG, SCHEMA1, TABLE2),
+        new TableId(CATALOG, SCHEMA2, TABLE3),
+        new TableId(CATALOG, SCHEMA1, TABLE4),
+        new TableId(CATALOG, SCHEMA2, TABLE5)
+    );
+    
+    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*", ".*\"schema2\".*"));
+    Set<String> excludeRegex = new HashSet<>(Arrays.asList(".*\"temp.*", ".*\"staging.*"));
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(3, result.size());
+    assertTrue(result.stream().anyMatch(t -> TABLE1.equals(t.tableName())));
+    assertTrue(result.stream().anyMatch(t -> TABLE2.equals(t.tableName())));
+    assertTrue(result.stream().anyMatch(t -> TABLE3.equals(t.tableName())));
+    assertFalse(result.stream().anyMatch(t -> TABLE4.equals(t.tableName())));
+    assertFalse(result.stream().anyMatch(t -> TABLE5.equals(t.tableName())));
+  }
+
+  @Test
+  public void testFilterTablesWithExcludeOnly() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1),
+        new TableId(CATALOG, SCHEMA1, TABLE4),
+        new TableId(CATALOG, SCHEMA2, TABLE5)
+    );
+    
+    // Empty include set means no tables will be included
+    Set<String> includeRegex = new HashSet<>();
+    Set<String> excludeRegex = new HashSet<>(Arrays.asList(".*temp.*"));
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testFilterTablesWithEmptyIncludeList() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1),
+        new TableId(CATALOG, SCHEMA1, TABLE2)
+    );
+    
+    Set<String> includeRegex = new HashSet<>();
+    Set<String> excludeRegex = new HashSet<>();
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testFilterTablesRemovesDuplicates() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1),
+        new TableId(CATALOG, SCHEMA1, TABLE1), // Duplicate
+        new TableId(CATALOG, SCHEMA1, TABLE2)
+    );
+    
+    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*"));
+    Set<String> excludeRegex = new HashSet<>();
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(2, result.size());
+    assertTrue(result.stream().anyMatch(t -> TABLE1.equals(t.tableName())));
+    assertTrue(result.stream().anyMatch(t -> TABLE2.equals(t.tableName())));
+  }
+
+  @Test
+  public void testFilterTablesWithComplexRegex() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, "prod_schema", "customer_data"),
+        new TableId(CATALOG, "test_schema", "customer_data"),
+        new TableId(CATALOG, "prod_schema", "order_history"),
+        new TableId(CATALOG, "staging_schema", "temp_data")
+    );
+    
+    Set<String> includeRegex = new HashSet<>(
+            Arrays.asList(".*\"prod_schema\".*\"customer.*", ".*\"prod_schema\".*\"order.*"));
+    Set<String> excludeRegex = new HashSet<>();
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(2, result.size());
+    assertTrue(result.stream().anyMatch(t -> "customer_data".equals(t.tableName())
+            && "prod_schema".equals(t.schemaName())));
+    assertTrue(result.stream().anyMatch(t -> "order_history".equals(t.tableName())
+            && "prod_schema".equals(t.schemaName())));
+  }
+
+  @Test
+  public void testValidateEachTableMatchesExactlyOneRegexWithValidTables() {
+    List<String> regexes = Arrays.asList(".*\"schema1\".*\"users\"", ".*\"schema1\".*\"orders\"");
+    List<TableId> tableIds = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1),
+        new TableId(CATALOG, SCHEMA1, TABLE2)
+    );
+    
+    List<String> problems = new ArrayList<>();
+    boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
+        regexes, tableIds, TableId::toString, problems::add
+    );
+    
+    assertTrue(result);
+    assertTrue(problems.isEmpty());
+  }
+
+  @Test
+  public void testValidateEachTableMatchesExactlyOneRegexWithNoMatch() {
+    List<String> regexes = Arrays.asList(".*\"schema1\".*\"users\"", ".*\"schema1\".*\"orders\"");
+    List<TableId> tableIds = Arrays.asList(
+        new TableId(CATALOG, SCHEMA2, TABLE3) // Won't match any regex
+    );
+    
+    List<String> problems = new ArrayList<>();
+    boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
+        regexes, tableIds, TableId::toString, problems::add
+    );
+    
+    assertFalse(result);
+    assertEquals(1, problems.size());
+    assertTrue(problems.get(0).contains("does not match any of the provided regexes"));
+  }
+
+  @Test
+  public void testValidateEachTableMatchesExactlyOneRegexWithMultipleMatches() {
+    List<String> regexes = Arrays.asList(".*\"schema1\".*\"users\"", ".*\"users\""); // Both will match
+    List<TableId> tableIds = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1)
+    );
+    
+    List<String> problems = new ArrayList<>();
+    boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
+        regexes, tableIds, TableId::toString, problems::add
+    );
+    
+    assertFalse(result);
+    assertEquals(1, problems.size());
+    assertTrue(problems.get(0).contains("matches more than one of the provided regexes"));
+  }
+
+  @Test
+  public void testValidateEachTableMatchesExactlyOneRegexWithEmptyRegexList() {
+    List<String> regexes = new ArrayList<>();
+    List<TableId> tableIds = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1)
+    );
+    
+    List<String> problems = new ArrayList<>();
+    boolean result = TableCollectionUtils.validateEachTableMatchesExactlyOneRegex(
+        regexes, tableIds, TableId::toString, problems::add
+    );
+    
+    assertFalse(result);
+    assertEquals(1, problems.size());
+    assertTrue(problems.get(0).contains("does not match any of the provided regexes"));
+  }
+
+  @Test
+  public void testFilterTablesWithNullSets() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, TABLE1)
+    );
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables,
+            null, null);
+    
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testFilterTablesPreservesOrder() {
+    List<TableId> tables = Arrays.asList(
+        new TableId(CATALOG, SCHEMA1, "zebra"),
+        new TableId(CATALOG, SCHEMA1, "apple"),
+        new TableId(CATALOG, SCHEMA1, "banana")
+    );
+    
+    Set<String> includeRegex = new HashSet<>(Arrays.asList(".*\"schema1\".*"));
+    Set<String> excludeRegex = new HashSet<>();
+    
+    List<TableId> result = TableCollectionUtils.filterTables(tables, includeRegex, excludeRegex);
+    
+    assertEquals(3, result.size());
+    assertEquals("zebra", result.get(0).tableName());
+    assertEquals("apple", result.get(1).tableName());
+    assertEquals("banana", result.get(2).tableName());
+  }
+}


### PR DESCRIPTION
- Introduces two new configs -- timestamp.columns.mapping and incrementing.column.mapping to specify the table regex to set of timestamp or incrementing columns to use in appropriate modes.
- Changed the include and exclude list behavior to first find tables which are included according to inclusion regexes and then filter out those excluded by exclusion regexes. 