### PR TITLE
feat: add ServiceLoader support for plugin.discovery=service_load

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,16 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+io.confluent.connect.jdbc.JdbcSinkConnector

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,16 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+io.confluent.connect.jdbc.JdbcSourceConnector


### PR DESCRIPTION
## Problem
Explained in issue #1567

## Root Cause Analysis

The issue appears to be that `kafka-connect-jdbc` is missing the required **ServiceLoader configuration files**. 

For ServiceLoader to discover connector implementations, the JAR needs to contain:

- `META-INF/services/org.apache.kafka.connect.source.SourceConnector`
- `META-INF/services/org.apache.kafka.connect.sink.SinkConnector`

These files should list the fully qualified class names of the connector implementations.


## Proposed Solution

Add ServiceLoader configuration files to the `kafka-connect-jdbc` JAR:

### 1. Create Source Connector Service File

**File:** `META-INF/services/org.apache.kafka.connect.source.SourceConnector`

```text
io.confluent.connect.jdbc.JdbcSourceConnector
```

### 2. Create Sink Connector Service File

**File:** `META-INF/services/org.apache.kafka.connect.sink.SinkConnector`

```text
io.confluent.connect.jdbc.JdbcSinkConnector
```

##### Does this solution apply anywhere else?
: yes

##### If yes, where? 
here: https://github.com/apache/kafka/tree/trunk/connect/file/src/main/resources/META-INF/services


## Test Strategy

### Manual Testing Performed

I manually tested this change by spinning up Kafka brokers and Connect servers locally.

#### Test Environment
- Kafka brokers running locally
- Kafka Connect server in distributed mode
- Configuration: `plugin.discovery=service_load`

#### Test Steps
1. Started local Kafka brokers
2. Configured Kafka Connect with `plugin.discovery=service_load`
3. Added kafka-connect-jdbc JAR with ServiceLoader configuration
4. Started Kafka Connect server
5. Verified connector discovery via REST API:
```bash
   curl http://localhost:8083/connector-plugins
```

## Release Plan

### Proposed Approach
- Merge to `master` branch for next release
- Consider backporting to active maintenance branches (if applicable)

### Compatibility
- ✅ Backward compatible - no breaking changes
- ✅ Safe to merge - only adds new functionality
- ✅ No rollback concerns - existing discovery modes unaffected

### Suggested Target
- Next minor/patch release
