### PR TITLE
CC-41005: honor trim.sensitive.log in JdbcDbWriter exception log sites

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.util.CachedConnectionProvider;
+import io.confluent.connect.jdbc.util.LogUtil;
 import io.confluent.connect.jdbc.util.TableId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,18 +87,23 @@ public class JdbcDbWriter {
       log.trace("Committing transaction");
       connection.commit();
     } catch (SQLException | TableAlterOrCreateException e) {
-      log.error("Error during write operation. Attempting rollback.", e);
+      log.error("Error during write operation. Attempting rollback.", maybeTrim(e));
       try {
         connection.rollback();
         log.info("Successfully rolled back transaction");
       } catch (SQLException sqle) {
-        log.error("Failed to rollback transaction", sqle);
+        log.error("Failed to rollback transaction", maybeTrim(sqle));
         e.addSuppressed(sqle);
       } finally {
         throw e;
       }
     }
     log.info("Completed write operation for {} records to the database", records.size());
+  }
+
+  Throwable maybeTrim(Throwable t) {
+    return (config.trimSensitiveLogsEnabled && t instanceof SQLException)
+        ? LogUtil.trimSensitiveData((SQLException) t) : t;
   }
 
   void closeQuietly() {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -98,6 +99,39 @@ public class JdbcDbWriterTest {
     public MockRollbackException() {
       super();
     }
+  }
+
+  @Test
+  public void maybeTrimReturnsExceptionAsIsWhenFlagDisabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("trim.sensitive.log", "false");
+    JdbcDbWriter writer = newWriter(props);
+    BatchUpdateException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
+            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
+            new int[0]);
+
+    Throwable result = writer.maybeTrim(exception);
+
+    assertSame(exception, result);
+    assertTrue(result.getMessage().contains("VALUES"));
+  }
+
+  @Test
+  public void maybeTrimRedactsBatchUpdateExceptionWhenFlagEnabled() {
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("trim.sensitive.log", "true");
+    JdbcDbWriter writer = newWriter(props);
+    BatchUpdateException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
+            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
+            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
+            new int[0]);
+
+    Throwable result = writer.maybeTrim(exception);
+
+    assertTrue(!result.getMessage().contains("VALUES"));
   }
 
   @Test


### PR DESCRIPTION
## Overview
Even though we this feature gated behind a cofig, it previously gated only `JdbcSinkTask`'s log sites, `JdbcDbWriter` was still logging the exception untrimmed, leaving a gap. (confirmed this locally on CP)

Apply `LogUtil.trimSensitiveData` to the two `log.error` sites in `JdbcDbWriter`'s write/rollback catch block (via a `maybeTrim` helper). 


## Verified via kafka-docker-playground

To force the `BatchpdateException`: 
1. We pre-created the `orders` table with a primary key on `id` and seeded one row (`id=1`). 
2. Configured the connector with `insert.mode=insert`, `pk.mode=record_value`, `pk.fields=id`, `batch.size=100`, then produced a Kafka record whose `id=1` collides with the seeded row. 
3. The Postgres JDBC driver fails the batch with a `BatchUpdateException` whose message includes the full `INSERT INTO ... VALUES (...)`, the leak shape this flag was designed to redact.

**Before** (`trim.sensitive.log` absent => default false):
```
java.sql.BatchUpdateException: Batch entry 0 INSERT INTO "postgres"."public"."orders" ("id","product","quantity","price") VALUES (('1'::int4),('LEAK_CANARY_PIIPIIPII_42'),('1'::int4),('9.99'::real)) was aborted: ERROR: duplicate key value violates unique constraint "orders_pkey"
```

**After** (`trim.sensitive.log=true`):
```
java.sql.BatchUpdateException: Batch entry 0 INSERT INTO "postgres"."public"."orders" ("id","product","quantity","price"): ERROR: duplicate key value violates unique constraint "orders_pkey"
```

| trim.sensitive.log | value occurrences in log |
|---|---|
| absent/false | 7 |
| true   | 0 |