### PR TITLE
Add getMetaData() shadow probe to source query validation

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -25,7 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +46,7 @@ public class JdbcSourceConnectorValidation {
   private static final Logger log = LoggerFactory.getLogger(JdbcSourceConnectorValidation.class);
   private static final Pattern SELECT_STATEMENT_PATTERN =
       Pattern.compile("(?is)^SELECT\\b");
+  private static final int SHADOW_QUERY_TIMEOUT_SECONDS = 60;
   protected JdbcSourceConnectorConfig config;
   protected Config validationResult;
   private final Map<String, String> connectorConfigs;
@@ -382,7 +385,19 @@ public class JdbcSourceConnectorValidation {
     try {
       dialect = createDialect();
       try (Connection connection = dialect.getConnection()) {
-        dialect.validateQuery(connection, query);
+        // The shadow probe must run regardless of the primary outcome, so it
+        // is invoked from the finally block; the original SQLException (if
+        // any) propagates afterwards to the outer catch.
+        boolean primarySucceeded = false;
+        try {
+          dialect.validateQuery(connection, query);
+          primarySucceeded = true;
+        } finally {
+          runGetMetaDataShadowProbe(
+              connection, query,
+              dialect.getClass().getSimpleName(),
+              primarySucceeded);
+        }
       }
       return true;
     } catch (SQLException e) {
@@ -401,6 +416,54 @@ public class JdbcSourceConnectorValidation {
       if (dialect != null) {
         dialect.close();
       }
+    }
+  }
+
+  /**
+   * Run {@link PreparedStatement#getMetaData()} as a shadow validation against
+   * the same connection used for the primary {@code EXPLAIN}-based validation.
+   * Never throws; any failure is logged at {@code WARN} with non-sensitive
+   * metadata only (dialect, SQLState, vendor error code, duration, primary
+   * outcome). The query text and the driver's exception message are
+   * deliberately omitted.
+   *
+   * <p>{@link PreparedStatement#setQueryTimeout(int)} is set to bound server
+   * time, but is honoured by drivers on a best-effort basis — most respect it
+   * for {@code getMetaData()}, but a few only honour it for actual
+   * {@code executeQuery}/{@code executeUpdate}.
+   */
+  private void runGetMetaDataShadowProbe(
+      Connection connection,
+      String query,
+      String dialectName,
+      boolean primarySucceeded
+  ) {
+    long startMs = System.currentTimeMillis();
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      stmt.setQueryTimeout(SHADOW_QUERY_TIMEOUT_SECONDS);
+      stmt.getMetaData();
+    } catch (SQLTimeoutException e) {
+      log.warn(
+          "Query validation getMetaData() probe timed out "
+              + "[dialect={}, primarySucceeded={}, timeoutSeconds={}, durationMs={}]",
+          dialectName, primarySucceeded, SHADOW_QUERY_TIMEOUT_SECONDS,
+          System.currentTimeMillis() - startMs);
+    } catch (SQLException e) {
+      log.warn(
+          "Query validation getMetaData() probe failed "
+              + "[dialect={}, primarySucceeded={}, sqlState={}, errorCode={}, "
+              + "durationMs={}]",
+          dialectName, primarySucceeded,
+          e.getSQLState() == null ? "null" : e.getSQLState(),
+          e.getErrorCode(),
+          System.currentTimeMillis() - startMs);
+    } catch (Exception e) {
+      log.warn(
+          "Query validation getMetaData() probe failed unexpectedly "
+              + "[dialect={}, primarySucceeded={}, causeClass={}, durationMs={}]",
+          dialectName, primarySucceeded,
+          e.getClass().getSimpleName(),
+          System.currentTimeMillis() - startMs);
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -46,7 +46,7 @@ public class JdbcSourceConnectorValidation {
   private static final Logger log = LoggerFactory.getLogger(JdbcSourceConnectorValidation.class);
   private static final Pattern SELECT_STATEMENT_PATTERN =
       Pattern.compile("(?is)^SELECT\\b");
-  private static final int SHADOW_QUERY_TIMEOUT_SECONDS = 60;
+  private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
   protected JdbcSourceConnectorConfig config;
   protected Config validationResult;
   private final Map<String, String> connectorConfigs;
@@ -420,17 +420,13 @@ public class JdbcSourceConnectorValidation {
   }
 
   /**
-   * Run {@link PreparedStatement#getMetaData()} as a shadow validation against
-   * the same connection used for the primary {@code EXPLAIN}-based validation.
-   * Never throws; any failure is logged at {@code WARN} with non-sensitive
-   * metadata only (dialect, SQLState, vendor error code, duration, primary
-   * outcome). The query text and the driver's exception message are
-   * deliberately omitted.
-   *
-   * <p>{@link PreparedStatement#setQueryTimeout(int)} is set to bound server
-   * time, but is honoured by drivers on a best-effort basis — most respect it
-   * for {@code getMetaData()}, but a few only honour it for actual
-   * {@code executeQuery}/{@code executeUpdate}.
+   * Shadow probe via {@link PreparedStatement#getMetaData()} on the same
+   * connection used for the primary validation. Never throws — failures are
+   * caught and logged at {@code WARN} with non-sensitive metadata only
+   * (dialect, SQLState, vendor error code, duration, primary outcome); the
+   * query text and the driver's exception message are deliberately omitted.
+   * Bounded by {@link PreparedStatement#setQueryTimeout(int)}, which drivers
+   * honour on a best-effort basis for {@code getMetaData()}.
    */
   private void runGetMetaDataShadowProbe(
       Connection connection,
@@ -440,13 +436,13 @@ public class JdbcSourceConnectorValidation {
   ) {
     long startMs = System.currentTimeMillis();
     try (PreparedStatement stmt = connection.prepareStatement(query)) {
-      stmt.setQueryTimeout(SHADOW_QUERY_TIMEOUT_SECONDS);
+      stmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
       stmt.getMetaData();
     } catch (SQLTimeoutException e) {
       log.warn(
           "Query validation getMetaData() probe timed out "
               + "[dialect={}, primarySucceeded={}, timeoutSeconds={}, durationMs={}]",
-          dialectName, primarySucceeded, SHADOW_QUERY_TIMEOUT_SECONDS,
+          dialectName, primarySucceeded, VALIDATE_QUERY_TIMEOUT_SECONDS,
           System.currentTimeMillis() - startMs);
     } catch (SQLException e) {
       log.warn(

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.SQLTimeoutException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -1320,9 +1319,8 @@ public class JdbcSourceConnectorValidationTest {
 
   // ========== getMetaData() Shadow Probe Tests ==========
   // The probe is invoked from validateQuerySemantics' finally block. It must
-  // never affect the user-visible validation result, regardless of what the
-  // probe itself encounters (success, SQLException, SQLTimeoutException,
-  // unexpected RuntimeException).
+  // never affect the user-visible validation result. The two cases below
+  // exercise both directions: primary succeeds and primary fails.
 
   @Test
   public void shadowProbe_failureDoesNotAffectPrimarySuccess() throws Exception {
@@ -1337,41 +1335,12 @@ public class JdbcSourceConnectorValidationTest {
     EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
     mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
     EasyMock.expectLastCall();
-    // Shadow probe: prepareStatement is called, then setQueryTimeout, then
-    // getMetaData throws. The probe must swallow the failure.
+    // Shadow probe: prepareStatement returns, getMetaData throws. The probe
+    // must swallow the failure so primary success surfaces unchanged.
     EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
         .andReturn(shadowStmt);
     EasyMock.expect(shadowStmt.getMetaData())
         .andThrow(new SQLException("driver-side failure", "08006", 17002));
-    mockConnection.close();
-    EasyMock.expectLastCall();
-    mockDialect.close();
-    EasyMock.expectLastCall();
-
-    EasyMock.replay(mockDialect, mockConnection, shadowStmt);
-    validateWithMockDialect(mockDialect);
-    EasyMock.verify(mockDialect, mockConnection, shadowStmt);
-
-    // Shadow failure must not register as a validation error.
-    assertNoErrors();
-  }
-
-  @Test
-  public void shadowProbe_timeoutDoesNotAffectPrimarySuccess() throws Exception {
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM users");
-
-    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    PreparedStatement shadowStmt = EasyMock.createNiceMock(PreparedStatement.class);
-
-    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
-    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.expectLastCall();
-    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
-        .andReturn(shadowStmt);
-    EasyMock.expect(shadowStmt.getMetaData())
-        .andThrow(new SQLTimeoutException("query timed out", "57014"));
     mockConnection.close();
     EasyMock.expectLastCall();
     mockDialect.close();
@@ -1418,33 +1387,6 @@ public class JdbcSourceConnectorValidationTest {
     ConfigValue queryConfigValue = valueFor(QUERY_CONFIG);
     assertTrue(queryConfigValue.errorMessages().get(0).contains("not valid"));
     assertTrue(queryConfigValue.errorMessages().get(0).contains("SQLState: 42S02"));
-  }
-
-  @Test
-  public void shadowProbe_runtimeExceptionFromDriverIsSwallowed() throws Exception {
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM users");
-
-    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-
-    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
-    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.expectLastCall();
-    // Driver throws an unchecked exception (e.g. NPE in a buggy JDBC impl).
-    // The probe's catch (Exception) arm must swallow it.
-    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
-        .andThrow(new RuntimeException("driver bug"));
-    mockConnection.close();
-    EasyMock.expectLastCall();
-    mockDialect.close();
-    EasyMock.expectLastCall();
-
-    EasyMock.replay(mockDialect, mockConnection);
-    validateWithMockDialect(mockDialect);
-    EasyMock.verify(mockDialect, mockConnection);
-
-    assertNoErrors();
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -23,7 +23,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -1213,7 +1215,7 @@ public class JdbcSourceConnectorValidationTest {
     props.put(QUERY_CONFIG, "SELECT id, name FROM users WHERE active = true");
 
     DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
+    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
 
     EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
     mockDialect.validateQuery(mockConnection, "SELECT id, name FROM users WHERE active = true");
@@ -1236,7 +1238,7 @@ public class JdbcSourceConnectorValidationTest {
     props.put(QUERY_CONFIG, "SELECT * FROM nonexistent_table");
 
     DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
+    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
 
     EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
     mockDialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
@@ -1299,11 +1301,140 @@ public class JdbcSourceConnectorValidationTest {
     props.put(QUERY_MASKED_CONFIG, "SELECT * FROM sensitive_data");
 
     DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
+    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
 
     EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
     mockDialect.validateQuery(mockConnection, "SELECT * FROM sensitive_data");
     EasyMock.expectLastCall();
+    mockConnection.close();
+    EasyMock.expectLastCall();
+    mockDialect.close();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockDialect, mockConnection);
+    validateWithMockDialect(mockDialect);
+    EasyMock.verify(mockDialect, mockConnection);
+
+    assertNoErrors();
+  }
+
+  // ========== getMetaData() Shadow Probe Tests ==========
+  // The probe is invoked from validateQuerySemantics' finally block. It must
+  // never affect the user-visible validation result, regardless of what the
+  // probe itself encounters (success, SQLException, SQLTimeoutException,
+  // unexpected RuntimeException).
+
+  @Test
+  public void shadowProbe_failureDoesNotAffectPrimarySuccess() throws Exception {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users");
+
+    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    PreparedStatement shadowStmt = EasyMock.createNiceMock(PreparedStatement.class);
+
+    // Primary validation succeeds.
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
+    EasyMock.expectLastCall();
+    // Shadow probe: prepareStatement is called, then setQueryTimeout, then
+    // getMetaData throws. The probe must swallow the failure.
+    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
+        .andReturn(shadowStmt);
+    EasyMock.expect(shadowStmt.getMetaData())
+        .andThrow(new SQLException("driver-side failure", "08006", 17002));
+    mockConnection.close();
+    EasyMock.expectLastCall();
+    mockDialect.close();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockDialect, mockConnection, shadowStmt);
+    validateWithMockDialect(mockDialect);
+    EasyMock.verify(mockDialect, mockConnection, shadowStmt);
+
+    // Shadow failure must not register as a validation error.
+    assertNoErrors();
+  }
+
+  @Test
+  public void shadowProbe_timeoutDoesNotAffectPrimarySuccess() throws Exception {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users");
+
+    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    PreparedStatement shadowStmt = EasyMock.createNiceMock(PreparedStatement.class);
+
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
+    EasyMock.expectLastCall();
+    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
+        .andReturn(shadowStmt);
+    EasyMock.expect(shadowStmt.getMetaData())
+        .andThrow(new SQLTimeoutException("query timed out", "57014"));
+    mockConnection.close();
+    EasyMock.expectLastCall();
+    mockDialect.close();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockDialect, mockConnection, shadowStmt);
+    validateWithMockDialect(mockDialect);
+    EasyMock.verify(mockDialect, mockConnection, shadowStmt);
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void shadowProbe_runsAndIsSwallowedWhenPrimaryFails() throws Exception {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM nonexistent_table");
+
+    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    PreparedStatement shadowStmt = EasyMock.createNiceMock(PreparedStatement.class);
+
+    // Primary validation fails.
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
+    EasyMock.expectLastCall().andThrow(new SQLException(
+        "Table 'nonexistent_table' doesn't exist", "42S02"));
+    // Shadow probe still runs in finally and also fails; must not mask the
+    // primary's user-visible error.
+    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM nonexistent_table"))
+        .andReturn(shadowStmt);
+    EasyMock.expect(shadowStmt.getMetaData())
+        .andThrow(new SQLException("does not exist", "42S02"));
+    mockConnection.close();
+    EasyMock.expectLastCall();
+    mockDialect.close();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockDialect, mockConnection, shadowStmt);
+    validateWithMockDialect(mockDialect);
+    EasyMock.verify(mockDialect, mockConnection, shadowStmt);
+
+    // Primary's SQLState 42S02 surfaces to the user; shadow does not interfere.
+    assertErrors(QUERY_CONFIG, 1);
+    ConfigValue queryConfigValue = valueFor(QUERY_CONFIG);
+    assertTrue(queryConfigValue.errorMessages().get(0).contains("not valid"));
+    assertTrue(queryConfigValue.errorMessages().get(0).contains("SQLState: 42S02"));
+  }
+
+  @Test
+  public void shadowProbe_runtimeExceptionFromDriverIsSwallowed() throws Exception {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users");
+
+    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
+    EasyMock.expectLastCall();
+    // Driver throws an unchecked exception (e.g. NPE in a buggy JDBC impl).
+    // The probe's catch (Exception) arm must swallow it.
+    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
+        .andThrow(new RuntimeException("driver bug"));
     mockConnection.close();
     EasyMock.expectLastCall();
     mockDialect.close();


### PR DESCRIPTION
## Problem
In this PR - https://github.com/confluentinc/kafka-connect-jdbc/pull/1616, introduced a query validation using EXPLAIN PLAN <query> mechanism. But this mechanism would require an extra privileges for the user on the EXPLAIN table which is not a better approach.

## Solution
Adds a non-blocking `PreparedStatement.getMetaData()` shadow probe alongside the existing EXPLAIN-based query validation in JdbcSourceConnector. The probe is a WARN-only observability hook — it does not change the user-visible validation result but would gather production data on whether getMetaData() would accept or reject the same queries the current validation accepts or rejects, before any decision is made about switching the primary validation strategy.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
