### PR TITLE
Make `addConfigError` protected

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -427,7 +427,7 @@ public class JdbcSourceConnectorValidation {
   /**
    * Helper method to add validation errors to config values.
    */
-  private void addConfigError(String configName, String errorMessage) {
+  protected void addConfigError(String configName, String errorMessage) {
     validationResult.configValues().stream()
         .filter(cv -> cv.name().equals(configName))
         .findFirst()


### PR DESCRIPTION
## Problem
The `addConfigError` was private. Hence subclasses didn't have ability to use it.

## Solution
Making it protected.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
