### PR TITLE
Revert unnecessary pint merge changes 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu24-04-amd64-1
+    type: s1-prod-ubuntu20-04-amd64-1
 
 fail_fast:
   cancel:
@@ -39,7 +39,7 @@ blocks:
           commands:
             - pip install confluent-release-tools -q
             - . sem-pint
-            - sudo apt-get --assume-yes install libncurses6
+            - sudo apt-get --assume-yes install libncurses5
             - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 -Ddependency.check.skip=true --batch-mode --no-transfer-progress clean verify install dependency:analyze validate
             - . cve-scan
             - . cache-maven store

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.source;
 
 import java.util.TimeZone;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -66,7 +67,7 @@ public class JdbcSourceTask extends SourceTask {
   private final AtomicBoolean running = new AtomicBoolean(false);
 
   public JdbcSourceTask() {
-    this.time = Time.SYSTEM;
+    this.time = new SystemTime();
   }
 
   public JdbcSourceTask(Time time) {

--- a/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/integration/PauseResumeIT.java
@@ -10,7 +10,6 @@ import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -80,7 +79,6 @@ public class PauseResumeIT {
     }
   }
 
-  @Ignore
   @Test
   public void testPauseResume() throws Exception {
     try (Connection conn = getConnection(); Statement stmt = conn.createStatement()) {


### PR DESCRIPTION
This reverts commit 675e6b364d4e53887f7998737d886b09e812cf44, reversing changes made to 9a5e806315a583caec467340dabf9c682f58ead2.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
