### PR TITLE
Backport query validation fix to 10.8.x branch

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -80,7 +80,8 @@ public class JdbcSourceConnectorValidation {
       }
 
       boolean validationResult = validateMultiConfigs()
-          && validateLegacyNewConfigCompatibility();
+          && validateLegacyNewConfigCompatibility()
+          && validateQueryConfigs();
 
       if (validationResult && isUsingNewConfigs()) {
         validationResult = validateTableInclusionConfigs()
@@ -158,6 +159,12 @@ public class JdbcSourceConnectorValidation {
     // Define legacy and new config keys
     boolean usingLegacyConfigs = isUsingLegacyConfigs();
     boolean usingNewConfigs = isUsingNewConfigs();
+
+    // Query mode does not require any table filtering configs;
+    // their mutual exclusion is enforced separately in validateQueryConfigs().
+    if (isUsingQueryConfig()) {
+      return true;
+    }
 
     if (usingLegacyConfigs && usingNewConfigs) {
       return addConfigErrorsForLegacyAndNewConfigConflict();
@@ -440,6 +447,53 @@ public class JdbcSourceConnectorValidation {
         .filter(cv -> cv.name().equals(configName))
         .findFirst()
         .ifPresent(cv -> cv.addErrorMessage(errorMessage));
+  }
+
+  /**
+   * Validate that query mode is not combined with any table filtering configs.
+   * When query is set, table.whitelist / table.blacklist / table.include.list /
+   * table.exclude.list must not be specified.
+   */
+  private boolean validateQueryConfigs() {
+    if (!isUsingQueryConfig() || !isUsingTableFilteringConfigs()) {
+      return true;
+    }
+
+    String msg = "Do not specify table filtering configs with '"
+        + JdbcSourceConnectorConfig.QUERY_CONFIG + "'. "
+        + "Remove " + JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + " / "
+        + JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG + " / "
+        + JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG + " / "
+        + JdbcSourceConnectorConfig.TABLE_EXCLUDE_LIST_CONFIG
+        + " when using query mode, or remove '"
+        + JdbcSourceConnectorConfig.QUERY_CONFIG + "' when using table filtering mode.";
+    addConfigError(JdbcSourceConnectorConfig.QUERY_CONFIG, msg);
+    if (!config.getTableWhitelistSet().isEmpty()) {
+      addConfigError(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, msg);
+    }
+    if (!config.getTableBlacklistSet().isEmpty()) {
+      addConfigError(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG, msg);
+    }
+    if (!config.getTableIncludeListSet().isEmpty()) {
+      addConfigError(JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG, msg);
+    }
+    if (!config.getTableExcludeListSet().isEmpty()) {
+      addConfigError(JdbcSourceConnectorConfig.TABLE_EXCLUDE_LIST_CONFIG, msg);
+    }
+    log.error(msg);
+    return false;
+  }
+
+  private boolean isUsingQueryConfig() {
+    String query = config.getString(JdbcSourceConnectorConfig.QUERY_CONFIG);
+    return query != null && !query.isEmpty();
+  }
+
+  private boolean isUsingTableFilteringConfigs() {
+    return !config.getTableWhitelistSet().isEmpty()
+        || !config.getTableBlacklistSet().isEmpty()
+        || !config.getTableIncludeListSet().isEmpty()
+        || !config.getTableExcludeListSet().isEmpty();
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -770,12 +770,48 @@ public class JdbcSourceConnectorValidationTest {
     props.put(MODE_CONFIG, MODE_BULK);
     props.put(TABLE_INCLUDE_LIST_CONFIG, "database.schema.table.*");
     props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-    
+
     validate();
-    
+
     assertErrors(1);
     assertErrors(MODE_CONFIG, 1);
     assertErrorMatches(MODE_CONFIG, ".*Incrementing column configurations should not be provided.*");
   }
-  
+
+  @Test
+  public void validate_withOnlyQuery_noErrors() {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users WHERE active = true");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryAndTableWhitelist_setsError() {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users");
+    props.put(TABLE_WHITELIST_CONFIG, "table1,table2");
+
+    validate();
+
+    assertErrors(QUERY_CONFIG, 1);
+    assertErrors(TABLE_WHITELIST_CONFIG, 1);
+    assertErrorMatches(QUERY_CONFIG, ".*Do not specify table filtering configs with 'query'.*");
+  }
+
+  @Test
+  public void validate_withQueryAndTableIncludeList_setsError() {
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users");
+    props.put(TABLE_INCLUDE_LIST_CONFIG, "database.schema.table.*");
+
+    validate();
+
+    assertErrors(QUERY_CONFIG, 1);
+    assertErrors(TABLE_INCLUDE_LIST_CONFIG, 1);
+    assertErrorMatches(QUERY_CONFIG, ".*Do not specify table filtering configs with 'query'.*");
+  }
+
 }


### PR DESCRIPTION
## Problem
[CC-41506](https://confluentinc.atlassian.net/browse/CC-41506) -

After upgrading to `v10.8.5`, JDBC Source Connectors configured in query mode fail with the following validation error introduced by PR #1543 (https://github.com/confluentinc/kafka-connect-jdbc/pull/1543):

> At least one table filtering configuration is required. Provide one of:
> table.whitelist, table.blacklist, table.include.list, or table.exclude.list.

Since query mode operates independently of table filtering configurations, there is no valid combination of settings that satisfies both constraints simultaneously — rendering query mode connectors non-deployable after the upgrade. This is a breaking regression for all existing query mode deployments. See Issue #1591 (https://github.com/confluentinc/kafka-connect-jdbc/issues/1591).

## Solution

Updated `JdbcSourceConnectorValidation` to correctly handle query mode during config validation:

- Skip table filtering requirement when query is set — query mode does not use table filtering configs, so requiring them was incorrect.
- Enforce mutual exclusion — added a new `validateQueryConfigs()` method that surfaces a clear validation error if both query and any table filtering config (`table.whitelist` / `table.blacklist` / `table.include.list` / `table.exclude.list`) are specified simultaneously. This provides an actionable error at validation time rather than a ConnectException at connector startup.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
- Unit tests added for all validation scenarios: query only (pass), query + table filter (fail with clear error), table filter only (pass), neither (fail with existing error).
- Validated end-to-end against a local Confluent Platform deployment via the Connect REST API

<img width="1557" height="242" alt="image" src="https://github.com/user-attachments/assets/2c816c4f-9cf7-4578-8dad-67cbb004aa5b" />


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-41506]: https://confluentinc.atlassian.net/browse/CC-41506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ