### PR TITLE
Replacing \u0000 with nothing for PostgreSqlDatabaseDialect #1264

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -503,6 +503,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   ) throws SQLException {
 
     switch (schema.type()) {
+      case STRING: {
+        String newValue = ((String) value).replace("\u0000","");
+        statement.setString(index, newValue);
+        return true;
+      }
       case ARRAY: {
         Class<?> valueClass = value.getClass();
         Object newValue = null;

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -462,7 +462,14 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     assertEquals(expectedMaxLength, actualMaxLength);
   }
-
+ 
+  @Test
+  public void bindFieldStringValueWithNulls() throws SQLException {
+    int index = ThreadLocalRandom.current().nextInt();
+    verifyBindField(++index, Schema.STRING_SCHEMA, "y\u0000ep\u0000\u0000").setString(index, "yep");
+    verifyBindField(++index, Schema.STRING_SCHEMA, null).setObject(index, null);
+  }
+ 
   @Test
   public void shouldGracefullyHandleErrorWhenComputingMaxTableNameLength() throws Exception {
     Statement statement = mock(Statement.class);


### PR DESCRIPTION
## Problem
Fixes exceptions in corpdb fields which contain utf8 null

## Solution
Strip chars from field when enctountred

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
