### PR TITLE
Fix MDC connector context not propagating to async querier thread

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/RecordQueue.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/RecordQueue.java
@@ -9,6 +9,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -29,8 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
-
-import org.slf4j.MDC;
 
 /**
  * A concurrent and blocking queue for source records, with the ability to asynchronously execute
@@ -328,10 +327,12 @@ public class RecordQueue<RecordT extends SourceRecord> implements RecordDestinat
         operationName,
         logContext,
         cancellableDestination,
-        generatorProcessor,
-        callerMdc
+        generatorProcessor
     );
-    return CompletableFuture.supplyAsync(supplier, executor);
+    return CompletableFuture.supplyAsync(
+        withMdcContext(supplier, callerMdc),
+        executor
+    );
   }
 
   @Override
@@ -471,13 +472,9 @@ public class RecordQueue<RecordT extends SourceRecord> implements RecordDestinat
       String operationName,
       String logContext,
       RecordDestination<RecordT> destination,
-      Function<RecordDestination<RecordT>, T> generatorProcessor,
-      Map<String, String> callerMdc
+      Function<RecordDestination<RecordT>, T> generatorProcessor
   ) {
     return () -> {
-      if (callerMdc != null) {
-        MDC.setContextMap(callerMdc);
-      }
       try (ConnectLogContext context = new ConnectLogContext(logContext)) {
         try {
           log.debug("{}Starting {}", context.prefix(), operationName);
@@ -489,8 +486,29 @@ public class RecordQueue<RecordT extends SourceRecord> implements RecordDestinat
         } finally {
           log.debug("{}Stopped {}", context.prefix(), operationName);
         }
+      }
+    };
+  }
+
+  private <T> Supplier<T> withMdcContext(
+      Supplier<T> supplier,
+      Map<String, String> callerMdc
+  ) {
+    return () -> {
+      Map<String, String> previousMdc = MDC.getCopyOfContextMap();
+      try {
+        if (callerMdc != null) {
+          MDC.setContextMap(callerMdc);
+        } else {
+          MDC.clear();
+        }
+        return supplier.get();
       } finally {
-        MDC.clear();
+        if (previousMdc != null) {
+          MDC.setContextMap(previousMdc);
+        } else {
+          MDC.clear();
+        }
       }
     };
   }

--- a/src/test/java/io/confluent/connect/jdbc/util/ConnectLogContextTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/ConnectLogContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ConnectLogContextTest {
+
+  private static final String CONNECTOR_MDC_CONTEXT = "connector.context";
+
+  @After
+  public void tearDown() {
+    MDC.clear();
+  }
+
+  @Test
+  public void shouldAppendSuffixWhenMdcHasConnectorContext() {
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+
+    try (ConnectLogContext ctx = new ConnectLogContext("tableQuerierProcessor")) {
+      // MDC should now have the appended context
+      assertEquals(
+          "[my-connector|task-0|tableQuerierProcessor] ",
+          MDC.get(CONNECTOR_MDC_CONTEXT)
+      );
+      // prefix should be empty since MDC is used
+      assertEquals("", ctx.prefix());
+    }
+
+    // After close, MDC should be restored to original value
+    assertEquals("[my-connector|task-0] ", MDC.get(CONNECTOR_MDC_CONTEXT));
+  }
+
+  @Test
+  public void shouldUsePrefixWhenMdcIsEmpty() {
+    // No MDC set
+    try (ConnectLogContext ctx = new ConnectLogContext("tableQuerierProcessor")) {
+      // MDC should still be null
+      assertNull(MDC.get(CONNECTOR_MDC_CONTEXT));
+      // prefix should contain the log context
+      assertEquals("tableQuerierProcessor ", ctx.prefix());
+    }
+  }
+
+  @Test
+  public void shouldHandleNestedContexts() {
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+
+    try (ConnectLogContext outer = new ConnectLogContext("outer")) {
+      assertEquals("[my-connector|task-0|outer] ", MDC.get(CONNECTOR_MDC_CONTEXT));
+
+      try (ConnectLogContext inner = new ConnectLogContext("inner")) {
+        assertEquals("[my-connector|task-0|outer|inner] ", MDC.get(CONNECTOR_MDC_CONTEXT));
+      }
+
+      // After inner closes, should restore to outer's context
+      assertEquals("[my-connector|task-0|outer] ", MDC.get(CONNECTOR_MDC_CONTEXT));
+    }
+
+    // After outer closes, should restore to original
+    assertEquals("[my-connector|task-0] ", MDC.get(CONNECTOR_MDC_CONTEXT));
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/RecordQueueMdcTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/RecordQueueMdcTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class RecordQueueMdcTest {
+
+  private static final String CONNECTOR_MDC_CONTEXT = "connector.context";
+
+  private RecordQueue<SourceRecord> queue;
+
+  @Before
+  public void setUp() {
+    queue = RecordQueue.<SourceRecord>builder()
+        .maxBatchSize(10)
+        .maxExecutorThreads(1)
+        .build();
+  }
+
+  @After
+  public void tearDown() throws InterruptedException {
+    MDC.clear();
+    if (queue != null) {
+      queue.stop();
+      queue.awaitTermination(Duration.ofSeconds(5));
+    }
+  }
+
+  @Test
+  public void shouldPropagateConnectorContextToExecutorThread() throws Exception {
+    // Simulate Kafka Connect setting MDC on the calling thread
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+
+    AtomicReference<String> capturedMdc = new AtomicReference<>();
+
+    CompletableFuture<Boolean> future = queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> {
+          // Capture the MDC value on the executor thread
+          capturedMdc.set(MDC.get(CONNECTOR_MDC_CONTEXT));
+          return true;
+        }
+    );
+
+    assertTrue(future.get(10, TimeUnit.SECONDS));
+
+    // The executor thread should have seen the connector context with appended suffix
+    assertNotNull("MDC should be propagated to executor thread", capturedMdc.get());
+    assertEquals(
+        "[my-connector|task-0|testProcessor] ",
+        capturedMdc.get()
+    );
+  }
+
+  @Test
+  public void shouldCleanUpMdcAfterExecution() throws Exception {
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+
+    AtomicReference<String> mdcAfterExecution = new AtomicReference<>();
+
+    // First submit — sets MDC on executor thread
+    CompletableFuture<Boolean> future1 = queue.submit(
+        "First Operation",
+        "firstProcessor",
+        destination -> true
+    );
+    future1.get(10, TimeUnit.SECONDS);
+
+    // Clear caller's MDC to simulate a different calling context
+    MDC.clear();
+
+    // Second submit — without MDC on the calling thread
+    CompletableFuture<Boolean> future2 = queue.submit(
+        "Second Operation",
+        "secondProcessor",
+        destination -> {
+          mdcAfterExecution.set(MDC.get(CONNECTOR_MDC_CONTEXT));
+          return true;
+        }
+    );
+    future2.get(10, TimeUnit.SECONDS);
+
+    // The second execution should NOT have the first execution's MDC
+    // (it should be null since the caller had no MDC set)
+    assertNull(
+        "MDC should be cleaned up between executions on pooled threads",
+        mdcAfterExecution.get()
+    );
+  }
+
+  @Test
+  public void shouldWorkWhenCallerHasNoMdc() throws Exception {
+    // No MDC set on the calling thread
+    AtomicReference<String> capturedMdc = new AtomicReference<>();
+
+    CompletableFuture<Boolean> future = queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> {
+          capturedMdc.set(MDC.get(CONNECTOR_MDC_CONTEXT));
+          return true;
+        }
+    );
+
+    assertTrue(future.get(10, TimeUnit.SECONDS));
+
+    // Without MDC, ConnectLogContext falls back to prefix mode — no MDC set
+    assertNull(capturedMdc.get());
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/RecordQueueMdcTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/RecordQueueMdcTest.java
@@ -11,25 +11,38 @@ import org.junit.Test;
 import org.slf4j.MDC;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class RecordQueueMdcTest {
 
   private static final String CONNECTOR_MDC_CONTEXT = "connector.context";
+  private static final String TRACE_MDC_CONTEXT = "trace.id";
+  private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
 
   private RecordQueue<SourceRecord> queue;
 
   @Before
   public void setUp() {
-    queue = RecordQueue.<SourceRecord>builder()
-        .maxBatchSize(10)
+    queue = queueBuilder()
         .maxExecutorThreads(1)
         .build();
   }
@@ -37,9 +50,24 @@ public class RecordQueueMdcTest {
   @After
   public void tearDown() throws InterruptedException {
     MDC.clear();
+    stopQueue();
+  }
+
+  private RecordQueue.Builder<SourceRecord> queueBuilder() {
+    return RecordQueue.<SourceRecord>builder()
+        .maxBatchSize(10);
+  }
+
+  private void replaceQueue(RecordQueue<SourceRecord> replacement) throws InterruptedException {
+    stopQueue();
+    queue = replacement;
+  }
+
+  private void stopQueue() throws InterruptedException {
     if (queue != null) {
       queue.stop();
-      queue.awaitTermination(Duration.ofSeconds(5));
+      queue.awaitTermination(TERMINATION_TIMEOUT);
+      queue = null;
     }
   }
 
@@ -124,5 +152,164 @@ public class RecordQueueMdcTest {
 
     // Without MDC, ConnectLogContext falls back to prefix mode — no MDC set
     assertNull(capturedMdc.get());
+  }
+
+  @Test
+  public void shouldInvokeProtectedCreateLoggingSupplierOverride() throws Exception {
+    TrackingRecordQueue trackingQueue = new TrackingRecordQueue(
+        queueBuilder().maxExecutorThreads(1)
+    );
+    replaceQueue(trackingQueue);
+
+    assertTrue(queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> true
+    ).get(10, TimeUnit.SECONDS));
+
+    assertTrue(trackingQueue.loggingSupplierCreated());
+  }
+
+  @Test
+  public void shouldRestoreCallerMdcWithDirectExecutor() throws Exception {
+    replaceQueue(
+        queueBuilder()
+            .executorFactory(DirectExecutorService::new)
+            .build()
+    );
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+    MDC.put(TRACE_MDC_CONTEXT, "caller-trace");
+    Map<String, String> callerMdc = MDC.getCopyOfContextMap();
+
+    assertTrue(queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> true
+    ).get(10, TimeUnit.SECONDS));
+
+    assertEquals(callerMdc, MDC.getCopyOfContextMap());
+  }
+
+  @Test
+  public void shouldRestorePreExistingExecutorMdc() throws Exception {
+    ExecutorService executor = useExecutorWithMdc(TRACE_MDC_CONTEXT, "worker-trace");
+    AtomicReference<String> capturedMdc = new AtomicReference<>();
+
+    assertTrue(queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> {
+          capturedMdc.set(MDC.get(TRACE_MDC_CONTEXT));
+          return true;
+        }
+    ).get(10, TimeUnit.SECONDS));
+
+    assertNull(capturedMdc.get());
+    assertEquals(
+        "worker-trace",
+        executor.submit(() -> MDC.get(TRACE_MDC_CONTEXT)).get(10, TimeUnit.SECONDS)
+    );
+  }
+
+  @Test
+  public void shouldRestorePreExistingExecutorMdcAfterFailure() throws Exception {
+    ExecutorService executor = useExecutorWithMdc(TRACE_MDC_CONTEXT, "worker-trace");
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+
+    CompletableFuture<Boolean> future = queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> {
+          throw new IllegalStateException("test failure");
+        }
+    );
+
+    assertThrows(
+        ExecutionException.class,
+        () -> future.get(10, TimeUnit.SECONDS)
+    );
+    assertEquals(
+        "worker-trace",
+        executor.submit(() -> MDC.get(TRACE_MDC_CONTEXT)).get(10, TimeUnit.SECONDS)
+    );
+  }
+
+  private ExecutorService useExecutorWithMdc(String key, String value) throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.submit(() -> MDC.put(key, value)).get(10, TimeUnit.SECONDS);
+    replaceQueue(
+        queueBuilder()
+            .executorFactory(() -> executor)
+            .build()
+    );
+    return executor;
+  }
+
+  private static class TrackingRecordQueue extends RecordQueue<SourceRecord> {
+
+    private final AtomicBoolean loggingSupplierCreated = new AtomicBoolean();
+
+    private TrackingRecordQueue(RecordQueue.Builder<SourceRecord> builder) {
+      super(builder);
+    }
+
+    @Override
+    protected <T> Supplier<T> createLoggingSupplier(
+        String operationName,
+        String logContext,
+        RecordDestination<SourceRecord> destination,
+        Function<RecordDestination<SourceRecord>, T> generatorProcessor
+    ) {
+      loggingSupplierCreated.set(true);
+      return super.createLoggingSupplier(
+          operationName,
+          logContext,
+          destination,
+          generatorProcessor
+      );
+    }
+
+    private boolean loggingSupplierCreated() {
+      return loggingSupplierCreated.get();
+    }
+  }
+
+  private static class DirectExecutorService extends AbstractExecutorService {
+
+    private final AtomicBoolean shutdown = new AtomicBoolean();
+
+    @Override
+    public void shutdown() {
+      shutdown.set(true);
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown.set(true);
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return shutdown.get();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return shutdown.get();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return isTerminated();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      if (isShutdown()) {
+        throw new RejectedExecutionException();
+      }
+      command.run();
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes regression in v10.8.5 where logs from the async query path (TableQuerierProcessor, TableQuerier, etc.) lost the `[connector-name|task-N]` prefix
- Root cause: MDC is thread-local and wasn't propagated to the executor thread introduced by RecordQueue (PR #1535)
- Fix: capture MDC on the poll thread before async handoff, restore it on the executor thread

## Verified with kafka-docker-playground

Ran a JDBC MySQL source connector with the fix applied. Logs from the async query thread now include the connector context:

**After fix (v10.8.6-SNAPSHOT):**
```
[2026-02-27 13:03:18,962] INFO [mysql-source|task-0|tableQuerierProcessor] Begin using SQL query: SELECT * FROM `mydb`.`team` WHERE ... (io.confluent.connect.jdbc.source.TableQuerier:182)
```

**Before fix (v10.8.5):**
```
[2026-02-27 04:01:07,958] INFO Begin using SQL query: Select * FROM testDB.dbo.customers2 WHERE ... (io.confluent.connect.jdbc.source.TableQuerier:186)
```

## Test plan

- [x] New `ConnectLogContextTest` — MDC append, prefix fallback, nested contexts
- [x] New `RecordQueueMdcTest` — MDC propagation to executor, cleanup between executions, no-MDC fallback
- [x] Existing `JdbcSourceTaskLifecycleTest` passes
- [x] E2E verified with kafka-docker-playground MySQL source connector