### PR TITLE
Use aws cli rather than curl

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -60,7 +60,7 @@ blocks:
   - name: Release
     dependencies: ["Test"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.x'"
+      when: "branch =~ '[0-9]+\\.[0-9]+\\.x'"
     task:
       jobs:
         - name: Release


### PR DESCRIPTION
## Problem
`(curl exit code: 43)` 
Was obtained in the last release job on 10.8.x

Looks like curl is not the recommended way. This PR replaces usage of curl to find the versions in artifactory with usage of aws cli.


## Solution
Use aws cli rather than curl

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
