### PR TITLE
Add another constructor for validation class

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -41,6 +41,12 @@ public class JdbcSourceConnectorValidation {
   protected final JdbcSourceConnectorConfig config;
   protected final Config validationResult;
 
+  public JdbcSourceConnectorValidation(JdbcSourceConnectorConfig config,
+                                          Config validationResult) {
+    this.config = config;
+    this.validationResult = validationResult;
+  }
+
   public JdbcSourceConnectorValidation(Map<String, String> connectorConfigs) {
     this.config = new JdbcSourceConnectorConfig(connectorConfigs);
     // Create Config object using ConfigDef.validateAll() approach


### PR DESCRIPTION
## Problem
Currently subclasses of JdbcSourceConnectorValidation are not able to use their own config and validation result to initialize the parent class.

## Solution
Adds another constructor for `JdbcSourceConnectorValidation` which allows to set the below two variables from subclasses.
```
protected final JdbcSourceConnectorConfig config;
protected final Config validationResult;
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
