### PR TITLE
Update Query Validation to use getMetadata method instead of EXPLAIN PLAN mechanism

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -707,20 +707,20 @@ public interface DatabaseDialect extends ConnectionProvider {
   String resolveSynonym(Connection connection, String synonymName) throws SQLException;
 
   /**
-   * Validate the given SQL query against the database without executing it.
-   * This method verifies that the query is valid by checking table and column existence,
-   * user permissions, and SQL correctness using database-specific mechanisms such as
-   * {@code EXPLAIN} or {@code prepareStatement}.
+   * Validate the user-supplied SQL without scanning user data. Implementations
+   * should ask the driver to compile the query (parse, resolve objects, check
+   * types, verify {@code SELECT} permission) so that any problem surfaces as a
+   * {@link SQLException}.
+   *
+   * <p>The user query must be passed through unmodified, which avoids the false
+   * positives that wrap-based probes suffer from (top-level {@code ORDER BY}
+   * on SQL Server, duplicate columns from {@code SELECT *} over JOINs,
+   * unaliased computed columns, {@code FOR UPDATE}, and so on).
    *
    * @param connection the database connection; may not be null
    * @param query      the SQL query to validate; may not be null
-   * @throws SQLException if the query is invalid, references non-existent tables or columns,
-   *                      or the user lacks necessary permissions
+   * @throws SQLException if the query is invalid, references missing tables or columns,
+   *                      or the user lacks {@code SELECT} permission
    */
-  default void validateQuery(Connection connection, String query) throws SQLException {
-    try (PreparedStatement stmt = connection.prepareStatement(query)) {
-        // Validate the query by preparing it. If the query is invalid,
-        // an SQLException will be thrown which will indicate the validation failure.
-    }
-  }
+  void validateQuery(Connection connection, String query) throws SQLException;
 }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -707,20 +707,17 @@ public interface DatabaseDialect extends ConnectionProvider {
   String resolveSynonym(Connection connection, String synonymName) throws SQLException;
 
   /**
-   * Validate the user-supplied SQL without scanning user data. Implementations
-   * should ask the driver to compile the query (parse, resolve objects, check
-   * types, verify {@code SELECT} permission) so that any problem surfaces as a
-   * {@link SQLException}.
-   *
-   * <p>The user query must be passed through unmodified, which avoids the false
-   * positives that wrap-based probes suffer from (top-level {@code ORDER BY}
-   * on SQL Server, duplicate columns from {@code SELECT *} over JOINs,
-   * unaliased computed columns, {@code FOR UPDATE}, and so on).
+   * Validate the SQL query by compiling it via {@link PreparedStatement#getMetaData()}
+   * without scanning user data.
    *
    * @param connection the database connection; may not be null
    * @param query      the SQL query to validate; may not be null
    * @throws SQLException if the query is invalid, references missing tables or columns,
    *                      or the user lacks {@code SELECT} permission
    */
-  void validateQuery(Connection connection, String query) throws SQLException;
+  default void validateQuery(Connection connection, String query) throws SQLException {
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      stmt.getMetaData();
+    }
+  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -707,8 +707,15 @@ public interface DatabaseDialect extends ConnectionProvider {
   String resolveSynonym(Connection connection, String synonymName) throws SQLException;
 
   /**
-   * Validate the SQL query by compiling it via {@link PreparedStatement#getMetaData()}
-   * without scanning user data.
+   * Validate the SQL query by asking the driver to compile it via
+   * {@link PreparedStatement#getMetaData()}, which surfaces syntax, missing-object
+   * and permission errors without scanning user data. The query is passed through
+   * unmodified to avoid false positives from rewrites (e.g. top-level {@code ORDER BY},
+   * duplicate columns from {@code SELECT *} over JOINs).
+   *
+   * <p>Kept as a {@code default} so out-of-tree dialects implementing this interface
+   * directly continue to work; {@link GenericDatabaseDialect} overrides it to add a
+   * query timeout.
    *
    * @param connection the database connection; may not be null
    * @param query      the SQL query to validate; may not be null

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -116,6 +116,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected static final int NUMERIC_TYPE_SCALE_HIGH = 127;
   protected static final int NUMERIC_TYPE_SCALE_UNSET = -127;
 
+  // Bounds the getMetaData() compile round-trip during query validation; drivers
+  // honour setQueryTimeout() best-effort, guarding against slow planners.
   private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
 
   // The maximum precision that can be achieved in a signed 64-bit integer is 2^63 ~= 9.223372e+18
@@ -1948,6 +1950,10 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       List<ColumnId> columns
   ) throws ConnectException { }
 
+  /**
+   * Validates the query via {@link PreparedStatement#getMetaData()}, bounded by a
+   * query timeout. See {@link DatabaseDialect#validateQuery(Connection, String)}.
+   */
   @Override
   public void validateQuery(Connection connection, String query) throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(query)) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -116,13 +116,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected static final int NUMERIC_TYPE_SCALE_HIGH = 127;
   protected static final int NUMERIC_TYPE_SCALE_UNSET = -127;
 
-  /**
-   * Upper bound, in seconds, on the time the driver is allowed to spend
-   * compiling the query for {@link #validateQuery(Connection, String)}. Drivers
-   * honour {@link PreparedStatement#setQueryTimeout(int)} on a best-effort basis
-   * for {@code getMetaData()}; this guards against pathologically slow planners
-   * stalling config validation.
-   */
   private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
 
   // The maximum precision that can be achieved in a signed 64-bit integer is 2^63 ~= 9.223372e+18
@@ -1955,18 +1948,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       List<ColumnId> columns
   ) throws ConnectException { }
 
-  /**
-   * Validate the user-supplied SQL by asking the driver to describe its result-set
-   * shape via {@link PreparedStatement#getMetaData()}. Every supported driver
-   * services this call by having the database compile the query (parse, resolve
-   * objects, check types, verify {@code SELECT} permission), so any problem
-   * surfaces as a {@link SQLException} without the rows being scanned.
-   *
-   * <p>The user query is passed through unmodified, which avoids the false
-   * positives that wrap-based probes suffer from (top-level {@code ORDER BY}
-   * on SQL Server, duplicate columns from {@code SELECT *} over JOINs,
-   * unaliased computed columns, {@code FOR UPDATE}, and so on).
-   */
   @Override
   public void validateQuery(Connection connection, String query) throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(query)) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -116,6 +116,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   protected static final int NUMERIC_TYPE_SCALE_HIGH = 127;
   protected static final int NUMERIC_TYPE_SCALE_UNSET = -127;
 
+  /**
+   * Upper bound, in seconds, on the time the driver is allowed to spend
+   * compiling the query for {@link #validateQuery(Connection, String)}. Drivers
+   * honour {@link PreparedStatement#setQueryTimeout(int)} on a best-effort basis
+   * for {@code getMetaData()}; this guards against pathologically slow planners
+   * stalling config validation.
+   */
+  private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
+
   // The maximum precision that can be achieved in a signed 64-bit integer is 2^63 ~= 9.223372e+18
   private static final int MAX_INTEGER_TYPE_PRECISION = 18;
 
@@ -1947,16 +1956,22 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   ) throws ConnectException { }
 
   /**
-   * The default implementation uses {@link Connection#prepareStatement(String)} which
-   * compiles the SQL without executing it. This validates syntax, table/column existence,
-   * and user permissions on most databases. Subclasses should override this method to use
-   * database-specific mechanisms like {@code EXPLAIN} for more thorough validation.
+   * Validate the user-supplied SQL by asking the driver to describe its result-set
+   * shape via {@link PreparedStatement#getMetaData()}. Every supported driver
+   * services this call by having the database compile the query (parse, resolve
+   * objects, check types, verify {@code SELECT} permission), so any problem
+   * surfaces as a {@link SQLException} without the rows being scanned.
+   *
+   * <p>The user query is passed through unmodified, which avoids the false
+   * positives that wrap-based probes suffer from (top-level {@code ORDER BY}
+   * on SQL Server, duplicate columns from {@code SELECT *} over JOINs,
+   * unaliased computed columns, {@code FOR UPDATE}, and so on).
    */
   @Override
   public void validateQuery(Connection connection, String query) throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(query)) {
-      glog.trace("Query validation successful for '{}'",
-          shouldRedactSensitiveLogs(query));
+      stmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
+      stmt.getMetaData();
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -26,7 +26,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -214,13 +213,4 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
     throw new SQLException("MySQL does not support synonyms. Please use views instead.");
   }
 
-  @Override
-  public void validateQuery(Connection connection, String query) throws SQLException {
-    String explainQuery = "EXPLAIN " + query;
-    try (Statement stmt = connection.createStatement()) {
-      stmt.execute(explainQuery);
-      log.trace("Query validation successful for '{}'",
-          shouldRedactSensitiveLogs(query));
-    }
-  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -31,7 +31,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Types;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -426,22 +425,4 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
     return null;
   }
 
-  @Override
-  public void validateQuery(Connection connection, String query) throws SQLException {
-    // Use EXPLAIN PLAN FOR to validate, fallback to prepareStatement if PLAN_TABLE missing
-    String explainQuery = "EXPLAIN PLAN FOR " + query;
-    try (Statement stmt = connection.createStatement()) {
-      stmt.execute(explainQuery);
-      log.trace("Query validation successful for '{}'",
-          shouldRedactSensitiveLogs(query));
-    } catch (SQLException e) {
-      // ORA-02404: specified plan table not found - fall back to prepareStatement
-      if (e.getErrorCode() == 2404) {
-        log.trace("Query validation failed,falling back to prepareStatement validation");
-        super.validateQuery(connection, query);
-      } else {
-        throw e;
-      }
-    }
-  }
 }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -44,7 +44,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
@@ -701,17 +700,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
 
     return defn.scale();
-  }
-
-  @Override
-  public void validateQuery(Connection connection, String query) throws SQLException {
-    // Use EXPLAIN to validate query syntax and metadata without executing
-    String explainQuery = "EXPLAIN " + query;
-    try (Statement stmt = connection.createStatement()) {
-      stmt.execute(explainQuery);
-      log.trace("Query validation successful for '{}'",
-          shouldRedactSensitiveLogs(query));
-    }
   }
 
 }

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -390,6 +390,8 @@ public class JdbcSourceConnectorValidation {
       String msg = "The configured query is not valid and has database/connection errors"
           + ". Please provide the correct query by validating the "
           + "query syntax and the existing table/column names with the database being connected";
+      // Append SQLState and vendor errorCode when present so the user can look up
+      // the exact cause; errorCode 0 is the JDBC default for "unset" and is omitted.
       String sqlState = e.getSQLState();
       int errorCode = e.getErrorCode();
       if (sqlState != null && errorCode != 0) {

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -25,9 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.SQLTimeoutException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +44,6 @@ public class JdbcSourceConnectorValidation {
   private static final Logger log = LoggerFactory.getLogger(JdbcSourceConnectorValidation.class);
   private static final Pattern SELECT_STATEMENT_PATTERN =
       Pattern.compile("(?is)^SELECT\\b");
-  private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
   protected JdbcSourceConnectorConfig config;
   protected Config validationResult;
   private final Map<String, String> connectorConfigs;
@@ -365,10 +362,11 @@ public class JdbcSourceConnectorValidation {
   }
 
   /**
-   * Validate the user's custom query against the database by performing a lightweight
-   * semantic check using the database-specific EXPLAIN mechanism. This validates:
+   * Validate the user query via the dialect. Surfaces syntax, missing-object,
+   * and {@code SELECT}-permission errors without scanning user data.
    *
-   * @return true if validation passes or no query is configured, false if validation fails
+   * @return {@code true} if validation passes or no query is configured;
+   *         {@code false} on {@link SQLException}
    */
   protected boolean validateQuerySemantics() {
     Optional<String> queryVal = config.getQuery();
@@ -385,27 +383,21 @@ public class JdbcSourceConnectorValidation {
     try {
       dialect = createDialect();
       try (Connection connection = dialect.getConnection()) {
-        // The shadow probe must run regardless of the primary outcome, so it
-        // is invoked from the finally block; the original SQLException (if
-        // any) propagates afterwards to the outer catch.
-        boolean primarySucceeded = false;
-        try {
-          dialect.validateQuery(connection, query);
-          primarySucceeded = true;
-        } finally {
-          runGetMetaDataShadowProbe(
-              connection, query,
-              dialect.getClass().getSimpleName(),
-              primarySucceeded);
-        }
+        dialect.validateQuery(connection, query);
       }
       return true;
     } catch (SQLException e) {
       String msg = "The configured query is not valid and has database/connection errors"
           + ". Please provide the correct query by validating the "
           + "query syntax and the existing table/column names with the database being connected";
-      if (e.getSQLState() != null) {
-        msg += " (SQLState: " + e.getSQLState() + ")";
+      String sqlState = e.getSQLState();
+      int errorCode = e.getErrorCode();
+      if (sqlState != null && errorCode != 0) {
+        msg += " (SQLState: " + sqlState + ", errorCode: " + errorCode + ")";
+      } else if (sqlState != null) {
+        msg += " (SQLState: " + sqlState + ")";
+      } else if (errorCode != 0) {
+        msg += " (errorCode: " + errorCode + ")";
       }
       addConfigError(configKey, msg);
       return false;
@@ -416,50 +408,6 @@ public class JdbcSourceConnectorValidation {
       if (dialect != null) {
         dialect.close();
       }
-    }
-  }
-
-  /**
-   * Shadow probe via {@link PreparedStatement#getMetaData()} on the same
-   * connection used for the primary validation. Never throws — failures are
-   * caught and logged at {@code WARN} with non-sensitive metadata only
-   * (dialect, SQLState, vendor error code, duration, primary outcome); the
-   * query text and the driver's exception message are deliberately omitted.
-   * Bounded by {@link PreparedStatement#setQueryTimeout(int)}, which drivers
-   * honour on a best-effort basis for {@code getMetaData()}.
-   */
-  private void runGetMetaDataShadowProbe(
-      Connection connection,
-      String query,
-      String dialectName,
-      boolean primarySucceeded
-  ) {
-    long startMs = System.currentTimeMillis();
-    try (PreparedStatement stmt = connection.prepareStatement(query)) {
-      stmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
-      stmt.getMetaData();
-    } catch (SQLTimeoutException e) {
-      log.warn(
-          "Query validation getMetaData() probe timed out "
-              + "[dialect={}, primarySucceeded={}, timeoutSeconds={}, durationMs={}]",
-          dialectName, primarySucceeded, VALIDATE_QUERY_TIMEOUT_SECONDS,
-          System.currentTimeMillis() - startMs);
-    } catch (SQLException e) {
-      log.warn(
-          "Query validation getMetaData() probe failed "
-              + "[dialect={}, primarySucceeded={}, sqlState={}, errorCode={}, "
-              + "durationMs={}]",
-          dialectName, primarySucceeded,
-          e.getSQLState() == null ? "null" : e.getSQLState(),
-          e.getErrorCode(),
-          System.currentTimeMillis() - startMs);
-    } catch (Exception e) {
-      log.warn(
-          "Query validation getMetaData() probe failed unexpectedly "
-              + "[dialect={}, primarySucceeded={}, causeClass={}, durationMs={}]",
-          dialectName, primarySucceeded,
-          e.getClass().getSimpleName(),
-          System.currentTimeMillis() - startMs);
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -741,6 +741,8 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   }
 
   // ========== validateQuery Tests ==========
+  // Validation delegates to PreparedStatement.getMetaData() with the query passed
+  // through unmodified, bounded by a query timeout.
   private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -32,6 +32,7 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -740,35 +741,134 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   }
 
   // ========== validateQuery Tests ==========
+  // Validation delegates to PreparedStatement.getMetaData(), which on every
+  // supported JDBC driver forces a server round-trip that compiles the query
+  // (parse + object resolution + type check + permission check). The user
+  // query is passed through unmodified -- no derived-table wrap, so there are
+  // no false positives from top-level ORDER BY, JOIN duplicate columns,
+  // unaliased computed columns, FOR UPDATE, etc. A 60-second query timeout
+  // guards against a pathologically slow planner stalling config validation.
+  private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
 
   @Test
-  public void validateQuery_shouldUsePrepareStatement() throws SQLException {
+  public void validateQuery_shouldDelegateToGetMetaData() throws SQLException {
     Connection mockConnection = EasyMock.createMock(Connection.class);
     PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
-    expect(mockConnection.prepareStatement("SELECT * FROM users")).andReturn(mockStmt);
+    ResultSetMetaData mockMd = EasyMock.createNiceMock(ResultSetMetaData.class);
+    String query = "SELECT * FROM users";
+
+    expect(mockConnection.prepareStatement(query)).andReturn(mockStmt);
+    mockStmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
+    EasyMock.expectLastCall();
+    expect(mockStmt.getMetaData()).andReturn(mockMd);
+    mockStmt.close();
+    EasyMock.expectLastCall();
+    replay(mockConnection, mockStmt, mockMd);
+
+    dialect.validateQuery(mockConnection, query);
+
+    verify(mockConnection, mockStmt, mockMd);
+  }
+
+  @Test
+  public void validateQuery_shouldApplyQueryTimeoutBeforeMetaDataCall()
+      throws SQLException {
+    // The timeout is set on the PreparedStatement before getMetaData() so the
+    // driver bounds the compile round-trip; this guards config validation
+    // against planners that stall on pathological queries.
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
+    ResultSetMetaData mockMd = EasyMock.createNiceMock(ResultSetMetaData.class);
+    String query = "SELECT * FROM users";
+
+    EasyMock.checkOrder(mockStmt, true);
+    expect(mockConnection.prepareStatement(query)).andReturn(mockStmt);
+    mockStmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
+    EasyMock.expectLastCall();
+    expect(mockStmt.getMetaData()).andReturn(mockMd);
+    mockStmt.close();
+    EasyMock.expectLastCall();
+    replay(mockConnection, mockStmt, mockMd);
+
+    dialect.validateQuery(mockConnection, query);
+
+    verify(mockConnection, mockStmt, mockMd);
+  }
+
+  @Test
+  public void validateQuery_shouldPropagateSqlExceptionFromGetMetaData()
+      throws SQLException {
+    // When the user query references a missing table or is otherwise invalid,
+    // getMetaData() throws SQLException; the exception must propagate.
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
+    String query = "SELECT * FROM nonexistent";
+
+    expect(mockConnection.prepareStatement(query)).andReturn(mockStmt);
+    mockStmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
+    EasyMock.expectLastCall();
+    expect(mockStmt.getMetaData())
+        .andThrow(new SQLException("table not found", "42S02"));
     mockStmt.close();
     EasyMock.expectLastCall();
     replay(mockConnection, mockStmt);
 
-    dialect.validateQuery(mockConnection, "SELECT * FROM users");
-
-    verify(mockConnection, mockStmt);
-  }
-
-  @Test
-  public void validateQuery_shouldPropagateExceptionForInvalidQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    expect(mockConnection.prepareStatement("SELECT * FROM nonexistent"))
-        .andThrow(new SQLException("table not found", "42S02"));
-    replay(mockConnection);
-
     try {
-      dialect.validateQuery(mockConnection, "SELECT * FROM nonexistent");
+      dialect.validateQuery(mockConnection, query);
       org.junit.Assert.fail("Expected SQLException to be thrown");
     } catch (SQLException e) {
       assertEquals("42S02", e.getSQLState());
     }
 
+    verify(mockConnection, mockStmt);
+  }
+
+  @Test
+  public void validateQuery_shouldPropagateSqlExceptionFromPrepareStatement()
+      throws SQLException {
+    // Some drivers (e.g. Oracle) reject malformed SQL at prepareStatement;
+    // others (e.g. MS SQL Server) defer until getMetaData. The dialect must
+    // surface either path's SQLException unchanged.
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    String query = "SELECT FROM";
+
+    expect(mockConnection.prepareStatement(query))
+        .andThrow(new SQLException("ORA-00936: missing expression", "42000", 936));
+    replay(mockConnection);
+
+    try {
+      dialect.validateQuery(mockConnection, query);
+      org.junit.Assert.fail("Expected SQLException to be thrown");
+    } catch (SQLException e) {
+      assertEquals("42000", e.getSQLState());
+      assertEquals(936, e.getErrorCode());
+    }
+
     verify(mockConnection);
+  }
+
+  @Test
+  public void validateQuery_shouldPassQueryThroughUnmodified() throws SQLException {
+    // Critical: the user's SQL must reach prepareStatement byte-for-byte, with
+    // no derived-table wrap or other rewrite. This guards forms that wrap-based
+    // probes break (top-level ORDER BY, duplicate columns from SELECT * over
+    // JOIN, unaliased computed columns).
+    Connection mockConnection = EasyMock.createMock(Connection.class);
+    PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
+    ResultSetMetaData mockMd = EasyMock.createNiceMock(ResultSetMetaData.class);
+    String complexQuery = "SELECT a.id, b.name FROM users a "
+        + "INNER JOIN orders b ON a.id = b.user_id ORDER BY a.id";
+
+    expect(mockConnection.prepareStatement(complexQuery)).andReturn(mockStmt);
+    mockStmt.setQueryTimeout(VALIDATE_QUERY_TIMEOUT_SECONDS);
+    EasyMock.expectLastCall();
+    expect(mockStmt.getMetaData()).andReturn(mockMd);
+    mockStmt.close();
+    EasyMock.expectLastCall();
+    replay(mockConnection, mockStmt, mockMd);
+
+    dialect.validateQuery(mockConnection, complexQuery);
+
+    verify(mockConnection, mockStmt, mockMd);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -741,13 +741,6 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   }
 
   // ========== validateQuery Tests ==========
-  // Validation delegates to PreparedStatement.getMetaData(), which on every
-  // supported JDBC driver forces a server round-trip that compiles the query
-  // (parse + object resolution + type check + permission check). The user
-  // query is passed through unmodified -- no derived-table wrap, so there are
-  // no false positives from top-level ORDER BY, JOIN duplicate columns,
-  // unaliased computed columns, FOR UPDATE, etc. A 60-second query timeout
-  // guards against a pathologically slow planner stalling config validation.
   private static final int VALIDATE_QUERY_TIMEOUT_SECONDS = 60;
 
   @Test
@@ -773,9 +766,6 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   @Test
   public void validateQuery_shouldApplyQueryTimeoutBeforeMetaDataCall()
       throws SQLException {
-    // The timeout is set on the PreparedStatement before getMetaData() so the
-    // driver bounds the compile round-trip; this guards config validation
-    // against planners that stall on pathological queries.
     Connection mockConnection = EasyMock.createMock(Connection.class);
     PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
     ResultSetMetaData mockMd = EasyMock.createNiceMock(ResultSetMetaData.class);
@@ -798,8 +788,6 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   @Test
   public void validateQuery_shouldPropagateSqlExceptionFromGetMetaData()
       throws SQLException {
-    // When the user query references a missing table or is otherwise invalid,
-    // getMetaData() throws SQLException; the exception must propagate.
     Connection mockConnection = EasyMock.createMock(Connection.class);
     PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
     String query = "SELECT * FROM nonexistent";
@@ -826,9 +814,6 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   @Test
   public void validateQuery_shouldPropagateSqlExceptionFromPrepareStatement()
       throws SQLException {
-    // Some drivers (e.g. Oracle) reject malformed SQL at prepareStatement;
-    // others (e.g. MS SQL Server) defer until getMetaData. The dialect must
-    // surface either path's SQLException unchanged.
     Connection mockConnection = EasyMock.createMock(Connection.class);
     String query = "SELECT FROM";
 
@@ -849,10 +834,6 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
   @Test
   public void validateQuery_shouldPassQueryThroughUnmodified() throws SQLException {
-    // Critical: the user's SQL must reach prepareStatement byte-for-byte, with
-    // no derived-table wrap or other rewrite. This guards forms that wrap-based
-    // probes break (top-level ORDER BY, duplicate columns from SELECT * over
-    // JOIN, unaliased computed columns).
     Connection mockConnection = EasyMock.createMock(Connection.class);
     PreparedStatement mockStmt = EasyMock.createMock(PreparedStatement.class);
     ResultSetMetaData mockMd = EasyMock.createNiceMock(ResultSetMetaData.class);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -23,11 +23,6 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import org.easymock.EasyMock;
-
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
@@ -261,50 +256,6 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
     );
   }
 
-  // ========== validateQuery Tests ==========
-
-  @Test
-  public void validateQuery_shouldExecuteExplainQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    EasyMock.expect(mockStatement.execute("EXPLAIN SELECT * FROM users")).andReturn(true);
-
-    EasyMock.replay(mockConnection, mockStatement);
-    dialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.verify(mockConnection, mockStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldPropagateExceptionForInvalidTable() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    EasyMock.expect(mockStatement.execute("EXPLAIN SELECT * FROM nonexistent_table"))
-        .andThrow(new SQLException(
-            "Table 'mydb.nonexistent_table' doesn't exist", "42S02"));
-
-    EasyMock.replay(mockConnection, mockStatement);
-    try {
-      dialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
-      org.junit.Assert.fail("Expected SQLException to be thrown");
-    } catch (SQLException e) {
-      assertEquals("42S02", e.getSQLState());
-    }
-    EasyMock.verify(mockConnection, mockStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldWorkWithComplexQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    String complexQuery = "SELECT a.id, b.name FROM users a "
-        + "INNER JOIN orders b ON a.id = b.user_id";
-    EasyMock.expect(mockStatement.execute("EXPLAIN " + complexQuery)).andReturn(true);
-
-    EasyMock.replay(mockConnection, mockStatement);
-    dialect.validateQuery(mockConnection, complexQuery);
-    EasyMock.verify(mockConnection, mockStatement);
-  }
+  // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
+  // GenericDatabaseDialectTest; no MySQL-specific override exists to test here.
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -21,8 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.sql.Connection;
-import java.sql.Statement;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -41,7 +39,6 @@ import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import oracle.jdbc.OraclePreparedStatement;
-import org.easymock.EasyMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -477,73 +474,6 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
     dialect.bindField(statement, index, schema, value, colDef, field);
     return verify(statement, times(1));
 }
-  // ========== validateQuery Tests ==========
-
-  @Test
-  public void validateQuery_shouldExecuteExplainPlanFor() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    EasyMock.expect(mockStatement.execute("EXPLAIN PLAN FOR SELECT * FROM users"))
-        .andReturn(true);
-
-    EasyMock.replay(mockConnection, mockStatement);
-    dialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.verify(mockConnection, mockStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldPropagateExceptionForInvalidTable() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    EasyMock.expect(mockStatement.execute("EXPLAIN PLAN FOR SELECT * FROM nonexistent_table"))
-        .andThrow(new SQLException(
-            "ORA-00942: table or view does not exist", "42000", 942));
-
-    EasyMock.replay(mockConnection, mockStatement);
-    try {
-      dialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
-      org.junit.Assert.fail("Expected SQLException to be thrown");
-    } catch (SQLException e) {
-      assertEquals("42000", e.getSQLState());
-      assertEquals(942, e.getErrorCode());
-    }
-    EasyMock.verify(mockConnection, mockStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldFallbackToPrepareStatementWhenPlanTableMissing()
-      throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    PreparedStatement mockPreparedStatement = EasyMock.createNiceMock(PreparedStatement.class);
-
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    // ORA-02404: specified plan table not found
-    EasyMock.expect(mockStatement.execute("EXPLAIN PLAN FOR SELECT * FROM users"))
-        .andThrow(new SQLException(
-            "ORA-02404: specified plan table not found", "42000", 2404));
-    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
-        .andReturn(mockPreparedStatement);
-
-    EasyMock.replay(mockConnection, mockStatement, mockPreparedStatement);
-    dialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.verify(mockConnection, mockStatement, mockPreparedStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldWorkWithComplexQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    String complexQuery = "SELECT a.id, b.name FROM users a "
-        + "INNER JOIN orders b ON a.id = b.user_id";
-    EasyMock.expect(mockStatement.execute("EXPLAIN PLAN FOR " + complexQuery))
-        .andReturn(true);
-
-    EasyMock.replay(mockConnection, mockStatement);
-    dialect.validateQuery(mockConnection, complexQuery);
-    EasyMock.verify(mockConnection, mockStatement);
-  }
+  // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
+  // GenericDatabaseDialectTest; no Oracle-specific override exists to test here.
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.easymock.EasyMock;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
@@ -652,51 +651,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
 
-  // ========== validateQuery Tests ==========
-
-  @Test
-  public void validateQuery_shouldExecuteExplainQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    EasyMock.expect(mockStatement.execute("EXPLAIN SELECT * FROM users")).andReturn(true);
-
-    EasyMock.replay(mockConnection, mockStatement);
-    dialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.verify(mockConnection, mockStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldPropagateExceptionForInvalidTable() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    EasyMock.expect(mockStatement.execute("EXPLAIN SELECT * FROM nonexistent_table"))
-        .andThrow(new SQLException(
-            "relation \"nonexistent_table\" does not exist", "42P01"));
-
-    EasyMock.replay(mockConnection, mockStatement);
-    try {
-      dialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
-      org.junit.Assert.fail("Expected SQLException to be thrown");
-    } catch (SQLException e) {
-      assertEquals("42P01", e.getSQLState());
-    }
-    EasyMock.verify(mockConnection, mockStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldWorkWithComplexQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    Statement mockStatement = EasyMock.createNiceMock(Statement.class);
-    EasyMock.expect(mockConnection.createStatement()).andReturn(mockStatement);
-    String complexQuery = "SELECT a.id, b.name FROM users a "
-        + "INNER JOIN orders b ON a.id = b.user_id";
-    EasyMock.expect(mockStatement.execute("EXPLAIN " + complexQuery)).andReturn(true);
-
-    EasyMock.replay(mockConnection, mockStatement);
-    dialect.validateQuery(mockConnection, complexQuery);
-    EasyMock.verify(mockConnection, mockStatement);
-  }
+  // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
+  // GenericDatabaseDialectTest; no PostgreSQL-specific override exists to test here.
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -18,8 +18,6 @@ package io.confluent.connect.jdbc.dialect;
 import java.sql.CallableStatement;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
-import java.sql.Statement;
-import java.sql.Connection;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -44,7 +42,6 @@ import org.junit.Test;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 import org.mockito.Mockito;
-import org.easymock.EasyMock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -494,54 +491,6 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
     verify(stmtNvarchar, times(1)).setNString(index, value);
   }
 
-  @Test
-  public void validateQuery_shouldUseGenericPreparedStatement() throws SQLException {
-    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
-    PreparedStatement mockPreparedStatement = EasyMock.createNiceMock(PreparedStatement.class);
-    String query = "SELECT * FROM users";
-
-    EasyMock.expect(mockConnection.prepareStatement(query)).andReturn(mockPreparedStatement);
-    mockPreparedStatement.close();
-    EasyMock.expectLastCall();
-
-    EasyMock.replay(mockConnection, mockPreparedStatement);
-    dialect.validateQuery(mockConnection, query);
-    EasyMock.verify(mockConnection, mockPreparedStatement);
-  }
-
-  @Test
-  public void validateQuery_shouldThrowOnInvalidQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
-    PreparedStatement mockPreparedStatement = EasyMock.createNiceMock(PreparedStatement.class);
-    String query = "SELECT * FROM nonexistent_table";
-
-    EasyMock.expect(mockConnection.prepareStatement(query))
-        .andThrow(new SQLException(
-            "Invalid object name 'nonexistent_table'.", "S0002"));
-
-    EasyMock.replay(mockConnection, mockPreparedStatement);
-    try {
-      dialect.validateQuery(mockConnection, query);
-      org.junit.Assert.fail("Expected SQLException to be thrown");
-    } catch (SQLException e) {
-      assertEquals("S0002", e.getSQLState());
-    }
-    EasyMock.verify(mockConnection);
-  }
-
-  @Test
-  public void validateQuery_shouldWorkWithComplexQuery() throws SQLException {
-    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
-    PreparedStatement mockPreparedStatement = EasyMock.createNiceMock(PreparedStatement.class);
-    String complexQuery = "SELECT a.id, b.name FROM users a "
-        + "INNER JOIN orders b ON a.id = b.user_id";
-
-    EasyMock.expect(mockConnection.prepareStatement(complexQuery)).andReturn(mockPreparedStatement);
-    mockPreparedStatement.close();
-    EasyMock.expectLastCall();
-
-    EasyMock.replay(mockConnection, mockPreparedStatement);
-    dialect.validateQuery(mockConnection, complexQuery);
-    EasyMock.verify(mockConnection, mockPreparedStatement);
-  }
+  // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
+  // GenericDatabaseDialectTest; no SQL Server-specific override exists to test here.
 }

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import java.util.HashMap;
@@ -33,6 +32,7 @@ import com.google.re2j.Pattern;
 
 import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.easymock.EasyMock;
 
@@ -1254,8 +1254,78 @@ public class JdbcSourceConnectorValidationTest {
 
     assertErrors(QUERY_CONFIG, 1);
     ConfigValue queryConfigValue = valueFor(QUERY_CONFIG);
-    assertTrue(queryConfigValue.errorMessages().get(0).contains("not valid"));
-    assertTrue(queryConfigValue.errorMessages().get(0).contains("SQLState: 42S02"));
+    String errorMessage = queryConfigValue.errorMessages().get(0);
+    assertTrue(errorMessage.contains("not valid"));
+    assertTrue(errorMessage.contains("SQLState: 42S02"));
+    // Vendor errorCode defaults to 0 when the 2-arg SQLException constructor
+    // is used; the formatter must omit it in that case rather than emit
+    // "errorCode: 0", which would be misleading noise.
+    assertFalse(errorMessage.contains("errorCode"));
+  }
+
+  @Test
+  public void validate_semanticValidationErrorIncludesErrorCodeWhenPresent()
+      throws Exception {
+    // When the driver populates both SQLState and the vendor errorCode (typical
+    // for Oracle ORA-942, SQL Server 208, MySQL 1146), both must appear in the
+    // user-facing message so the user can look up the exact error.
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM nonexistent_table");
+
+    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
+
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
+    EasyMock.expectLastCall().andThrow(new SQLException(
+        "Invalid object name 'nonexistent_table'.", "S0002", 208));
+    mockConnection.close();
+    EasyMock.expectLastCall();
+    mockDialect.close();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockDialect, mockConnection);
+    validateWithMockDialect(mockDialect);
+    EasyMock.verify(mockDialect, mockConnection);
+
+    assertErrors(QUERY_CONFIG, 1);
+    String errorMessage = valueFor(QUERY_CONFIG).errorMessages().get(0);
+    assertTrue(errorMessage.contains("not valid"));
+    assertTrue(errorMessage.contains("SQLState: S0002"));
+    assertTrue(errorMessage.contains("errorCode: 208"));
+  }
+
+  @Test
+  public void validate_semanticValidationErrorIncludesErrorCodeAloneWhenSqlStateMissing()
+      throws Exception {
+    // Some drivers throw with a vendor errorCode but no SQLState (e.g. Oracle
+    // network failures, MySQL connection-time errors). The user-facing message
+    // must still include the errorCode so the user has at least one identifier
+    // to grep their driver docs against.
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM users");
+
+    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
+
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
+    EasyMock.expectLastCall().andThrow(new SQLException(
+        "ORA-17002: I/O Error: Connection reset", null, 17002));
+    mockConnection.close();
+    EasyMock.expectLastCall();
+    mockDialect.close();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockDialect, mockConnection);
+    validateWithMockDialect(mockDialect);
+    EasyMock.verify(mockDialect, mockConnection);
+
+    assertErrors(QUERY_CONFIG, 1);
+    String errorMessage = valueFor(QUERY_CONFIG).errorMessages().get(0);
+    assertTrue(errorMessage.contains("not valid"));
+    assertTrue(errorMessage.contains("errorCode: 17002"));
+    assertFalse(errorMessage.contains("SQLState"));
   }
 
   @Test
@@ -1315,78 +1385,6 @@ public class JdbcSourceConnectorValidationTest {
     EasyMock.verify(mockDialect, mockConnection);
 
     assertNoErrors();
-  }
-
-  // ========== getMetaData() Shadow Probe Tests ==========
-  // The probe is invoked from validateQuerySemantics' finally block. It must
-  // never affect the user-visible validation result. The two cases below
-  // exercise both directions: primary succeeds and primary fails.
-
-  @Test
-  public void shadowProbe_failureDoesNotAffectPrimarySuccess() throws Exception {
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM users");
-
-    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    PreparedStatement shadowStmt = EasyMock.createNiceMock(PreparedStatement.class);
-
-    // Primary validation succeeds.
-    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
-    mockDialect.validateQuery(mockConnection, "SELECT * FROM users");
-    EasyMock.expectLastCall();
-    // Shadow probe: prepareStatement returns, getMetaData throws. The probe
-    // must swallow the failure so primary success surfaces unchanged.
-    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM users"))
-        .andReturn(shadowStmt);
-    EasyMock.expect(shadowStmt.getMetaData())
-        .andThrow(new SQLException("driver-side failure", "08006", 17002));
-    mockConnection.close();
-    EasyMock.expectLastCall();
-    mockDialect.close();
-    EasyMock.expectLastCall();
-
-    EasyMock.replay(mockDialect, mockConnection, shadowStmt);
-    validateWithMockDialect(mockDialect);
-    EasyMock.verify(mockDialect, mockConnection, shadowStmt);
-
-    assertNoErrors();
-  }
-
-  @Test
-  public void shadowProbe_runsAndIsSwallowedWhenPrimaryFails() throws Exception {
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM nonexistent_table");
-
-    DatabaseDialect mockDialect = EasyMock.createMock(DatabaseDialect.class);
-    Connection mockConnection = EasyMock.createMock(Connection.class);
-    PreparedStatement shadowStmt = EasyMock.createNiceMock(PreparedStatement.class);
-
-    // Primary validation fails.
-    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
-    mockDialect.validateQuery(mockConnection, "SELECT * FROM nonexistent_table");
-    EasyMock.expectLastCall().andThrow(new SQLException(
-        "Table 'nonexistent_table' doesn't exist", "42S02"));
-    // Shadow probe still runs in finally and also fails; must not mask the
-    // primary's user-visible error.
-    EasyMock.expect(mockConnection.prepareStatement("SELECT * FROM nonexistent_table"))
-        .andReturn(shadowStmt);
-    EasyMock.expect(shadowStmt.getMetaData())
-        .andThrow(new SQLException("does not exist", "42S02"));
-    mockConnection.close();
-    EasyMock.expectLastCall();
-    mockDialect.close();
-    EasyMock.expectLastCall();
-
-    EasyMock.replay(mockDialect, mockConnection, shadowStmt);
-    validateWithMockDialect(mockDialect);
-    EasyMock.verify(mockDialect, mockConnection, shadowStmt);
-
-    // Primary's SQLState 42S02 surfaces to the user; shadow does not interfere.
-    assertErrors(QUERY_CONFIG, 1);
-    ConfigValue queryConfigValue = valueFor(QUERY_CONFIG);
-    assertTrue(queryConfigValue.errorMessages().get(0).contains("not valid"));
-    assertTrue(queryConfigValue.errorMessages().get(0).contains("SQLState: 42S02"));
   }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -1257,18 +1257,12 @@ public class JdbcSourceConnectorValidationTest {
     String errorMessage = queryConfigValue.errorMessages().get(0);
     assertTrue(errorMessage.contains("not valid"));
     assertTrue(errorMessage.contains("SQLState: 42S02"));
-    // Vendor errorCode defaults to 0 when the 2-arg SQLException constructor
-    // is used; the formatter must omit it in that case rather than emit
-    // "errorCode: 0", which would be misleading noise.
     assertFalse(errorMessage.contains("errorCode"));
   }
 
   @Test
   public void validate_semanticValidationErrorIncludesErrorCodeWhenPresent()
       throws Exception {
-    // When the driver populates both SQLState and the vendor errorCode (typical
-    // for Oracle ORA-942, SQL Server 208, MySQL 1146), both must appear in the
-    // user-facing message so the user can look up the exact error.
     props.put(MODE_CONFIG, MODE_BULK);
     props.put(QUERY_CONFIG, "SELECT * FROM nonexistent_table");
 
@@ -1298,10 +1292,6 @@ public class JdbcSourceConnectorValidationTest {
   @Test
   public void validate_semanticValidationErrorIncludesErrorCodeAloneWhenSqlStateMissing()
       throws Exception {
-    // Some drivers throw with a vendor errorCode but no SQLState (e.g. Oracle
-    // network failures, MySQL connection-time errors). The user-facing message
-    // must still include the errorCode so the user has at least one identifier
-    // to grep their driver docs against.
     props.put(MODE_CONFIG, MODE_BULK);
     props.put(QUERY_CONFIG, "SELECT * FROM users");
 

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -1257,6 +1257,7 @@ public class JdbcSourceConnectorValidationTest {
     String errorMessage = queryConfigValue.errorMessages().get(0);
     assertTrue(errorMessage.contains("not valid"));
     assertTrue(errorMessage.contains("SQLState: 42S02"));
+    // errorCode defaults to 0 here and must be omitted rather than shown as "errorCode: 0".
     assertFalse(errorMessage.contains("errorCode"));
   }
 


### PR DESCRIPTION
## Problem
In this PR - https://github.com/confluentinc/kafka-connect-jdbc/pull/1616, introduced a query validation using `EXPLAIN PLAN <query>` mechanism. But this mechanism would require an extra privileges for the user on the EXPLAIN table which is not a better approach. 

## Solution
Replaces per-dialect `EXPLAIN / EXPLAIN PLAN` FOR query validation with a single, dialect-agnostic JDBC probe based on PreparedStatement.getMetaData(). The user's query is sent to the database unchanged; if it has a syntax error, references a missing table or column, or fails a permission check, the driver throws SQLException and the connector reports a validation error before the task starts.

`PreparedStatement.getMetaData()` asks the JDBC driver to return the column descriptors for the query. To do so, every supported driver has the database compile the query — parse, resolve objects, type-check, verify SELECT permission — and return the describe. Rows are not fetched.Any error like bad syntax, missing table, no permission) surfaces with validation error and corresponding SQL Codes.

Other alternative rejected approaches
- `EXPLAIN PLAN` — no special privileges, no PLAN_TABLE setup, no plan-table writes, and one implementation instead of four.
- wrapping the query as `SELECT * FROM (<query>) WHERE 1=0` — the wrap rewrites the user's SQL into a derived table, which is illegal for several legal top-level forms (ORDER BY on SQL Server, SELECT * over JOINs producing duplicate columns, FOR UPDATE, CTE-only queries). Passing the query through unmodified eliminates these false positives.
- `setMaxRows(1)` + `executeQuery()` — opens a result set and fetches a row; getMetaData() does not. Strictly cheaper or equal on every driver.
- prepareStatement() alone — several drivers prepare lazily on the client and never contact the server, so missing tables and columns slip through. `getMetaData()` forces the round trip.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Tested it on local CP environment by deploying the changes for the JDBC Source connectors.

Verified end-to-end against PostgreSQL, MySQL, SQL Server, Oracle and IBM DB2 on the systest cluster. The matrix per dialect covers valid SELECT *, missing table, missing column, top-level ORDER BY, GROUP BY with unaliased COUNT(*), subquery in WHERE, self-JOIN with duplicate columns, incomplete predicates, and aliased projection with ORDER BY plus LIMIT/TOP/FETCH FIRST. All five dialects reject missing tables and columns; all five accept the legal forms that previously failed under the wrap-based probe.

<details>
<summary>Postgres JDBC Source</summary>

**Fail Fast Validation Error Message on Configuration Step**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 11 55 PM" src="https://github.com/user-attachments/assets/69929d0e-bd74-478e-9fd3-1bf4335e49fe" />

**Even fails with semi-colon at the end of query**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 12 14 PM" src="https://github.com/user-attachments/assets/58099227-51b3-4aa6-8e79-5bd010f7bdaf" />

**Successful Provisioning with correct query without any validation error**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 12 34 PM" src="https://github.com/user-attachments/assets/b31bbcde-9155-4181-8576-b558ff633ed0" />
</details>

<details>
<summary>MySQL JDBC Source</summary>

**Fail Fast Validation Error Message**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 17 14 PM" src="https://github.com/user-attachments/assets/5fe1106f-f0bd-4b60-9948-97b22bd9f3f6" />


**Successful Provisioning with correct query without any validation error**
<img width="1728" height="937" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/26ccd3f8-205d-4187-9717-078a02c62f21" />

</details>

<details>
<summary>Oracle JDBC Source</summary>

**Fail Fast Validation Error Message**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 22 35 PM" src="https://github.com/user-attachments/assets/4df07750-613a-4e8a-94f6-24d6f1c0aff9" />


**Successful Provisioning with correct query without any validation error**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 32 39 PM" src="https://github.com/user-attachments/assets/5293867b-df42-4221-a888-03f5a04d8596" />


</details>

<details>
<summary>MSSQL Server JDBC Source</summary>

**Fail Fast Validation Error Message**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 30 21 PM" src="https://github.com/user-attachments/assets/9c5b9ad0-55d9-4e37-97e8-c16354955ab5" />


**Successful Provisioning with correct query without any validation error**
<img width="1728" height="937" alt="Screenshot 2026-05-04 at 4 58 08 PM" src="https://github.com/user-attachments/assets/57ce23f3-9f0e-40c6-a6a5-5d470157151a" />

</details>

<details>
<summary>IBM DB2 JDBC Source</summary>

**Fail Fast Validation Error Message**
<img width="1728" height="937" alt="Screenshot 2026-05-05 at 5 39 16 PM" src="https://github.com/user-attachments/assets/8a79d34e-2c30-4879-bff3-48f2cb159c58" />


**Successful Provisioning with correct query without any validation error**
<img width="1728" height="937" alt="Screenshot 2026-05-05 at 5 39 47 PM" src="https://github.com/user-attachments/assets/f46b274a-4f4b-4d39-b9fb-13dc927f0890" />

</details> 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
