### PR TITLE
 Update AbstractJdbcSourceConnectorIT to use new configs

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TableCollectionUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableCollectionUtils.java
@@ -66,12 +66,7 @@ public class TableCollectionUtils {
       String tableString = table.toUnquotedString();
       boolean includeMatch = matchesAny(tableString, inclusionRegex);
       boolean excludeMatch = matchesAny(tableString, exclusionRegex);
-      
-      // Use System.out for immediate visibility in logs
-      System.out.println("DEBUG: Table " + tableString + " - Include match: " + includeMatch 
-                        + ", Exclude match: " + excludeMatch + ", Final result: " 
-                        + (includeMatch && !excludeMatch));
-      
+
       if (includeMatch && !excludeMatch) {
         filteredTables.add(table);
       }

--- a/src/test/java/io/confluent/connect/jdbc/integration/PostgresJdbcSourceConnectorIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/PostgresJdbcSourceConnectorIT.java
@@ -99,7 +99,7 @@ public class PostgresJdbcSourceConnectorIT extends AbstractJdbcSourceConnectorIT
   }
 
   @Override
-  public void createTable(String tableName) throws SQLException {
+  protected void createTable(String tableName) throws SQLException {
     try (Statement stmt = connection.createStatement()) {
       stmt.execute("CREATE TABLE " + tableName + " (" +
                    "id SERIAL PRIMARY KEY, " +


### PR DESCRIPTION
## Problem
`table.whitelist`, `table.blacklist`, `incrementing.column.name` and `timestamp.column.name` are deprecated
 and `table.include.list`, `table.exclude.list`, `incrementing.column.mapping` or `timestamp.column.mappings` should be the ones used.

## Solution
Updates AbstractJdbcSourceConnectorIT to use the newer configs.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
