### PR TITLE
Add primitive value schema support in JDBC sink connector to allow StringConverter values to be written directly as VARCHAR

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -117,6 +117,7 @@ public class BufferedRecords {
           config.pkMode,
           config.pkFields,
           config.fieldsWhitelist,
+          config.stringOutputValueColumnName,
           schemaPair
       );
       dbStructure.createOrAmendIfNecessary(

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -267,6 +267,19 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "specific dialect. All properly-packaged dialects in the JDBC connector plugin "
       + "can be used.";
 
+  public static final String STRING_OUTPUT_VALUE_COLUMN_NAME = "string.output.value.column.name";
+  public static final String STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT = "recordValue";
+  private static final String STRING_OUTPUT_VALUE_COLUMN_NAME_DOC =
+      "When the Kafka record value uses the String schema (e.g. records produced with "
+      + "StringConverter), the connector writes the value into a single column with this name. "
+      + "If the destination table is being auto-created, the column is created with this name. "
+      + "If the table already exists and the column is missing, the column is added via ALTER "
+      + "when 'auto.evolve' is true; otherwise the connector fails with the standard "
+      + "auto-evolution-disabled error. Defaults to '"
+      + STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT + "'.";
+  private static final String STRING_OUTPUT_VALUE_COLUMN_NAME_DISPLAY =
+      "String Value Column Name";
+
   public static final String DB_TIMEZONE_CONFIG = "db.timezone";
   public static final String DB_TIMEZONE_DEFAULT = "UTC";
   private static final String DB_TIMEZONE_CONFIG_DOC =
@@ -606,6 +619,18 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.MEDIUM,
             DATE_CALENDAR_SYSTEM_DISPLAY
         )
+        .define(
+            STRING_OUTPUT_VALUE_COLUMN_NAME,
+            ConfigDef.Type.STRING,
+            STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+            new ConfigDef.NonEmptyString(),
+            ConfigDef.Importance.LOW,
+            STRING_OUTPUT_VALUE_COLUMN_NAME_DOC,
+            DATAMAPPING_GROUP,
+            10,
+            ConfigDef.Width.MEDIUM,
+            STRING_OUTPUT_VALUE_COLUMN_NAME_DISPLAY
+        )
         // DDL
         .define(
             AUTO_CREATE,
@@ -700,6 +725,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final PrimaryKeyMode pkMode;
   public final List<String> pkFields;
   public final Set<String> fieldsWhitelist;
+  public final String stringOutputValueColumnName;
   public final Set<String> timestampFieldsList;
   public final String dialectName;
   public final ZoneId zoneId;
@@ -733,6 +759,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     pkFields = getList(PK_FIELDS);
     dialectName = getString(DIALECT_NAME_CONFIG);
     fieldsWhitelist = new HashSet<>(getList(FIELDS_WHITELIST));
+    stringOutputValueColumnName = getString(STRING_OUTPUT_VALUE_COLUMN_NAME);
     String dbTimeZone = getString(DB_TIMEZONE_CONFIG);
     zoneId = ZoneId.of(dbTimeZone);
     DateTimezone dateTimezoneConfig =

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -268,7 +268,7 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "can be used.";
 
   public static final String STRING_OUTPUT_VALUE_COLUMN_NAME = "string.output.value.column.name";
-  public static final String STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT = "recordValue";
+  public static final String STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT = "record_value";
   private static final String STRING_OUTPUT_VALUE_COLUMN_NAME_DOC =
       "When the Kafka record value uses the String schema (e.g. records produced with "
       + "StringConverter), the connector writes the value into a single column with this name. "

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -108,11 +108,11 @@ public class PreparedStatementBinder implements StatementBinder {
         case INSERT:
         case UPSERT:
           index = bindKeyFields(record, index);
-          bindNonKeyFields(record, valueStruct, isStringValue, index);
+          bindNonKeyFields(record, valueStruct, index);
           break;
 
         case UPDATE:
-          index = bindNonKeyFields(record, valueStruct, isStringValue, index);
+          index = bindNonKeyFields(record, valueStruct, index);
           bindKeyFields(record, index);
           break;
         default:
@@ -173,11 +173,11 @@ public class PreparedStatementBinder implements StatementBinder {
   protected int bindNonKeyFields(
       SinkRecord record,
       Struct valueStruct,
-      boolean isStringValue,
       int index
   ) throws SQLException {
     for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
-      if (isStringValue) {
+      if (valueStruct == null) {
+        // String-value record: bind the raw value into the synthetic column
         bindField(index++, record.valueSchema(), record.value(), fieldName);
       } else {
         final Field field = record.valueSchema().field(fieldName);

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -89,6 +89,9 @@ public class PreparedStatementBinder implements StatementBinder {
 
   @Override
   public void bindRecord(SinkRecord record) throws SQLException {
+    final Struct valueStruct = record.valueSchema() != null
+        && record.valueSchema().type() == Schema.Type.STRING
+        ? null : (Struct) record.value();
     final boolean isDelete = isNull(record.value());
     // Assumption: the relevant SQL has placeholders for keyFieldNames first followed by
     //             nonKeyFieldNames, in iteration order for all INSERT/ UPSERT queries
@@ -105,11 +108,11 @@ public class PreparedStatementBinder implements StatementBinder {
         case INSERT:
         case UPSERT:
           index = bindKeyFields(record, index);
-          bindNonKeyFields(record, index);
+          bindNonKeyFields(record, valueStruct, index);
           break;
 
         case UPDATE:
-          index = bindNonKeyFields(record, index);
+          index = bindNonKeyFields(record, valueStruct, index);
           bindKeyFields(record, index);
           break;
         default:
@@ -169,6 +172,7 @@ public class PreparedStatementBinder implements StatementBinder {
 
   protected int bindNonKeyFields(
       SinkRecord record,
+      Struct valueStruct,
       int index
   ) throws SQLException {
     if (record.valueSchema().type() == Schema.Type.STRING) {
@@ -176,7 +180,6 @@ public class PreparedStatementBinder implements StatementBinder {
         bindField(index++, record.valueSchema(), record.value(), fieldName);
       }
     } else {
-      final Struct valueStruct = (Struct) record.value();
       for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
         final Field field = record.valueSchema().field(fieldName);
         Object objectValue = this.replaceNullWithDefault

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -89,8 +89,10 @@ public class PreparedStatementBinder implements StatementBinder {
 
   @Override
   public void bindRecord(SinkRecord record) throws SQLException {
-    final Struct valueStruct = (Struct) record.value();
-    final boolean isDelete = isNull(valueStruct);
+    final boolean isPrimitiveValue = record.valueSchema() != null
+        && record.valueSchema().type().isPrimitive();
+    final Struct valueStruct = isPrimitiveValue ? null : (Struct) record.value();
+    final boolean isDelete = isNull(record.value());
     // Assumption: the relevant SQL has placeholders for keyFieldNames first followed by
     //             nonKeyFieldNames, in iteration order for all INSERT/ UPSERT queries
     //             the relevant SQL has placeholders for keyFieldNames,
@@ -106,11 +108,11 @@ public class PreparedStatementBinder implements StatementBinder {
         case INSERT:
         case UPSERT:
           index = bindKeyFields(record, index);
-          bindNonKeyFields(record, valueStruct, index);
+          bindNonKeyFields(record, valueStruct, isPrimitiveValue, index);
           break;
 
         case UPDATE:
-          index = bindNonKeyFields(record, valueStruct, index);
+          index = bindNonKeyFields(record, valueStruct, isPrimitiveValue, index);
           bindKeyFields(record, index);
           break;
         default:
@@ -171,14 +173,19 @@ public class PreparedStatementBinder implements StatementBinder {
   protected int bindNonKeyFields(
       SinkRecord record,
       Struct valueStruct,
+      boolean isPrimitiveValue,
       int index
   ) throws SQLException {
     for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
-      final Field field = record.valueSchema().field(fieldName);
-      Object objectValue = this.replaceNullWithDefault
-              ? valueStruct.get(field)
-              : valueStruct.getWithoutDefault(field.name());
-      bindField(index++, field.schema(), objectValue, fieldName);
+      if (isPrimitiveValue) {
+        bindField(index++, record.valueSchema(), record.value(), fieldName);
+      } else {
+        final Field field = record.valueSchema().field(fieldName);
+        Object objectValue = this.replaceNullWithDefault
+                ? valueStruct.get(field)
+                : valueStruct.getWithoutDefault(field.name());
+        bindField(index++, field.schema(), objectValue, fieldName);
+      }
     }
     return index;
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -89,9 +89,6 @@ public class PreparedStatementBinder implements StatementBinder {
 
   @Override
   public void bindRecord(SinkRecord record) throws SQLException {
-    final Struct valueStruct = record.valueSchema() != null
-        && record.valueSchema().type() == Schema.Type.STRING
-        ? null : (Struct) record.value();
     final boolean isDelete = isNull(record.value());
     // Assumption: the relevant SQL has placeholders for keyFieldNames first followed by
     //             nonKeyFieldNames, in iteration order for all INSERT/ UPSERT queries
@@ -108,11 +105,11 @@ public class PreparedStatementBinder implements StatementBinder {
         case INSERT:
         case UPSERT:
           index = bindKeyFields(record, index);
-          bindNonKeyFields(record, valueStruct, index);
+          bindNonKeyFields(record, index);
           break;
 
         case UPDATE:
-          index = bindNonKeyFields(record, valueStruct, index);
+          index = bindNonKeyFields(record, index);
           bindKeyFields(record, index);
           break;
         default:
@@ -172,7 +169,6 @@ public class PreparedStatementBinder implements StatementBinder {
 
   protected int bindNonKeyFields(
       SinkRecord record,
-      Struct valueStruct,
       int index
   ) throws SQLException {
     if (record.valueSchema().type() == Schema.Type.STRING) {
@@ -180,6 +176,7 @@ public class PreparedStatementBinder implements StatementBinder {
         bindField(index++, record.valueSchema(), record.value(), fieldName);
       }
     } else {
+      final Struct valueStruct = (Struct) record.value();
       for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
         final Field field = record.valueSchema().field(fieldName);
         Object objectValue = this.replaceNullWithDefault

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -89,9 +89,6 @@ public class PreparedStatementBinder implements StatementBinder {
 
   @Override
   public void bindRecord(SinkRecord record) throws SQLException {
-    final boolean isStringValue = record.valueSchema() != null
-        && record.valueSchema().type() == Schema.Type.STRING;
-    final Struct valueStruct = isStringValue ? null : (Struct) record.value();
     final boolean isDelete = isNull(record.value());
     // Assumption: the relevant SQL has placeholders for keyFieldNames first followed by
     //             nonKeyFieldNames, in iteration order for all INSERT/ UPSERT queries
@@ -108,11 +105,11 @@ public class PreparedStatementBinder implements StatementBinder {
         case INSERT:
         case UPSERT:
           index = bindKeyFields(record, index);
-          bindNonKeyFields(record, valueStruct, index);
+          bindNonKeyFields(record, index);
           break;
 
         case UPDATE:
-          index = bindNonKeyFields(record, valueStruct, index);
+          index = bindNonKeyFields(record, index);
           bindKeyFields(record, index);
           break;
         default:
@@ -172,14 +169,15 @@ public class PreparedStatementBinder implements StatementBinder {
 
   protected int bindNonKeyFields(
       SinkRecord record,
-      Struct valueStruct,
       int index
   ) throws SQLException {
-    for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
-      if (valueStruct == null) {
-        // String-value record: bind the raw value into the synthetic column
+    if (record.valueSchema().type() == Schema.Type.STRING) {
+      for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
         bindField(index++, record.valueSchema(), record.value(), fieldName);
-      } else {
+      }
+    } else {
+      final Struct valueStruct = (Struct) record.value();
+      for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
         final Field field = record.valueSchema().field(fieldName);
         Object objectValue = this.replaceNullWithDefault
                 ? valueStruct.get(field)

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -89,9 +89,9 @@ public class PreparedStatementBinder implements StatementBinder {
 
   @Override
   public void bindRecord(SinkRecord record) throws SQLException {
-    final boolean isPrimitiveValue = record.valueSchema() != null
-        && record.valueSchema().type().isPrimitive();
-    final Struct valueStruct = isPrimitiveValue ? null : (Struct) record.value();
+    final boolean isStringValue = record.valueSchema() != null
+        && record.valueSchema().type() == Schema.Type.STRING;
+    final Struct valueStruct = isStringValue ? null : (Struct) record.value();
     final boolean isDelete = isNull(record.value());
     // Assumption: the relevant SQL has placeholders for keyFieldNames first followed by
     //             nonKeyFieldNames, in iteration order for all INSERT/ UPSERT queries
@@ -108,11 +108,11 @@ public class PreparedStatementBinder implements StatementBinder {
         case INSERT:
         case UPSERT:
           index = bindKeyFields(record, index);
-          bindNonKeyFields(record, valueStruct, isPrimitiveValue, index);
+          bindNonKeyFields(record, valueStruct, isStringValue, index);
           break;
 
         case UPDATE:
-          index = bindNonKeyFields(record, valueStruct, isPrimitiveValue, index);
+          index = bindNonKeyFields(record, valueStruct, isStringValue, index);
           bindKeyFields(record, index);
           break;
         default:
@@ -173,11 +173,11 @@ public class PreparedStatementBinder implements StatementBinder {
   protected int bindNonKeyFields(
       SinkRecord record,
       Struct valueStruct,
-      boolean isPrimitiveValue,
+      boolean isStringValue,
       int index
   ) throws SQLException {
     for (final String fieldName : fieldsMetadata.nonKeyFieldNames) {
-      if (isPrimitiveValue) {
+      if (isStringValue) {
         bindField(index++, record.valueSchema(), record.value(), fieldName);
       } else {
         final Field field = record.valueSchema().field(fieldName);

--- a/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -21,6 +21,9 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @FunctionalInterface
 public interface RecordValidator {
 
@@ -81,6 +84,9 @@ public interface RecordValidator {
           && valueSchema != null
           && (valueSchema.type() == Schema.Type.STRUCT
               || valueSchema.type() == Schema.Type.STRING)) {
+        if (valueSchema.type() == Schema.Type.STRING) {
+          rejectIncompatibleStringValueConfigs(config);
+        }
         return;
       }
       throw new ConnectException(
@@ -135,5 +141,37 @@ public interface RecordValidator {
           )
       );
     };
+  }
+
+  /**
+   * Reject records with a {@link Schema.Type#STRING} value when the connector is configured with
+   * field-level options that only apply to records whose value is a {@code Struct}. The
+   * synthetic single-column projection used for String values has no inner fields for these
+   * options to operate on; honoring them would be a silent no-op, so we fail fast on the first
+   * String record to show the misconfiguration.
+   */
+  static void rejectIncompatibleStringValueConfigs(JdbcSinkConfig config) {
+    final List<String> conflictingConfigs = new ArrayList<>();
+    if (!config.fieldsWhitelist.isEmpty()) {
+      conflictingConfigs.add(JdbcSinkConfig.FIELDS_WHITELIST);
+    }
+    if (!config.timestampFieldsList.isEmpty()) {
+      conflictingConfigs.add(JdbcSinkConfig.TIMESTAMP_FIELDS_LIST);
+    }
+    if (config.originals().containsKey(JdbcSinkConfig.TIMESTAMP_PRECISION_MODE_CONFIG)) {
+      conflictingConfigs.add(JdbcSinkConfig.TIMESTAMP_PRECISION_MODE_CONFIG);
+    }
+    if (conflictingConfigs.isEmpty()) {
+      return;
+    }
+    throw new ConnectException(
+        String.format(
+            "Sink connector '%s' is configured with field-level options that are not "
+            + "applicable to String values: %s. Remove these options, or have the upstream "
+            + "producer emit Struct values instead.",
+            config.connectorName(),
+            String.join(", ", conflictingConfigs)
+        )
+    );
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -79,15 +79,16 @@ public interface RecordValidator {
       Schema valueSchema = record.valueSchema();
       if (record.value() != null
           && valueSchema != null
-          && (valueSchema.type() == Schema.Type.STRUCT || valueSchema.type().isPrimitive())) {
+          && (valueSchema.type() == Schema.Type.STRUCT
+              || valueSchema.type() == Schema.Type.STRING)) {
         return;
       }
       throw new ConnectException(
           String.format(
               "Sink connector '%s' is configured with '%s=%s' and "
               + "'%s=%s' and therefore requires records with a non-null "
-              + "Struct or primitive value and non-null Struct or "
-              + "primitive schema, but found record at "
+              + "Struct or String value and non-null Struct or "
+              + "String schema, but found record at "
               + "(topic='%s',partition=%d,offset=%d,timestamp=%d) "
               + "with a %s value and %s value schema.",
               config.connectorName(),

--- a/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -79,14 +79,16 @@ public interface RecordValidator {
       Schema valueSchema = record.valueSchema();
       if (record.value() != null
           && valueSchema != null
-          && valueSchema.type() == Schema.Type.STRUCT) {
+          && (valueSchema.type() == Schema.Type.STRUCT || valueSchema.type().isPrimitive())) {
         return;
       }
       throw new ConnectException(
           String.format(
-              "Sink connector '%s' is configured with '%s=%s' and '%s=%s' and therefore requires "
-              + "records with a non-null Struct value and non-null Struct schema, "
-              + "but found record at (topic='%s',partition=%d,offset=%d,timestamp=%d) "
+              "Sink connector '%s' is configured with '%s=%s' and "
+              + "'%s=%s' and therefore requires records with a non-null "
+              + "Struct or primitive value and non-null Struct or "
+              + "primitive schema, but found record at "
+              + "(topic='%s',partition=%d,offset=%d,timestamp=%d) "
               + "with a %s value and %s value schema.",
               config.connectorName(),
               JdbcSinkConfig.DELETE_ENABLED,

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -57,7 +57,7 @@ public class FieldsMetadata {
     this.allFields = allFields;
   }
 
-  public static final String DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME = "recordValue";
+  public static final String DEFAULT_STRING_VALUE_COLUMN_NAME = "recordValue";
 
   public static FieldsMetadata extract(
       final String tableName,
@@ -71,6 +71,26 @@ public class FieldsMetadata {
         pkMode,
         configuredPkFields,
         fieldsWhitelist,
+        DEFAULT_STRING_VALUE_COLUMN_NAME,
+        schemaPair.keySchema,
+        schemaPair.valueSchema
+    );
+  }
+
+  public static FieldsMetadata extract(
+      final String tableName,
+      final JdbcSinkConfig.PrimaryKeyMode pkMode,
+      final List<String> configuredPkFields,
+      final Set<String> fieldsWhitelist,
+      final String stringValueColumnName,
+      final SchemaPair schemaPair
+  ) {
+    return extract(
+        tableName,
+        pkMode,
+        configuredPkFields,
+        fieldsWhitelist,
+        stringValueColumnName,
         schemaPair.keySchema,
         schemaPair.valueSchema
     );
@@ -84,14 +104,34 @@ public class FieldsMetadata {
       final Schema keySchema,
       final Schema valueSchema
   ) {
+    return extract(
+        tableName,
+        pkMode,
+        configuredPkFields,
+        fieldsWhitelist,
+        DEFAULT_STRING_VALUE_COLUMN_NAME,
+        keySchema,
+        valueSchema
+    );
+  }
+
+  public static FieldsMetadata extract(
+      final String tableName,
+      final JdbcSinkConfig.PrimaryKeyMode pkMode,
+      final List<String> configuredPkFields,
+      final Set<String> fieldsWhitelist,
+      final String stringValueColumnName,
+      final Schema keySchema,
+      final Schema valueSchema
+  ) {
     if (valueSchema != null
         && valueSchema.type() != Schema.Type.STRUCT
-        && !valueSchema.type().isPrimitive()) {
-      throw new ConnectException("Value schema must be of type Struct or a primitive type");
+        && valueSchema.type() != Schema.Type.STRING) {
+      throw new ConnectException("Value schema must be of type Struct or String");
     }
 
-    final boolean isPrimitiveValue = valueSchema != null
-        && valueSchema.type().isPrimitive();
+    final boolean isStringValue = valueSchema != null
+        && valueSchema.type() == Schema.Type.STRING;
 
     final Map<String, SinkRecordField> allFields = new HashMap<>();
 
@@ -109,9 +149,9 @@ public class FieldsMetadata {
         break;
 
       case RECORD_VALUE:
-        if (isPrimitiveValue) {
+        if (isStringValue) {
           throw new ConnectException(
-              "pk.mode record_value is not supported with primitive value schemas"
+              "pk.mode record_value is not supported with String value schemas"
           );
         }
         extractRecordValuePk(tableName, configuredPkFields, valueSchema, allFields, keyFieldNames);
@@ -122,25 +162,33 @@ public class FieldsMetadata {
     }
 
     final Set<String> nonKeyFieldNames = new LinkedHashSet<>();
-    if (valueSchema != null) {
-      if (isPrimitiveValue) {
-        final String colName = DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME;
-        nonKeyFieldNames.add(colName);
-        allFields.put(colName, new SinkRecordField(valueSchema, colName, false));
-      } else {
-        for (Field field : valueSchema.fields()) {
-          if (keyFieldNames.contains(field.name())) {
-            continue;
-          }
-          if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(field.name())) {
-            continue;
-          }
-
-          nonKeyFieldNames.add(field.name());
-
-          final Schema fieldSchema = field.schema();
-          allFields.put(field.name(), new SinkRecordField(fieldSchema, field.name(), false));
+    if (isStringValue) {
+      if (keyFieldNames.contains(stringValueColumnName)) {
+        throw new ConnectException(String.format(
+            "Configured %s '%s' conflicts with a primary key column for table '%s'",
+            JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME,
+            stringValueColumnName,
+            tableName
+        ));
+      }
+      nonKeyFieldNames.add(stringValueColumnName);
+      allFields.put(
+          stringValueColumnName,
+          new SinkRecordField(Schema.OPTIONAL_STRING_SCHEMA, stringValueColumnName, false)
+      );
+    } else if (valueSchema != null) {
+      for (Field field : valueSchema.fields()) {
+        if (keyFieldNames.contains(field.name())) {
+          continue;
         }
+        if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(field.name())) {
+          continue;
+        }
+
+        nonKeyFieldNames.add(field.name());
+
+        final Schema fieldSchema = field.schema();
+        allFields.put(field.name(), new SinkRecordField(fieldSchema, field.name(), false));
       }
     }
 
@@ -157,18 +205,15 @@ public class FieldsMetadata {
       }
     }
 
-    if (valueSchema != null) {
-      if (isPrimitiveValue) {
-        final String colName = DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME;
-        if (allFields.containsKey(colName)) {
-          allFieldsOrdered.put(colName, allFields.get(colName));
-        }
-      } else {
-        for (Field field : valueSchema.fields()) {
-          String fieldName = field.name();
-          if (allFields.containsKey(fieldName)) {
-            allFieldsOrdered.put(fieldName, allFields.get(fieldName));
-          }
+    if (isStringValue) {
+      if (allFields.containsKey(stringValueColumnName)) {
+        allFieldsOrdered.put(stringValueColumnName, allFields.get(stringValueColumnName));
+      }
+    } else if (valueSchema != null) {
+      for (Field field : valueSchema.fields()) {
+        String fieldName = field.name();
+        if (allFields.containsKey(fieldName)) {
+          allFieldsOrdered.put(fieldName, allFields.get(fieldName));
         }
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -132,17 +132,6 @@ public class FieldsMetadata {
             tableName
         ));
       }
-      if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(stringValueColumnName)) {
-        throw new ConnectException(String.format(
-            "fields.whitelist=%s does not include the configured %s '%s' for table '%s'. "
-            + "Either add '%s' to fields.whitelist or remove the whitelist.",
-            fieldsWhitelist,
-            JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME,
-            stringValueColumnName,
-            tableName,
-            stringValueColumnName
-        ));
-      }
       nonKeyFieldNames.add(stringValueColumnName);
       allFields.put(
           stringValueColumnName,

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -57,26 +57,6 @@ public class FieldsMetadata {
     this.allFields = allFields;
   }
 
-  public static final String DEFAULT_STRING_VALUE_COLUMN_NAME = "recordValue";
-
-  public static FieldsMetadata extract(
-      final String tableName,
-      final JdbcSinkConfig.PrimaryKeyMode pkMode,
-      final List<String> configuredPkFields,
-      final Set<String> fieldsWhitelist,
-      final SchemaPair schemaPair
-  ) {
-    return extract(
-        tableName,
-        pkMode,
-        configuredPkFields,
-        fieldsWhitelist,
-        DEFAULT_STRING_VALUE_COLUMN_NAME,
-        schemaPair.keySchema,
-        schemaPair.valueSchema
-    );
-  }
-
   public static FieldsMetadata extract(
       final String tableName,
       final JdbcSinkConfig.PrimaryKeyMode pkMode,
@@ -93,25 +73,6 @@ public class FieldsMetadata {
         stringValueColumnName,
         schemaPair.keySchema,
         schemaPair.valueSchema
-    );
-  }
-
-  public static FieldsMetadata extract(
-      final String tableName,
-      final JdbcSinkConfig.PrimaryKeyMode pkMode,
-      final List<String> configuredPkFields,
-      final Set<String> fieldsWhitelist,
-      final Schema keySchema,
-      final Schema valueSchema
-  ) {
-    return extract(
-        tableName,
-        pkMode,
-        configuredPkFields,
-        fieldsWhitelist,
-        DEFAULT_STRING_VALUE_COLUMN_NAME,
-        keySchema,
-        valueSchema
     );
   }
 
@@ -169,6 +130,17 @@ public class FieldsMetadata {
             JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME,
             stringValueColumnName,
             tableName
+        ));
+      }
+      if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(stringValueColumnName)) {
+        throw new ConnectException(String.format(
+            "fields.whitelist=%s does not include the configured %s '%s' for table '%s'. "
+            + "Either add '%s' to fields.whitelist or remove the whitelist.",
+            fieldsWhitelist,
+            JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME,
+            stringValueColumnName,
+            tableName,
+            stringValueColumnName
         ));
       }
       nonKeyFieldNames.add(stringValueColumnName);

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadata.java
@@ -57,6 +57,8 @@ public class FieldsMetadata {
     this.allFields = allFields;
   }
 
+  public static final String DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME = "recordValue";
+
   public static FieldsMetadata extract(
       final String tableName,
       final JdbcSinkConfig.PrimaryKeyMode pkMode,
@@ -82,9 +84,14 @@ public class FieldsMetadata {
       final Schema keySchema,
       final Schema valueSchema
   ) {
-    if (valueSchema != null && valueSchema.type() != Schema.Type.STRUCT) {
-      throw new ConnectException("Value schema must be of type Struct");
+    if (valueSchema != null
+        && valueSchema.type() != Schema.Type.STRUCT
+        && !valueSchema.type().isPrimitive()) {
+      throw new ConnectException("Value schema must be of type Struct or a primitive type");
     }
+
+    final boolean isPrimitiveValue = valueSchema != null
+        && valueSchema.type().isPrimitive();
 
     final Map<String, SinkRecordField> allFields = new HashMap<>();
 
@@ -102,6 +109,11 @@ public class FieldsMetadata {
         break;
 
       case RECORD_VALUE:
+        if (isPrimitiveValue) {
+          throw new ConnectException(
+              "pk.mode record_value is not supported with primitive value schemas"
+          );
+        }
         extractRecordValuePk(tableName, configuredPkFields, valueSchema, allFields, keyFieldNames);
         break;
 
@@ -111,18 +123,24 @@ public class FieldsMetadata {
 
     final Set<String> nonKeyFieldNames = new LinkedHashSet<>();
     if (valueSchema != null) {
-      for (Field field : valueSchema.fields()) {
-        if (keyFieldNames.contains(field.name())) {
-          continue;
-        }
-        if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(field.name())) {
-          continue;
-        }
+      if (isPrimitiveValue) {
+        final String colName = DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME;
+        nonKeyFieldNames.add(colName);
+        allFields.put(colName, new SinkRecordField(valueSchema, colName, false));
+      } else {
+        for (Field field : valueSchema.fields()) {
+          if (keyFieldNames.contains(field.name())) {
+            continue;
+          }
+          if (!fieldsWhitelist.isEmpty() && !fieldsWhitelist.contains(field.name())) {
+            continue;
+          }
 
-        nonKeyFieldNames.add(field.name());
+          nonKeyFieldNames.add(field.name());
 
-        final Schema fieldSchema = field.schema();
-        allFields.put(field.name(), new SinkRecordField(fieldSchema, field.name(), false));
+          final Schema fieldSchema = field.schema();
+          allFields.put(field.name(), new SinkRecordField(fieldSchema, field.name(), false));
+        }
       }
     }
 
@@ -140,10 +158,17 @@ public class FieldsMetadata {
     }
 
     if (valueSchema != null) {
-      for (Field field : valueSchema.fields()) {
-        String fieldName = field.name();
-        if (allFields.containsKey(fieldName)) {
-          allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+      if (isPrimitiveValue) {
+        final String colName = DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME;
+        if (allFields.containsKey(colName)) {
+          allFieldsOrdered.put(colName, allFields.get(colName));
+        }
+      } else {
+        for (Field field : valueSchema.fields()) {
+          String fieldName = field.name();
+          if (allFields.containsKey(fieldName)) {
+            allFieldsOrdered.put(fieldName, allFields.get(fieldName));
+          }
         }
       }
     }

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -574,9 +574,9 @@ public class BufferedRecordsTest {
     // Delete is not enabled, so therefore require non-null key and values with schemas
     assertValidRecord(true, true, true, true);
     // Fail when ingesting tombstones
-    assertInvalidRecord(true, true, false, true, "Struct or String");
-    assertInvalidRecord(true, true, true, false, "Struct or String");
-    assertInvalidRecord(true, true, false, false, "Struct or String");
+    assertInvalidRecord(true, true, false, true, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(true, true, true, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(true, true, false, false, "requires records with a non-null Struct or String value");
 
     // Fail when null key and null key schema
     assertInvalidRecord(false, false, true, true, "with a null key and null key schema");
@@ -636,20 +636,20 @@ public class BufferedRecordsTest {
     assertValidRecord(true, false, true, true);
     assertValidRecord(false, false, true, true);
 
-    assertInvalidRecord(true, true, true, false, "Struct or String");
-    assertInvalidRecord(false, true, true, false, "Struct or String");
-    assertInvalidRecord(true, false, true, false, "Struct or String");
-    assertInvalidRecord(false, false, true, false, "Struct or String");
+    assertInvalidRecord(true, true, true, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(false, true, true, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(true, false, true, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(false, false, true, false, "requires records with a non-null Struct or String value");
 
-    assertInvalidRecord(true, true, false, true, "Struct or String");
-    assertInvalidRecord(false, true, false, true, "Struct or String");
-    assertInvalidRecord(true, false, false, true, "Struct or String");
-    assertInvalidRecord(false, false, false, true, "Struct or String");
+    assertInvalidRecord(true, true, false, true, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(false, true, false, true, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(true, false, false, true, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(false, false, false, true, "requires records with a non-null Struct or String value");
 
-    assertInvalidRecord(true, true, false, false, "Struct or String");
-    assertInvalidRecord(false, true, false, false, "Struct or String");
-    assertInvalidRecord(true, false, false, false, "Struct or String");
-    assertInvalidRecord(false, false, false, false, "Struct or String");
+    assertInvalidRecord(true, true, false, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(false, true, false, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(true, false, false, false, "requires records with a non-null Struct or String value");
+    assertInvalidRecord(false, false, false, false, "requires records with a non-null Struct or String value");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -782,48 +782,6 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testStringValueInsertPkModeNone() throws SQLException {
-    props.put("pk.mode", "none");
-    final JdbcSinkConfig config = new JdbcSinkConfig(props);
-
-    final String url = sqliteHelper.sqliteUri();
-    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
-    final DbStructure dbStructure = new DbStructure(dbDialect);
-
-    final TableId tableId = new TableId(null, null, "stringValueTest");
-    final BufferedRecords buffer = new BufferedRecords(
-        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
-    );
-
-    final SinkRecord record = new SinkRecord(
-        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
-    );
-    assertEquals(Collections.emptyList(), buffer.add(record));
-    assertEquals(Collections.singletonList(record), buffer.flush());
-  }
-
-  @Test
-  public void testStringValueInsertPkModeKafka() throws SQLException {
-    props.put("pk.mode", "kafka");
-    final JdbcSinkConfig config = new JdbcSinkConfig(props);
-
-    final String url = sqliteHelper.sqliteUri();
-    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
-    final DbStructure dbStructure = new DbStructure(dbDialect);
-
-    final TableId tableId = new TableId(null, null, "stringValueKafkaTest");
-    final BufferedRecords buffer = new BufferedRecords(
-        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
-    );
-
-    final SinkRecord record = new SinkRecord(
-        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
-    );
-    assertEquals(Collections.emptyList(), buffer.add(record));
-    assertEquals(Collections.singletonList(record), buffer.flush());
-  }
-
-  @Test
   public void testStringValueWithRecordKeyPk() throws SQLException {
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "the_key");
@@ -843,75 +801,6 @@ public class BufferedRecordsTest {
     );
     assertEquals(Collections.emptyList(), buffer.add(record));
     assertEquals(Collections.singletonList(record), buffer.flush());
-  }
-
-  @Test
-  public void testStringValueDeleteWithRecordKeyPk() throws SQLException {
-    props.put("delete.enabled", true);
-    props.put("insert.mode", "upsert");
-    props.put("pk.mode", "record_key");
-    props.put("pk.fields", "the_key");
-    final JdbcSinkConfig config = new JdbcSinkConfig(props);
-
-    final String url = sqliteHelper.sqliteUri();
-    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
-    final DbStructure dbStructure = new DbStructure(dbDialect);
-
-    final TableId tableId = new TableId(null, null, "stringValueDeleteTest");
-    final BufferedRecords buffer = new BufferedRecords(
-        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
-    );
-
-    final SinkRecord insertRecord = new SinkRecord(
-        "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
-    );
-    final SinkRecord deleteRecord = new SinkRecord(
-        "topic", 0, Schema.INT64_SCHEMA, 42L, null, null, 1
-    );
-
-    assertEquals(Collections.emptyList(), buffer.add(insertRecord));
-    assertEquals(Collections.emptyList(), buffer.add(deleteRecord));
-    assertEquals(Arrays.asList(insertRecord, deleteRecord), buffer.flush());
-  }
-
-  @Test
-  public void testStringValueBatchingWithSchemaChange() throws SQLException {
-    props.put("pk.mode", "none");
-    final JdbcSinkConfig config = new JdbcSinkConfig(props);
-
-    final String url = sqliteHelper.sqliteUri();
-    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
-    final DbStructure dbStructure = new DbStructure(dbDialect);
-
-    final TableId tableId = new TableId(null, null, "stringValueBatchTest");
-    final BufferedRecords buffer = new BufferedRecords(
-        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
-    );
-
-    final SinkRecord stringRecord = new SinkRecord(
-        "topic", 0, null, null, Schema.OPTIONAL_STRING_SCHEMA, "hello", 0
-    );
-    final Schema structSchema = SchemaBuilder.struct()
-        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
-        .build();
-    final Struct structValue = new Struct(structSchema).put("name", "world");
-    final SinkRecord structRecord = new SinkRecord(
-        "topic", 0, null, null, structSchema, structValue, 1
-    );
-
-    assertEquals(Collections.emptyList(), buffer.add(stringRecord));
-    assertEquals(Collections.singletonList(stringRecord), buffer.add(structRecord));
-    assertEquals(Collections.singletonList(structRecord), buffer.flush());
-  }
-
-  @Test
-  public void testStringValueValidation() throws SQLException {
-    props.put("pk.mode", "none");
-
-    final SinkRecord stringRecord = new SinkRecord(
-        "dummy", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
-    );
-    assertValidRecord(stringRecord);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -574,9 +574,9 @@ public class BufferedRecordsTest {
     // Delete is not enabled, so therefore require non-null key and values with schemas
     assertValidRecord(true, true, true, true);
     // Fail when ingesting tombstones
-    assertInvalidRecord(true, true, false, true, "Struct or primitive");
-    assertInvalidRecord(true, true, true, false, "Struct or primitive");
-    assertInvalidRecord(true, true, false, false, "Struct or primitive");
+    assertInvalidRecord(true, true, false, true, "Struct or String");
+    assertInvalidRecord(true, true, true, false, "Struct or String");
+    assertInvalidRecord(true, true, false, false, "Struct or String");
 
     // Fail when null key and null key schema
     assertInvalidRecord(false, false, true, true, "with a null key and null key schema");
@@ -636,20 +636,20 @@ public class BufferedRecordsTest {
     assertValidRecord(true, false, true, true);
     assertValidRecord(false, false, true, true);
 
-    assertInvalidRecord(true, true, true, false, "Struct or primitive");
-    assertInvalidRecord(false, true, true, false, "Struct or primitive");
-    assertInvalidRecord(true, false, true, false, "Struct or primitive");
-    assertInvalidRecord(false, false, true, false, "Struct or primitive");
+    assertInvalidRecord(true, true, true, false, "Struct or String");
+    assertInvalidRecord(false, true, true, false, "Struct or String");
+    assertInvalidRecord(true, false, true, false, "Struct or String");
+    assertInvalidRecord(false, false, true, false, "Struct or String");
 
-    assertInvalidRecord(true, true, false, true, "Struct or primitive");
-    assertInvalidRecord(false, true, false, true, "Struct or primitive");
-    assertInvalidRecord(true, false, false, true, "Struct or primitive");
-    assertInvalidRecord(false, false, false, true, "Struct or primitive");
+    assertInvalidRecord(true, true, false, true, "Struct or String");
+    assertInvalidRecord(false, true, false, true, "Struct or String");
+    assertInvalidRecord(true, false, false, true, "Struct or String");
+    assertInvalidRecord(false, false, false, true, "Struct or String");
 
-    assertInvalidRecord(true, true, false, false, "Struct or primitive");
-    assertInvalidRecord(false, true, false, false, "Struct or primitive");
-    assertInvalidRecord(true, false, false, false, "Struct or primitive");
-    assertInvalidRecord(false, false, false, false, "Struct or primitive");
+    assertInvalidRecord(true, true, false, false, "Struct or String");
+    assertInvalidRecord(false, true, false, false, "Struct or String");
+    assertInvalidRecord(true, false, false, false, "Struct or String");
+    assertInvalidRecord(false, false, false, false, "Struct or String");
   }
 
   @Test
@@ -782,7 +782,7 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testPrimitiveValueInsertPkModeNone() throws SQLException {
+  public void testStringValueInsertPkModeNone() throws SQLException {
     props.put("pk.mode", "none");
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
@@ -790,7 +790,7 @@ public class BufferedRecordsTest {
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
     final DbStructure dbStructure = new DbStructure(dbDialect);
 
-    final TableId tableId = new TableId(null, null, "primitiveTest");
+    final TableId tableId = new TableId(null, null, "stringValueTest");
     final BufferedRecords buffer = new BufferedRecords(
         config, tableId, dbDialect, dbStructure, sqliteHelper.connection
     );
@@ -803,7 +803,7 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testPrimitiveValueInsertPkModeKafka() throws SQLException {
+  public void testStringValueInsertPkModeKafka() throws SQLException {
     props.put("pk.mode", "kafka");
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
@@ -811,7 +811,7 @@ public class BufferedRecordsTest {
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
     final DbStructure dbStructure = new DbStructure(dbDialect);
 
-    final TableId tableId = new TableId(null, null, "primitiveKafkaTest");
+    final TableId tableId = new TableId(null, null, "stringValueKafkaTest");
     final BufferedRecords buffer = new BufferedRecords(
         config, tableId, dbDialect, dbStructure, sqliteHelper.connection
     );
@@ -824,7 +824,7 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testPrimitiveValueWithRecordKeyPk() throws SQLException {
+  public void testStringValueWithRecordKeyPk() throws SQLException {
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "the_key");
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
@@ -833,7 +833,7 @@ public class BufferedRecordsTest {
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
     final DbStructure dbStructure = new DbStructure(dbDialect);
 
-    final TableId tableId = new TableId(null, null, "primitiveKeyTest");
+    final TableId tableId = new TableId(null, null, "stringValueKeyTest");
     final BufferedRecords buffer = new BufferedRecords(
         config, tableId, dbDialect, dbStructure, sqliteHelper.connection
     );
@@ -846,7 +846,7 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testPrimitiveValueDeleteWithRecordKeyPk() throws SQLException {
+  public void testStringValueDeleteWithRecordKeyPk() throws SQLException {
     props.put("delete.enabled", true);
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "record_key");
@@ -857,7 +857,7 @@ public class BufferedRecordsTest {
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
     final DbStructure dbStructure = new DbStructure(dbDialect);
 
-    final TableId tableId = new TableId(null, null, "primitiveDeleteTest");
+    final TableId tableId = new TableId(null, null, "stringValueDeleteTest");
     final BufferedRecords buffer = new BufferedRecords(
         config, tableId, dbDialect, dbStructure, sqliteHelper.connection
     );
@@ -875,7 +875,7 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testPrimitiveValueBatchingWithSchemaChange() throws SQLException {
+  public void testStringValueBatchingWithSchemaChange() throws SQLException {
     props.put("pk.mode", "none");
     final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
@@ -883,7 +883,7 @@ public class BufferedRecordsTest {
     final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
     final DbStructure dbStructure = new DbStructure(dbDialect);
 
-    final TableId tableId = new TableId(null, null, "primitiveBatchTest");
+    final TableId tableId = new TableId(null, null, "stringValueBatchTest");
     final BufferedRecords buffer = new BufferedRecords(
         config, tableId, dbDialect, dbStructure, sqliteHelper.connection
     );
@@ -905,13 +905,119 @@ public class BufferedRecordsTest {
   }
 
   @Test
-  public void testPrimitiveValueValidation() throws SQLException {
+  public void testStringValueValidation() throws SQLException {
     props.put("pk.mode", "none");
 
-    final SinkRecord primitiveRecord = new SinkRecord(
+    final SinkRecord stringRecord = new SinkRecord(
         "dummy", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
     );
-    assertValidRecord(primitiveRecord);
+    assertValidRecord(stringRecord);
+  }
+
+  @Test
+  public void testStringValueCustomColumnNameNewTable() throws SQLException {
+    props.put("pk.mode", "none");
+    props.put("string.output.value.column.name", "payload");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "stringValueCustomColTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    );
+    assertEquals(Collections.emptyList(), buffer.add(record));
+    assertEquals(Collections.singletonList(record), buffer.flush());
+  }
+
+  @Test
+  public void testStringValueCustomColumnNameExistingTableHasColumn() throws SQLException {
+    props.put("pk.mode", "none");
+    props.put("string.output.value.column.name", "payload");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    sqliteHelper.createTable(
+        "CREATE TABLE stringValueExistingTest (payload TEXT NULL)"
+    );
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "stringValueExistingTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    );
+    assertEquals(Collections.emptyList(), buffer.add(record));
+    assertEquals(Collections.singletonList(record), buffer.flush());
+  }
+
+  @Test
+  public void testStringValueCustomColumnNameAutoEvolveAddsColumn() throws SQLException {
+    props.put("pk.mode", "none");
+    props.put("string.output.value.column.name", "payload");
+    props.put("auto.evolve", true);
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    sqliteHelper.createTable(
+        "CREATE TABLE stringValueAutoEvolveTest (other_col TEXT NULL)"
+    );
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "stringValueAutoEvolveTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    );
+    assertEquals(Collections.emptyList(), buffer.add(record));
+    assertEquals(Collections.singletonList(record), buffer.flush());
+  }
+
+  @Test
+  public void testStringValueCustomColumnNameNoAutoEvolveFails() throws SQLException {
+    props.put("pk.mode", "none");
+    props.put("string.output.value.column.name", "payload");
+    props.put("auto.evolve", false);
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    sqliteHelper.createTable(
+        "CREATE TABLE stringValueNoEvolveTest (other_col TEXT NULL)"
+    );
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "stringValueNoEvolveTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    );
+    TableAlterOrCreateException ex = assertThrows(
+        TableAlterOrCreateException.class,
+        () -> buffer.add(record)
+    );
+    assertTrue(ex.getMessage().contains("payload"));
+    assertTrue(ex.getMessage().contains("auto-evolution is disabled"));
   }
 
   protected void assertValidRecord(SinkRecord record) throws SQLException {

--- a/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/BufferedRecordsTest.java
@@ -574,9 +574,9 @@ public class BufferedRecordsTest {
     // Delete is not enabled, so therefore require non-null key and values with schemas
     assertValidRecord(true, true, true, true);
     // Fail when ingesting tombstones
-    assertInvalidRecord(true, true, false, true, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(true, true, true, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(true, true, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, false, true, "Struct or primitive");
+    assertInvalidRecord(true, true, true, false, "Struct or primitive");
+    assertInvalidRecord(true, true, false, false, "Struct or primitive");
 
     // Fail when null key and null key schema
     assertInvalidRecord(false, false, true, true, "with a null key and null key schema");
@@ -636,20 +636,20 @@ public class BufferedRecordsTest {
     assertValidRecord(true, false, true, true);
     assertValidRecord(false, false, true, true);
 
-    assertInvalidRecord(true, true, true, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(false, true, true, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(true, false, true, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(false, false, true, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, true, false, "Struct or primitive");
+    assertInvalidRecord(false, true, true, false, "Struct or primitive");
+    assertInvalidRecord(true, false, true, false, "Struct or primitive");
+    assertInvalidRecord(false, false, true, false, "Struct or primitive");
 
-    assertInvalidRecord(true, true, false, true, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(false, true, false, true, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(true, false, false, true, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(false, false, false, true, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, false, true, "Struct or primitive");
+    assertInvalidRecord(false, true, false, true, "Struct or primitive");
+    assertInvalidRecord(true, false, false, true, "Struct or primitive");
+    assertInvalidRecord(false, false, false, true, "Struct or primitive");
 
-    assertInvalidRecord(true, true, false, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(false, true, false, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(true, false, false, false, "with a non-null Struct value and non-null Struct schema");
-    assertInvalidRecord(false, false, false, false, "with a non-null Struct value and non-null Struct schema");
+    assertInvalidRecord(true, true, false, false, "Struct or primitive");
+    assertInvalidRecord(false, true, false, false, "Struct or primitive");
+    assertInvalidRecord(true, false, false, false, "Struct or primitive");
+    assertInvalidRecord(false, false, false, false, "Struct or primitive");
   }
 
   @Test
@@ -779,6 +779,139 @@ public class BufferedRecordsTest {
     assertValidRecord(
         generateRecord(includeKeySchema, includeKey, includeValueSchema, includeValue)
     );
+  }
+
+  @Test
+  public void testPrimitiveValueInsertPkModeNone() throws SQLException {
+    props.put("pk.mode", "none");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "primitiveTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    );
+    assertEquals(Collections.emptyList(), buffer.add(record));
+    assertEquals(Collections.singletonList(record), buffer.flush());
+  }
+
+  @Test
+  public void testPrimitiveValueInsertPkModeKafka() throws SQLException {
+    props.put("pk.mode", "kafka");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "primitiveKafkaTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    );
+    assertEquals(Collections.emptyList(), buffer.add(record));
+    assertEquals(Collections.singletonList(record), buffer.flush());
+  }
+
+  @Test
+  public void testPrimitiveValueWithRecordKeyPk() throws SQLException {
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "the_key");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "primitiveKeyTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord record = new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
+    );
+    assertEquals(Collections.emptyList(), buffer.add(record));
+    assertEquals(Collections.singletonList(record), buffer.flush());
+  }
+
+  @Test
+  public void testPrimitiveValueDeleteWithRecordKeyPk() throws SQLException {
+    props.put("delete.enabled", true);
+    props.put("insert.mode", "upsert");
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "the_key");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "primitiveDeleteTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord insertRecord = new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
+    );
+    final SinkRecord deleteRecord = new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, null, null, 1
+    );
+
+    assertEquals(Collections.emptyList(), buffer.add(insertRecord));
+    assertEquals(Collections.emptyList(), buffer.add(deleteRecord));
+    assertEquals(Arrays.asList(insertRecord, deleteRecord), buffer.flush());
+  }
+
+  @Test
+  public void testPrimitiveValueBatchingWithSchemaChange() throws SQLException {
+    props.put("pk.mode", "none");
+    final JdbcSinkConfig config = new JdbcSinkConfig(props);
+
+    final String url = sqliteHelper.sqliteUri();
+    final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+    final DbStructure dbStructure = new DbStructure(dbDialect);
+
+    final TableId tableId = new TableId(null, null, "primitiveBatchTest");
+    final BufferedRecords buffer = new BufferedRecords(
+        config, tableId, dbDialect, dbStructure, sqliteHelper.connection
+    );
+
+    final SinkRecord stringRecord = new SinkRecord(
+        "topic", 0, null, null, Schema.OPTIONAL_STRING_SCHEMA, "hello", 0
+    );
+    final Schema structSchema = SchemaBuilder.struct()
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final Struct structValue = new Struct(structSchema).put("name", "world");
+    final SinkRecord structRecord = new SinkRecord(
+        "topic", 0, null, null, structSchema, structValue, 1
+    );
+
+    assertEquals(Collections.emptyList(), buffer.add(stringRecord));
+    assertEquals(Collections.singletonList(stringRecord), buffer.add(structRecord));
+    assertEquals(Collections.singletonList(structRecord), buffer.flush());
+  }
+
+  @Test
+  public void testPrimitiveValueValidation() throws SQLException {
+    props.put("pk.mode", "none");
+
+    final SinkRecord primitiveRecord = new SinkRecord(
+        "dummy", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
+    );
+    assertValidRecord(primitiveRecord);
   }
 
   protected void assertValidRecord(SinkRecord record) throws SQLException {

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -111,7 +111,10 @@ public class PreparedStatementBinderTest {
 
     List<String> pkFields = Collections.singletonList("long");
 
-    FieldsMetadata fieldsMetadata = FieldsMetadata.extract("people", pkMode, pkFields, Collections.<String>emptySet(), schemaPair);
+    FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+        "people", pkMode, pkFields, Collections.<String>emptySet(),
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        schemaPair);
 
     PreparedStatement statement = mock(PreparedStatement.class);
     TableId tabId = new TableId("ORCL", "ADMIN", "people");
@@ -209,86 +212,92 @@ public class PreparedStatementBinderTest {
     verify(statement, times(1)).setObject(index++, null);
   }
 
-    @Test
-    public void bindRecordStringValueInsert() throws SQLException {
-      SchemaPair schemaPair = new SchemaPair(null, Schema.STRING_SCHEMA);
+  @Test
+  public void bindRecordStringValueInsert() throws SQLException {
+    SchemaPair schemaPair = new SchemaPair(null, Schema.STRING_SCHEMA);
 
-      JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.NONE;
+    JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.NONE;
 
-      FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
-          "stringValueTable", pkMode, Collections.<String>emptyList(),
-          Collections.<String>emptySet(), schemaPair
-      );
+    FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+        "stringValueTable", pkMode, Collections.<String>emptyList(),
+        Collections.<String>emptySet(),
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        schemaPair
+    );
 
-      PreparedStatement statement = mock(PreparedStatement.class);
-      TableId tabId = new TableId(null, null, "stringValueTable");
-      List<ColumnDefinition> colDefs = new ArrayList<>();
-      colDefs.add(mock(ColumnDefinition.class));
-      when(colDefs.get(0).type()).thenReturn(Types.VARCHAR);
-      when(colDefs.get(0).id()).thenReturn(new ColumnId(tabId, "recordValue"));
-      when(colDefs.get(0).isPrimaryKey()).thenReturn(false);
-      TableDefinition tabDef = new TableDefinition(tabId, colDefs);
+    PreparedStatement statement = mock(PreparedStatement.class);
+    TableId tabId = new TableId(null, null, "stringValueTable");
+    List<ColumnDefinition> colDefs = new ArrayList<>();
+    colDefs.add(mock(ColumnDefinition.class));
+    when(colDefs.get(0).type()).thenReturn(Types.VARCHAR);
+    when(colDefs.get(0).id()).thenReturn(
+        new ColumnId(tabId, JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT));
+    when(colDefs.get(0).isPrimaryKey()).thenReturn(false);
+    TableDefinition tabDef = new TableDefinition(tabId, colDefs);
 
-      PreparedStatementBinder binder = new PreparedStatementBinder(
-          dialect,
-          statement,
-          pkMode,
-          schemaPair,
-          fieldsMetadata,
-          tabDef,
-          JdbcSinkConfig.InsertMode.INSERT,
-          true
-      );
+    PreparedStatementBinder binder = new PreparedStatementBinder(
+        dialect,
+        statement,
+        pkMode,
+        schemaPair,
+        fieldsMetadata,
+        tabDef,
+        JdbcSinkConfig.InsertMode.INSERT,
+        true
+    );
 
-      binder.bindRecord(new SinkRecord(
-          "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
-      ));
+    binder.bindRecord(new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+    ));
 
-      verify(statement, times(1)).setString(1, "hello world");
-    }
+    verify(statement, times(1)).setString(1, "hello world");
+  }
 
-    @Test
-    public void bindRecordStringValueWithPrimitiveKey() throws SQLException {
-      SchemaPair schemaPair = new SchemaPair(Schema.INT64_SCHEMA, Schema.STRING_SCHEMA);
+  @Test
+  public void bindRecordStringValueWithPrimitiveKey() throws SQLException {
+    SchemaPair schemaPair = new SchemaPair(Schema.INT64_SCHEMA, Schema.STRING_SCHEMA);
 
-      JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY;
+    JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY;
 
-      FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
-          "stringValueTable", pkMode, Collections.singletonList("the_key"),
-          Collections.<String>emptySet(), schemaPair
-      );
+    FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+        "stringValueTable", pkMode, Collections.singletonList("the_key"),
+        Collections.<String>emptySet(),
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        schemaPair
+    );
 
-      PreparedStatement statement = mock(PreparedStatement.class);
-      TableId tabId = new TableId(null, null, "stringValueTable");
-      List<ColumnDefinition> colDefs = new ArrayList<>();
-      colDefs.add(mock(ColumnDefinition.class));
-      colDefs.add(mock(ColumnDefinition.class));
-      when(colDefs.get(0).type()).thenReturn(Types.BIGINT);
-      when(colDefs.get(0).id()).thenReturn(new ColumnId(tabId, "the_key"));
-      when(colDefs.get(0).isPrimaryKey()).thenReturn(true);
-      when(colDefs.get(1).type()).thenReturn(Types.VARCHAR);
-      when(colDefs.get(1).id()).thenReturn(new ColumnId(tabId, "recordValue"));
-      when(colDefs.get(1).isPrimaryKey()).thenReturn(false);
-      TableDefinition tabDef = new TableDefinition(tabId, colDefs);
+    PreparedStatement statement = mock(PreparedStatement.class);
+    TableId tabId = new TableId(null, null, "stringValueTable");
+    List<ColumnDefinition> colDefs = new ArrayList<>();
+    colDefs.add(mock(ColumnDefinition.class));
+    colDefs.add(mock(ColumnDefinition.class));
+    when(colDefs.get(0).type()).thenReturn(Types.BIGINT);
+    when(colDefs.get(0).id()).thenReturn(new ColumnId(tabId, "the_key"));
+    when(colDefs.get(0).isPrimaryKey()).thenReturn(true);
+    when(colDefs.get(1).type()).thenReturn(Types.VARCHAR);
+    when(colDefs.get(1).id()).thenReturn(
+        new ColumnId(tabId, JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT));
+    when(colDefs.get(1).isPrimaryKey()).thenReturn(false);
+    TableDefinition tabDef = new TableDefinition(tabId, colDefs);
 
-      PreparedStatementBinder binder = new PreparedStatementBinder(
-          dialect,
-          statement,
-          pkMode,
-          schemaPair,
-          fieldsMetadata,
-          tabDef,
-          JdbcSinkConfig.InsertMode.INSERT,
-          true
-      );
+    PreparedStatementBinder binder = new PreparedStatementBinder(
+        dialect,
+        statement,
+        pkMode,
+        schemaPair,
+        fieldsMetadata,
+        tabDef,
+        JdbcSinkConfig.InsertMode.INSERT,
+        true
+    );
 
-      binder.bindRecord(new SinkRecord(
-          "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
-      ));
+    binder.bindRecord(new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
+    ));
 
-      verify(statement, times(1)).setLong(1, 42L);
-      verify(statement, times(1)).setString(2, "hello");
-    }
+    verify(statement, times(1)).setLong(1, 42L);
+    verify(statement, times(1)).setString(2, "hello");
+  }
 
     @Test
     public void bindRecordUpsertMode() throws SQLException, ParseException {
@@ -307,7 +316,10 @@ public class PreparedStatementBinderTest {
 
       List<String> pkFields = Collections.singletonList("long");
 
-      FieldsMetadata fieldsMetadata = FieldsMetadata.extract("people", pkMode, pkFields, Collections.<String>emptySet(), schemaPair);
+      FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+        "people", pkMode, pkFields, Collections.<String>emptySet(),
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        schemaPair);
 
       PreparedStatement statement = mock(PreparedStatement.class);
       TableId tabId = new TableId("ORCL", "ADMIN", "people");
@@ -358,8 +370,10 @@ public class PreparedStatementBinderTest {
 
       List<String> pkFields = Collections.singletonList("long");
 
-      FieldsMetadata fieldsMetadata = FieldsMetadata.extract("people", pkMode, pkFields,
-              Collections.<String>emptySet(), schemaPair);
+      FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+          "people", pkMode, pkFields, Collections.<String>emptySet(),
+          JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+          schemaPair);
 
       PreparedStatement statement = mock(PreparedStatement.class);
       TableId tabId = new TableId("ORCL", "ADMIN", "people");

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -210,18 +210,18 @@ public class PreparedStatementBinderTest {
   }
 
     @Test
-    public void bindRecordPrimitiveValueInsert() throws SQLException {
+    public void bindRecordStringValueInsert() throws SQLException {
       SchemaPair schemaPair = new SchemaPair(null, Schema.STRING_SCHEMA);
 
       JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.NONE;
 
       FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
-          "primitiveTable", pkMode, Collections.<String>emptyList(),
+          "stringValueTable", pkMode, Collections.<String>emptyList(),
           Collections.<String>emptySet(), schemaPair
       );
 
       PreparedStatement statement = mock(PreparedStatement.class);
-      TableId tabId = new TableId(null, null, "primitiveTable");
+      TableId tabId = new TableId(null, null, "stringValueTable");
       List<ColumnDefinition> colDefs = new ArrayList<>();
       colDefs.add(mock(ColumnDefinition.class));
       when(colDefs.get(0).type()).thenReturn(Types.VARCHAR);
@@ -248,18 +248,18 @@ public class PreparedStatementBinderTest {
     }
 
     @Test
-    public void bindRecordPrimitiveValueWithPrimitiveKey() throws SQLException {
+    public void bindRecordStringValueWithPrimitiveKey() throws SQLException {
       SchemaPair schemaPair = new SchemaPair(Schema.INT64_SCHEMA, Schema.STRING_SCHEMA);
 
       JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY;
 
       FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
-          "primitiveTable", pkMode, Collections.singletonList("the_key"),
+          "stringValueTable", pkMode, Collections.singletonList("the_key"),
           Collections.<String>emptySet(), schemaPair
       );
 
       PreparedStatement statement = mock(PreparedStatement.class);
-      TableId tabId = new TableId(null, null, "primitiveTable");
+      TableId tabId = new TableId(null, null, "stringValueTable");
       List<ColumnDefinition> colDefs = new ArrayList<>();
       colDefs.add(mock(ColumnDefinition.class));
       colDefs.add(mock(ColumnDefinition.class));

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -210,6 +210,87 @@ public class PreparedStatementBinderTest {
   }
 
     @Test
+    public void bindRecordPrimitiveValueInsert() throws SQLException {
+      SchemaPair schemaPair = new SchemaPair(null, Schema.STRING_SCHEMA);
+
+      JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.NONE;
+
+      FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+          "primitiveTable", pkMode, Collections.<String>emptyList(),
+          Collections.<String>emptySet(), schemaPair
+      );
+
+      PreparedStatement statement = mock(PreparedStatement.class);
+      TableId tabId = new TableId(null, null, "primitiveTable");
+      List<ColumnDefinition> colDefs = new ArrayList<>();
+      colDefs.add(mock(ColumnDefinition.class));
+      when(colDefs.get(0).type()).thenReturn(Types.VARCHAR);
+      when(colDefs.get(0).id()).thenReturn(new ColumnId(tabId, "recordValue"));
+      when(colDefs.get(0).isPrimaryKey()).thenReturn(false);
+      TableDefinition tabDef = new TableDefinition(tabId, colDefs);
+
+      PreparedStatementBinder binder = new PreparedStatementBinder(
+          dialect,
+          statement,
+          pkMode,
+          schemaPair,
+          fieldsMetadata,
+          tabDef,
+          JdbcSinkConfig.InsertMode.INSERT,
+          true
+      );
+
+      binder.bindRecord(new SinkRecord(
+          "topic", 0, null, null, Schema.STRING_SCHEMA, "hello world", 0
+      ));
+
+      verify(statement, times(1)).setString(1, "hello world");
+    }
+
+    @Test
+    public void bindRecordPrimitiveValueWithPrimitiveKey() throws SQLException {
+      SchemaPair schemaPair = new SchemaPair(Schema.INT64_SCHEMA, Schema.STRING_SCHEMA);
+
+      JdbcSinkConfig.PrimaryKeyMode pkMode = JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY;
+
+      FieldsMetadata fieldsMetadata = FieldsMetadata.extract(
+          "primitiveTable", pkMode, Collections.singletonList("the_key"),
+          Collections.<String>emptySet(), schemaPair
+      );
+
+      PreparedStatement statement = mock(PreparedStatement.class);
+      TableId tabId = new TableId(null, null, "primitiveTable");
+      List<ColumnDefinition> colDefs = new ArrayList<>();
+      colDefs.add(mock(ColumnDefinition.class));
+      colDefs.add(mock(ColumnDefinition.class));
+      when(colDefs.get(0).type()).thenReturn(Types.BIGINT);
+      when(colDefs.get(0).id()).thenReturn(new ColumnId(tabId, "the_key"));
+      when(colDefs.get(0).isPrimaryKey()).thenReturn(true);
+      when(colDefs.get(1).type()).thenReturn(Types.VARCHAR);
+      when(colDefs.get(1).id()).thenReturn(new ColumnId(tabId, "recordValue"));
+      when(colDefs.get(1).isPrimaryKey()).thenReturn(false);
+      TableDefinition tabDef = new TableDefinition(tabId, colDefs);
+
+      PreparedStatementBinder binder = new PreparedStatementBinder(
+          dialect,
+          statement,
+          pkMode,
+          schemaPair,
+          fieldsMetadata,
+          tabDef,
+          JdbcSinkConfig.InsertMode.INSERT,
+          true
+      );
+
+      binder.bindRecord(new SinkRecord(
+          "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
+      ));
+
+      verify(statement, times(1)).setLong(1, 42L);
+      verify(statement, times(1)).setString(2, "hello");
+    }
+
+    @Test
     public void bindRecordUpsertMode() throws SQLException, ParseException {
       Schema valueSchema = SchemaBuilder.struct().name("com.example.Person")
               .field("firstName", Schema.STRING_SCHEMA)

--- a/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
@@ -128,4 +128,92 @@ public class RecordValidatorTest {
     );
     validator.validate(deleteRecord);
   }
+
+  @Test
+  public void stringValueWithFieldsWhitelistIsRejected() {
+    props.put("pk.mode", "none");
+    props.put("fields.whitelist", "field_a,field_b");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
+    );
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("fields.whitelist"));
+    assertTrue(e.getMessage().contains("not applicable to String values"));
+  }
+
+  @Test
+  public void stringValueWithTimestampFieldsListIsRejected() {
+    props.put("pk.mode", "none");
+    props.put("timestamp.fields.list", "created_at");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
+    );
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("timestamp.fields.list"));
+    assertTrue(e.getMessage().contains("not applicable to String values"));
+  }
+
+  @Test
+  public void stringValueWithExplicitTimestampPrecisionModeIsRejected() {
+    props.put("pk.mode", "none");
+    props.put("timestamp.precision.mode", "nanoseconds");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
+    );
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("timestamp.precision.mode"));
+    assertTrue(e.getMessage().contains("not applicable to String values"));
+  }
+
+  @Test
+  public void stringValueWithAllIncompatibleConfigsIsRejectedWithAllConfigsNamed() {
+    props.put("pk.mode", "none");
+    props.put("fields.whitelist", "field_a");
+    props.put("timestamp.fields.list", "created_at");
+    props.put("timestamp.precision.mode", "nanoseconds");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
+    );
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("fields.whitelist"));
+    assertTrue(e.getMessage().contains("timestamp.fields.list"));
+    assertTrue(e.getMessage().contains("timestamp.precision.mode"));
+  }
+
+  @Test
+  public void structValueWithIncompatibleConfigsIsAccepted() {
+    // The same configs that fail for STRING values are perfectly valid for STRUCT values —
+    // the rejection must only fire on the STRING path.
+    props.put("pk.mode", "none");
+    props.put("fields.whitelist", "name");
+    props.put("timestamp.fields.list", "created_at");
+    props.put("timestamp.precision.mode", "nanoseconds");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("created_at", Schema.INT64_SCHEMA)
+        .build();
+    Struct value = new Struct(valueSchema).put("name", "test").put("created_at", 1L);
+    SinkRecord record = new SinkRecord("topic", 0, null, null, valueSchema, value, 0);
+
+    validator.validate(record);
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
@@ -97,21 +97,6 @@ public class RecordValidatorTest {
   }
 
   @Test
-  public void requiresValueRejectsMapSchema() {
-    props.put("pk.mode", "none");
-    JdbcSinkConfig config = new JdbcSinkConfig(props);
-    RecordValidator validator = RecordValidator.create(config);
-
-    Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build();
-    Map<String, String> mapValue = new HashMap<>();
-    mapValue.put("key", "value");
-    SinkRecord record = new SinkRecord("topic", 0, null, null, mapSchema, mapValue, 0);
-
-    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
-    assertTrue(e.getMessage().contains("Struct or String"));
-  }
-
-  @Test
   public void stringValueWithRecordKeyPkMode() {
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "id");

--- a/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class RecordValidatorTest {
+
+  private Map<Object, Object> props;
+
+  @Before
+  public void setUp() {
+    props = new HashMap<>();
+    props.put("name", "test-connector");
+    props.put("connection.url", "jdbc:bogus:something");
+    props.put("connection.user", "sa");
+    props.put("connection.password", "password");
+  }
+
+  @Test
+  public void requiresValueAcceptsStructSchema() {
+    props.put("pk.mode", "none");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(valueSchema).put("name", "test");
+    SinkRecord record = new SinkRecord("topic", 0, null, null, valueSchema, value, 0);
+
+    validator.validate(record);
+  }
+
+  @Test
+  public void requiresValueAcceptsStringSchema() {
+    props.put("pk.mode", "none");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
+    );
+
+    validator.validate(record);
+  }
+
+  @Test
+  public void requiresValueRejectsNonStringPrimitiveSchema() {
+    props.put("pk.mode", "none");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, Schema.INT32_SCHEMA, 42, 0
+    );
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("Struct or String"));
+  }
+
+  @Test
+  public void requiresValueRejectsNullValue() {
+    props.put("pk.mode", "none");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("with a null value"));
+  }
+
+  @Test
+  public void requiresValueRejectsMapSchema() {
+    props.put("pk.mode", "none");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build();
+    Map<String, String> mapValue = new HashMap<>();
+    mapValue.put("key", "value");
+    SinkRecord record = new SinkRecord("topic", 0, null, null, mapSchema, mapValue, 0);
+
+    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
+    assertTrue(e.getMessage().contains("Struct or String"));
+  }
+
+  @Test
+  public void stringValueWithRecordKeyPkMode() {
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
+    );
+
+    validator.validate(record);
+  }
+
+  @Test
+  public void stringValueWithDeleteEnabled() {
+    props.put("delete.enabled", true);
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+    JdbcSinkConfig config = new JdbcSinkConfig(props);
+    RecordValidator validator = RecordValidator.create(config);
+
+    SinkRecord insertRecord = new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, Schema.STRING_SCHEMA, "hello", 0
+    );
+    validator.validate(insertRecord);
+
+    SinkRecord deleteRecord = new SinkRecord(
+        "topic", 0, Schema.INT64_SCHEMA, 42L, null, null, 1
+    );
+    validator.validate(deleteRecord);
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -77,16 +77,6 @@ public class FieldsMetadataTest {
     );
   }
 
-  @Test(expected = ConnectException.class)
-  public void nonStringPrimitiveValueSchemaIsRejected() {
-    extract(
-        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
-        Collections.<String>emptyList(),
-        null,
-        Schema.INT64_SCHEMA
-    );
-  }
-
   @Test
   public void missingValueSchemaCanBeOk() {
     assertEquals(

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -50,30 +50,40 @@ public class FieldsMetadataTest {
   }
 
   @Test
-  public void primitiveValueSchemaIsAllowed() {
+  public void stringValueSchemaIsAllowed() {
     FieldsMetadata metadata = extract(
         JdbcSinkConfig.PrimaryKeyMode.KAFKA,
         Collections.<String>emptyList(),
         SIMPLE_PRIMITIVE_SCHEMA,
-        SIMPLE_PRIMITIVE_SCHEMA
+        Schema.STRING_SCHEMA
     );
     assertEquals(
-        Collections.singleton(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME),
+        Collections.singleton(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME),
         metadata.nonKeyFieldNames
     );
     assertEquals(
-        Schema.Type.INT64,
-        metadata.allFields.get(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME).schemaType()
+        Schema.Type.STRING,
+        metadata.allFields.get(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME).schemaType()
     );
   }
 
   @Test(expected = ConnectException.class)
-  public void valueSchemaMustBeStructOrPrimitiveIfPresent() {
+  public void valueSchemaMustBeStructOrStringIfPresent() {
     extract(
         JdbcSinkConfig.PrimaryKeyMode.KAFKA,
         Collections.<String>emptyList(),
         null,
         SIMPLE_MAP_SCHEMA
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void nonStringPrimitiveValueSchemaIsRejected() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        Collections.<String>emptyList(),
+        null,
+        Schema.INT64_SCHEMA
     );
   }
 
@@ -326,7 +336,7 @@ public class FieldsMetadataTest {
   }
 
   @Test
-  public void primitiveValueSchemaPkModeNone() {
+  public void stringValueSchemaPkModeNone() {
     FieldsMetadata metadata = extract(
         JdbcSinkConfig.PrimaryKeyMode.NONE,
         Collections.<String>emptyList(),
@@ -335,17 +345,17 @@ public class FieldsMetadataTest {
     );
     assertEquals(Collections.emptySet(), metadata.keyFieldNames);
     assertEquals(
-        Collections.singleton(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME),
+        Collections.singleton(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME),
         metadata.nonKeyFieldNames
     );
     SinkRecordField field =
-        metadata.allFields.get(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME);
+        metadata.allFields.get(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME);
     assertEquals(Schema.Type.STRING, field.schemaType());
     assertFalse(field.isPrimaryKey());
   }
 
   @Test
-  public void primitiveValueSchemaWithRecordKeyPk() {
+  public void stringValueSchemaWithRecordKeyPk() {
     FieldsMetadata metadata = extract(
         JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
         Collections.singletonList("the_pk"),
@@ -354,17 +364,47 @@ public class FieldsMetadataTest {
     );
     assertEquals(Collections.singleton("the_pk"), metadata.keyFieldNames);
     assertEquals(
-        Collections.singleton(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME),
+        Collections.singleton(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME),
         metadata.nonKeyFieldNames
     );
   }
 
   @Test(expected = ConnectException.class)
-  public void primitiveValueSchemaWithRecordValuePkFails() {
+  public void stringValueSchemaWithRecordValuePkFails() {
     extract(
         JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE,
         Collections.singletonList("name"),
         null,
+        Schema.STRING_SCHEMA
+    );
+  }
+
+  @Test
+  public void stringValueColumnNameIsHonored() {
+    FieldsMetadata metadata = FieldsMetadata.extract(
+        "table",
+        JdbcSinkConfig.PrimaryKeyMode.NONE,
+        Collections.<String>emptyList(),
+        Collections.<String>emptySet(),
+        "myValueColumn",
+        null,
+        Schema.STRING_SCHEMA
+    );
+    assertEquals(Collections.singleton("myValueColumn"), metadata.nonKeyFieldNames);
+    SinkRecordField field = metadata.allFields.get("myValueColumn");
+    assertEquals(Schema.Type.STRING, field.schemaType());
+    assertTrue(field.isOptional());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void stringValueColumnNameConflictsWithKeyColumnName() {
+    FieldsMetadata.extract(
+        "table",
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Collections.singletonList("the_key"),
+        Collections.<String>emptySet(),
+        "the_key",
+        Schema.INT64_SCHEMA,
         Schema.STRING_SCHEMA
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -49,13 +49,31 @@ public class FieldsMetadataTest {
     );
   }
 
-  @Test(expected = ConnectException.class)
-  public void valueSchemaMustBeStructIfPresent() {
-    extract(
+  @Test
+  public void primitiveValueSchemaIsAllowed() {
+    FieldsMetadata metadata = extract(
         JdbcSinkConfig.PrimaryKeyMode.KAFKA,
         Collections.<String>emptyList(),
         SIMPLE_PRIMITIVE_SCHEMA,
         SIMPLE_PRIMITIVE_SCHEMA
+    );
+    assertEquals(
+        Collections.singleton(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME),
+        metadata.nonKeyFieldNames
+    );
+    assertEquals(
+        Schema.Type.INT64,
+        metadata.allFields.get(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME).schemaType()
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void valueSchemaMustBeStructOrPrimitiveIfPresent() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.KAFKA,
+        Collections.<String>emptyList(),
+        null,
+        SIMPLE_MAP_SCHEMA
     );
   }
 
@@ -305,6 +323,50 @@ public class FieldsMetadataTest {
     );
 
     assertEquals(Arrays.asList("field1", "field2", "field3"), new ArrayList<>(metadata.allFields.keySet()));
+  }
+
+  @Test
+  public void primitiveValueSchemaPkModeNone() {
+    FieldsMetadata metadata = extract(
+        JdbcSinkConfig.PrimaryKeyMode.NONE,
+        Collections.<String>emptyList(),
+        null,
+        Schema.STRING_SCHEMA
+    );
+    assertEquals(Collections.emptySet(), metadata.keyFieldNames);
+    assertEquals(
+        Collections.singleton(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME),
+        metadata.nonKeyFieldNames
+    );
+    SinkRecordField field =
+        metadata.allFields.get(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME);
+    assertEquals(Schema.Type.STRING, field.schemaType());
+    assertFalse(field.isPrimaryKey());
+  }
+
+  @Test
+  public void primitiveValueSchemaWithRecordKeyPk() {
+    FieldsMetadata metadata = extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_KEY,
+        Collections.singletonList("the_pk"),
+        SIMPLE_PRIMITIVE_SCHEMA,
+        Schema.STRING_SCHEMA
+    );
+    assertEquals(Collections.singleton("the_pk"), metadata.keyFieldNames);
+    assertEquals(
+        Collections.singleton(FieldsMetadata.DEFAULT_PRIMITIVE_VALUE_COLUMN_NAME),
+        metadata.nonKeyFieldNames
+    );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void primitiveValueSchemaWithRecordValuePkFails() {
+    extract(
+        JdbcSinkConfig.PrimaryKeyMode.RECORD_VALUE,
+        Collections.singletonList("name"),
+        null,
+        Schema.STRING_SCHEMA
+    );
   }
 
   private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Schema keySchema, Schema valueSchema) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -58,12 +58,12 @@ public class FieldsMetadataTest {
         Schema.STRING_SCHEMA
     );
     assertEquals(
-        Collections.singleton(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME),
+        Collections.singleton(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT),
         metadata.nonKeyFieldNames
     );
     assertEquals(
         Schema.Type.STRING,
-        metadata.allFields.get(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME).schemaType()
+        metadata.allFields.get(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT).schemaType()
     );
   }
 
@@ -345,11 +345,11 @@ public class FieldsMetadataTest {
     );
     assertEquals(Collections.emptySet(), metadata.keyFieldNames);
     assertEquals(
-        Collections.singleton(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME),
+        Collections.singleton(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT),
         metadata.nonKeyFieldNames
     );
     SinkRecordField field =
-        metadata.allFields.get(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME);
+        metadata.allFields.get(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT);
     assertEquals(Schema.Type.STRING, field.schemaType());
     assertFalse(field.isPrimaryKey());
   }
@@ -364,7 +364,7 @@ public class FieldsMetadataTest {
     );
     assertEquals(Collections.singleton("the_pk"), metadata.keyFieldNames);
     assertEquals(
-        Collections.singleton(FieldsMetadata.DEFAULT_STRING_VALUE_COLUMN_NAME),
+        Collections.singleton(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT),
         metadata.nonKeyFieldNames
     );
   }
@@ -409,11 +409,59 @@ public class FieldsMetadataTest {
     );
   }
 
+  @Test(expected = ConnectException.class)
+  public void stringValueWithWhitelistThatExcludesColumnIsRejected() {
+    FieldsMetadata.extract(
+        "table",
+        JdbcSinkConfig.PrimaryKeyMode.NONE,
+        Collections.<String>emptyList(),
+        Collections.singleton("other_field"),
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        null,
+        Schema.STRING_SCHEMA
+    );
+  }
+
+  @Test
+  public void stringValueWithWhitelistThatIncludesColumnIsAccepted() {
+    FieldsMetadata metadata = FieldsMetadata.extract(
+        "table",
+        JdbcSinkConfig.PrimaryKeyMode.NONE,
+        Collections.<String>emptyList(),
+        Collections.singleton("payload"),
+        "payload",
+        null,
+        Schema.STRING_SCHEMA
+    );
+    assertEquals(Collections.singleton("payload"), metadata.nonKeyFieldNames);
+  }
+
+  @Test
+  public void stringValueWithEmptyWhitelistIsAccepted() {
+    FieldsMetadata metadata = FieldsMetadata.extract(
+        "table",
+        JdbcSinkConfig.PrimaryKeyMode.NONE,
+        Collections.<String>emptyList(),
+        Collections.<String>emptySet(),
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        null,
+        Schema.STRING_SCHEMA
+    );
+    assertEquals(
+        Collections.singleton(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT),
+        metadata.nonKeyFieldNames
+    );
+  }
+
   private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Schema keySchema, Schema valueSchema) {
     return extract(pkMode, pkFields, Collections.<String>emptySet(), keySchema, valueSchema);
   }
 
   private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Set<String> whitelist, Schema keySchema, Schema valueSchema) {
-    return FieldsMetadata.extract("table", pkMode, pkFields, whitelist, keySchema, valueSchema);
+    return FieldsMetadata.extract(
+        "table", pkMode, pkFields, whitelist,
+        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
+        keySchema, valueSchema
+    );
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/metadata/FieldsMetadataTest.java
@@ -399,50 +399,6 @@ public class FieldsMetadataTest {
     );
   }
 
-  @Test(expected = ConnectException.class)
-  public void stringValueWithWhitelistThatExcludesColumnIsRejected() {
-    FieldsMetadata.extract(
-        "table",
-        JdbcSinkConfig.PrimaryKeyMode.NONE,
-        Collections.<String>emptyList(),
-        Collections.singleton("other_field"),
-        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
-        null,
-        Schema.STRING_SCHEMA
-    );
-  }
-
-  @Test
-  public void stringValueWithWhitelistThatIncludesColumnIsAccepted() {
-    FieldsMetadata metadata = FieldsMetadata.extract(
-        "table",
-        JdbcSinkConfig.PrimaryKeyMode.NONE,
-        Collections.<String>emptyList(),
-        Collections.singleton("payload"),
-        "payload",
-        null,
-        Schema.STRING_SCHEMA
-    );
-    assertEquals(Collections.singleton("payload"), metadata.nonKeyFieldNames);
-  }
-
-  @Test
-  public void stringValueWithEmptyWhitelistIsAccepted() {
-    FieldsMetadata metadata = FieldsMetadata.extract(
-        "table",
-        JdbcSinkConfig.PrimaryKeyMode.NONE,
-        Collections.<String>emptyList(),
-        Collections.<String>emptySet(),
-        JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT,
-        null,
-        Schema.STRING_SCHEMA
-    );
-    assertEquals(
-        Collections.singleton(JdbcSinkConfig.STRING_OUTPUT_VALUE_COLUMN_NAME_DEFAULT),
-        metadata.nonKeyFieldNames
-    );
-  }
-
   private static FieldsMetadata extract(JdbcSinkConfig.PrimaryKeyMode pkMode, List<String> pkFields, Schema keySchema, Schema valueSchema) {
     return extract(pkMode, pkFields, Collections.<String>emptySet(), keySchema, valueSchema);
   }


### PR DESCRIPTION
## Problem
The JDBC Sink Connector currently rejects every record whose value schema is not STRUCT. `RecordValidator.requiresValue()` enforces this with a hard schema-type check and raises a ConnectException for anything else — including the `Schema.STRING` records produced by StringConverter. As a result, records carrying raw String payloads (logs, raw JSON documents, plain text) cannot be written to a JDBC target unless they are first transformed upstream into a Struct.

## Solution
Extend the connector to accept records whose value schema is `Schema.STRING`. The `STRUCT` path is left entirely unchanged.

For a STRING record:
  - The value is written into a single column whose name is controlled by a new config, `string.output.value.column.name` (default `recordValue`).
  - When the destination table does not exist, auto.create provisions the table with this column as NULLABLE.
  - When the table exists but the column is missing, `auto.evolve=true` adds it via `ALTER TABLE … ADD COLUMN` (also NULLABLE, so the `ALTER` does not violate constraints on pre-existing rows). With `auto.evolve=false`, the connector raises the standard auto evolution disabled error — no new failure path.
  - The value is bound to the configured column via `PreparedStatement.setString(...)` regardless of database dialect.

Two configuration combinations are rejected up front with explicit, actionable error messages:
  - `pk.mode=record_value` with a STRING value — a String has no fields to designate as a primary key.
  - `string.output.value.column.name` colliding with a primary-key column name

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
