### PR TITLE
Remove timestamp.precision.mode from String-value config gating

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/RecordValidator.java
@@ -158,9 +158,6 @@ public interface RecordValidator {
     if (!config.timestampFieldsList.isEmpty()) {
       conflictingConfigs.add(JdbcSinkConfig.TIMESTAMP_FIELDS_LIST);
     }
-    if (config.originals().containsKey(JdbcSinkConfig.TIMESTAMP_PRECISION_MODE_CONFIG)) {
-      conflictingConfigs.add(JdbcSinkConfig.TIMESTAMP_PRECISION_MODE_CONFIG);
-    }
     if (conflictingConfigs.isEmpty()) {
       return;
     }

--- a/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/RecordValidatorTest.java
@@ -162,27 +162,10 @@ public class RecordValidatorTest {
   }
 
   @Test
-  public void stringValueWithExplicitTimestampPrecisionModeIsRejected() {
-    props.put("pk.mode", "none");
-    props.put("timestamp.precision.mode", "nanoseconds");
-    JdbcSinkConfig config = new JdbcSinkConfig(props);
-    RecordValidator validator = RecordValidator.create(config);
-
-    SinkRecord record = new SinkRecord(
-        "topic", 0, null, null, Schema.STRING_SCHEMA, "hello", 0
-    );
-
-    ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
-    assertTrue(e.getMessage().contains("timestamp.precision.mode"));
-    assertTrue(e.getMessage().contains("not applicable to String values"));
-  }
-
-  @Test
   public void stringValueWithAllIncompatibleConfigsIsRejectedWithAllConfigsNamed() {
     props.put("pk.mode", "none");
     props.put("fields.whitelist", "field_a");
     props.put("timestamp.fields.list", "created_at");
-    props.put("timestamp.precision.mode", "nanoseconds");
     JdbcSinkConfig config = new JdbcSinkConfig(props);
     RecordValidator validator = RecordValidator.create(config);
 
@@ -193,7 +176,6 @@ public class RecordValidatorTest {
     ConnectException e = assertThrows(ConnectException.class, () -> validator.validate(record));
     assertTrue(e.getMessage().contains("fields.whitelist"));
     assertTrue(e.getMessage().contains("timestamp.fields.list"));
-    assertTrue(e.getMessage().contains("timestamp.precision.mode"));
   }
 
   @Test
@@ -203,7 +185,6 @@ public class RecordValidatorTest {
     props.put("pk.mode", "none");
     props.put("fields.whitelist", "name");
     props.put("timestamp.fields.list", "created_at");
-    props.put("timestamp.precision.mode", "nanoseconds");
     JdbcSinkConfig config = new JdbcSinkConfig(props);
     RecordValidator validator = RecordValidator.create(config);
 


### PR DESCRIPTION
## Problem
Remove timestamp.precision.mode from String-value config gating

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
