### PR TITLE
Update INFO logs to DEBUG to avoid frequent logging in Table Monitor Thread

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -247,9 +247,9 @@ public class TableMonitorThread extends Thread {
   private boolean updateTables() {
     final List<TableId> allTables;
     try {
-      log.info("Fetching all tables from database");
+      log.debug("Fetching all tables from database");
       allTables = dialect.tableIds(connectionProvider.getConnection());
-      log.info("Retrieved {} tables from database: {}", allTables.size(), allTables);
+      log.debug("Retrieved {} tables from database: {}", allTables.size(), allTables);
     } catch (SQLException e) {
       log.error(
           "Error while trying to get updated table list, ignoring and waiting for next table poll"
@@ -271,9 +271,9 @@ public class TableMonitorThread extends Thread {
           includeListRegex != null ? includeListRegex : java.util.Collections.emptySet(),
           excludeListRegex != null ? excludeListRegex : java.util.Collections.emptySet()
       );
-      log.info("Regex filtering resulted in {} tables from {} total tables", 
+      log.debug("Regex filtering resulted in {} tables from {} total tables",
                filteredTables.size(), allTables.size());
-      log.info("Filtered tables: {}", filteredTables);
+      log.debug("Filtered tables: {}", filteredTables);
     } else {
       // Legacy exact-match filtering
       filteredTables = applyLegacyFiltering(allTables);
@@ -281,7 +281,8 @@ public class TableMonitorThread extends Thread {
 
     List<TableId> priorTablesSnapshot = tables.getAndSet(filteredTables);
     if (!Objects.equals(priorTablesSnapshot, filteredTables)) {
-      log.info("Filtered tables size: {}", filteredTables);
+      log.info("Filtered tables size: {}", filteredTables.size());
+      log.debug("Filtered tables: {}", filteredTables);
     }
     synchronized (tables) {
       tables.notifyAll();


### PR DESCRIPTION
## Problem
[CC-40213](https://confluentinc.atlassian.net/browse/CC-40213) - Few INFO logs in Table Monitor Thread has been frequently being logged causing the unnecessary size overhead of the log files
Ref - https://github.com/confluentinc/kafka-connect-jdbc/blob/c15df37ae1934c18e670c3aaf6c75932a5b83a1f/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java#L250



## Solution
Moved these log lines to DEBUG, so as to enable only when debugging.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-40213]: https://confluentinc.atlassian.net/browse/CC-40213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ