### PR TITLE
Release new version only when triggered via promotion

### DIFF
--- a/.semaphore/release-internal-version.yml
+++ b/.semaphore/release-internal-version.yml
@@ -1,0 +1,26 @@
+version: v1.0
+name: Release Internal Version
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 8
+      - . cache-maven restore
+
+blocks:
+  - name: Release
+    dependencies: []
+    run:
+      when: "branch =~ '[0-9]+\\.[0-9]+\\.x'"
+    task:
+      jobs:
+        - name: Release
+          commands:
+            - . assume-iam-role arn:aws:iam::519856050701:role/semaphore-oidc
+            - chmod +x scripts/release-internal-version.sh
+            - ./scripts/release-internal-version.sh
+

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,17 +57,6 @@ blocks:
             - . publish-test-results
             - artifact push workflow target/test-results
 
-  - name: Release
-    dependencies: ["Test"]
-    run:
-      when: "branch =~ '[0-9]+\\.[0-9]+\\.x'"
-    task:
-      jobs:
-        - name: Release
-          commands:
-            - . assume-iam-role arn:aws:iam::519856050701:role/semaphore-oidc
-            - chmod +x scripts/release-internal-version.sh
-            - ./scripts/release-internal-version.sh
   - name: Release Notes
     dependencies: []
     run:
@@ -96,3 +85,7 @@ after_pipeline:
           - checkout
           - sem-version java 11
           - emit-sonarqube-data -a test-results
+
+promotions:
+  - name: Release incremental f/w version
+    pipeline_file: release-internal-version.yml


### PR DESCRIPTION
## Problem
The release pipeline which releases a new `io.confluent:kafka-connect-jdbc` artifact used to be triggered after every merge to 10.8.x. Hence even for minute changes, a new dependency version was released.

We want to make it as a promotion which would release a new version only when a user triggers the promotion in the pipeline.

This would ensure that the versions released are all well-tested and of production-grade readiness.

## Solution
Refactored to run the `release-internal-version.sh` script inside a promotion in the semaphore job.

<img width="1584" height="750" alt="image" src="https://github.com/user-attachments/assets/62ddb7ae-42ae-4a76-afe5-9d786d16e78e" />


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
