### PR TITLE
Bump org.postgresql:postgresql to 42.7.11 (CVE-2026-42198) [CC-41166]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>12.8.2.jre8</mssqlserver.jdbc.driver.version>
-        <postgresql.version>42.4.4</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>


### PR DESCRIPTION
## Summary

Upgrade the PostgreSQL JDBC driver from **42.4.4** to **42.7.11** on the `10.9.x` line to remediate **CVE-2026-42198** ([CVE-17326](https://confluentinc.atlassian.net/browse/CVE-17326), tracked under [CC-41166](https://confluentinc.atlassian.net/browse/CC-41166)).

[CVE-17326]: https://confluentinc.atlassian.net/browse/CVE-17326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-41166]: https://confluentinc.atlassian.net/browse/CC-41166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ