### PR TITLE
Fix flakiness due to testTableLocksWithStreamingReads

### DIFF
--- a/src/test/java/io/confluent/connect/jdbc/source/integration/PostgresOOMIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/PostgresOOMIT.java
@@ -63,11 +63,9 @@ public class PostgresOOMIT extends BaseOOMIntegrationTest {
     props.put(JdbcSourceTaskConfig.TABLES_CONFIG, "test_table");
     props.put(JdbcSourceTaskConfig.TABLES_FETCHED, "true");
     startTask();
-    assertNoLocksOpen(task);
     assertTrue(task.poll().size() > 0);
     assertNoLocksOpen(task);
     task.stop();
-    Thread.sleep(1000); // to ensure that postgres has time to close the connection
     assertNoLocksOpen(task);
   }
 

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -17,7 +17,7 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.appender.stdout.layout.ConversionPattern=[%d] [%t] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.kafka=ERROR
 log4j.logger.io.confluent.connect=ERROR


### PR DESCRIPTION
## Problem
testTableLocksWithStreamingReads was flaky and lead to productivity dip

## Solution
Before the recent record queue enhancements, `poll` function was responsible to make the DB calls. This test relied on the old behaviour, hence before polling it expected no locks to be taken. 

Howeverm after change in implementation now querying DB part is done by some other thread, hence it's not tied to poll.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
