### PR TITLE
Add ServiceLoader definitions for JdbcSourceConnector and JdbcSinkConnector to support SERVICE_LOAD plugin discovery

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,1 @@
+io.confluent.connect.jdbc.JdbcSinkConnector

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,1 @@
+io.confluent.connect.jdbc.JdbcSourceConnector


### PR DESCRIPTION
## Problem
The JdbcSourceConnector and JdbcSinkConnector are not compatible with service_load plugin discovery as mentioned in this issue: https://github.com/confluentinc/kafka-connect-jdbc/issues/1512

## Solution
Added the definitions for the connectors to support the service_load plugin discovery.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Without these definitions, when using the `plugin.discovery=service_load`, the connector implementation couldn't be discovered, resulting in the following error:
```
Failed to find any class that implements Connector and which name matches io.confluent.connect.jdbc.JdbcSourceConnector, available connectors are:
...
```

After adding these definitions, the connector started running successfully:
```
Added plugin 'io.confluent.connect.jdbc.JdbcSourceConnector':PluginDesc{klass=class io.confluent.connect.jdbc.JdbcSourceConnector, name='io.confluent.connect.jdbc.JdbcSourceConnector', version='10.9.0-SNAPSHOT', encodedVersion=10.9.0-SNAPSHOT, type=source, typeName='source', location='file:/usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/'} (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader:111)
```


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
