### PR TITLE
Push to maven-snapshots rather than maven

### DIFF
--- a/scripts/release-internal-version.sh
+++ b/scripts/release-internal-version.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 DOMAIN_OWNER="519856050701"
 DOMAIN="confluent"
 REGION="us-west-2"
-REPOSITORY="maven"
+REPOSITORY="maven-snapshots"
 NAMESPACE="io/confluent"
 ARTIFACT_ID="kafka-connect-jdbc"
 


### PR DESCRIPTION
## Problem

```
[INFO] --- deploy:2.8.2:deploy (default-deploy) @ kafka-connect-jdbc ---00:42
[INFO] Using alternate deployment repository confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven/00:42
[INFO] ------------------------------------------------------------------------00:42
[INFO] BUILD FAILURE00:42
[INFO] ------------------------------------------------------------------------00:42
[INFO] Total time:  28.543 s00:42
[INFO] Finished at: 2025-09-23T15:19:41Z00:42
[INFO] ------------------------------------------------------------------------00:42
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project kafka-connect-jdbc: Failed to deploy artifacts: Could not transfer artifact io.confluent:kafka-connect-jdbc:jar:10.8.5_1 from/to confluent-codeartifact-internal (https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven/): status code: 403, reason phrase: Forbidden (403) -> [Help 1]
```

## Solution
Pusing to maven-snapshots rather than maven

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
