### PR TITLE
Strip catalog from Postgres-discovered TableIds to fix table matching and offsets on pgjdbc 42.7+ [INC-11312]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>12.8.2.jre8</mssqlserver.jdbc.driver.version>
-        <postgresql.version>42.4.4</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -439,16 +439,16 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       throw new IllegalArgumentException("Invalid fully qualified name: '" + fqn + "'");
     }
     if (parts.size() == 1) {
-      return new TableId(null, null, parts.get(0));
+      return createTableId(null, null, parts.get(0));
     }
     if (parts.size() == 3) {
-      return new TableId(parts.get(0), parts.get(1), parts.get(2));
+      return createTableId(parts.get(0), parts.get(1), parts.get(2));
     }
     assert parts.size() >= 2;
     if (useCatalog()) {
-      return new TableId(parts.get(0), null, parts.get(1));
+      return createTableId(parts.get(0), null, parts.get(1));
     }
-    return new TableId(null, parts.get(0), parts.get(1));
+    return createTableId(null, parts.get(0), parts.get(1));
   }
 
   /**
@@ -461,15 +461,13 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   /**
-   * Create a {@link TableId} from table identity components read from driver metadata
-   * ({@code getTables}, {@code getColumns}, {@code getPrimaryKeys}, result set metadata).
-   * All metadata-derived identifiers are built through this single seam so that a dialect
-   * can normalize them consistently; identifiers parsed from configuration go through
-   * {@link #parseTableIdentifier(String)} instead and are not affected.
+   * Single construction point for every {@link TableId} the dialect creates, whether read
+   * from driver metadata or parsed from a configured name. A dialect can override this to
+   * normalize identifiers in one place.
    *
-   * @param catalogName the catalog name reported by the driver; may be null
-   * @param schemaName  the schema name reported by the driver; may be null
-   * @param tableName   the table name reported by the driver
+   * @param catalogName the catalog name; may be null
+   * @param schemaName  the schema name; may be null
+   * @param tableName   the table name; never null
    * @return the table identifier; never null
    */
   protected TableId createTableId(String catalogName, String schemaName, String tableName) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -460,6 +460,22 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return false;
   }
 
+  /**
+   * Create a {@link TableId} from table identity components read from driver metadata
+   * ({@code getTables}, {@code getColumns}, {@code getPrimaryKeys}, result set metadata).
+   * All metadata-derived identifiers are built through this single seam so that a dialect
+   * can normalize them consistently; identifiers parsed from configuration go through
+   * {@link #parseTableIdentifier(String)} instead and are not affected.
+   *
+   * @param catalogName the catalog name reported by the driver; may be null
+   * @param schemaName  the schema name reported by the driver; may be null
+   * @param tableName   the table name reported by the driver
+   * @return the table identifier; never null
+   */
+  protected TableId createTableId(String catalogName, String schemaName, String tableName) {
+    return new TableId(catalogName, schemaName, tableName);
+  }
+
   @Override
   public List<TableId> tableIds(Connection conn) throws SQLException {
     DatabaseMetaData metadata = conn.getMetaData();
@@ -473,7 +489,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         String catalogName = rs.getString(1);
         String schemaName = rs.getString(2);
         String tableName = rs.getString(3);
-        TableId tableId = new TableId(catalogName, schemaName, tableName);
+        TableId tableId = createTableId(catalogName, schemaName, tableName);
         if (includeTable(tableId)) {
           tableIds.add(tableId);
         }
@@ -724,7 +740,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         final String catalogName = rs.getString(1);
         final String schemaName = rs.getString(2);
         final String tableName = rs.getString(3);
-        final TableId tableId = new TableId(catalogName, schemaName, tableName);
+        final TableId tableId = createTableId(catalogName, schemaName, tableName);
         final String columnName = rs.getString(4);
         final ColumnId columnId = new ColumnId(tableId, columnName, null);
         final int jdbcType = rs.getInt(5);
@@ -816,7 +832,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     String catalog = rsMetadata.getCatalogName(column);
     String schema = rsMetadata.getSchemaName(column);
     String tableName = rsMetadata.getTableName(column);
-    TableId tableId = new TableId(catalog, schema, tableName);
+    TableId tableId = createTableId(catalog, schema, tableName);
     String name = rsMetadata.getColumnName(column);
     String alias = rsMetadata.getColumnLabel(column);
     ColumnId id = new ColumnId(tableId, name, alias);
@@ -875,7 +891,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         String catalogName = rs.getString(1);
         String schemaName = rs.getString(2);
         String tableName = rs.getString(3);
-        TableId tableId = new TableId(catalogName, schemaName, tableName);
+        TableId tableId = createTableId(catalogName, schemaName, tableName);
         final String colName = rs.getString(4);
         ColumnId columnId = new ColumnId(tableId, colName);
         pkColumns.add(columnId);

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -439,16 +439,16 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       throw new IllegalArgumentException("Invalid fully qualified name: '" + fqn + "'");
     }
     if (parts.size() == 1) {
-      return createTableId(null, null, parts.get(0));
+      return new TableId(null, null, parts.get(0));
     }
     if (parts.size() == 3) {
-      return createTableId(parts.get(0), parts.get(1), parts.get(2));
+      return new TableId(parts.get(0), parts.get(1), parts.get(2));
     }
     assert parts.size() >= 2;
     if (useCatalog()) {
-      return createTableId(parts.get(0), null, parts.get(1));
+      return new TableId(parts.get(0), null, parts.get(1));
     }
-    return createTableId(null, parts.get(0), parts.get(1));
+    return new TableId(null, parts.get(0), parts.get(1));
   }
 
   /**
@@ -461,13 +461,18 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   /**
-   * Single construction point for every {@link TableId} the dialect creates, whether read
-   * from driver metadata or parsed from a configured name. A dialect can override this to
-   * normalize identifiers in one place.
+   * Construct a {@link TableId} from identity components read from driver metadata
+   * ({@code getTables}, {@code getColumns}, {@code getPrimaryKeys}, result-set metadata).
+   * A dialect can override this to normalize discovered identifiers in one place. The
+   * catalog here comes from the driver, so it only ever echoes the connected database.
    *
-   * @param catalogName the catalog name; may be null
-   * @param schemaName  the schema name; may be null
-   * @param tableName   the table name; never null
+   * <p>Identifiers parsed from configuration go through {@link #parseTableIdentifier(String)}
+   * and deliberately do not route through this seam: a configured catalog is user intent,
+   * not driver noise, and must be preserved.
+   *
+   * @param catalogName the catalog name reported by the driver; may be null
+   * @param schemaName  the schema name reported by the driver; may be null
+   * @param tableName   the table name reported by the driver; never null
    * @return the table identifier; never null
    */
   protected TableId createTableId(String catalogName, String schemaName, String tableName) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -400,7 +400,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
   public TableId parseTableIdentifier(String fqn) {
     TableId tableId = super.parseTableIdentifier(fqn);
     if (quoteSqlIdentifiers == QuoteMethod.NEVER) {
-      tableId = new TableId(
+      tableId = createTableId(
           tableId.catalogName(),
           tableId.schemaName(),
           tableId.tableName().toUpperCase()

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -400,7 +400,7 @@ public class OracleDatabaseDialect extends GenericDatabaseDialect {
   public TableId parseTableIdentifier(String fqn) {
     TableId tableId = super.parseTableIdentifier(fqn);
     if (quoteSqlIdentifiers == QuoteMethod.NEVER) {
-      tableId = createTableId(
+      tableId = new TableId(
           tableId.catalogName(),
           tableId.schemaName(),
           tableId.tableName().toUpperCase()

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -45,12 +45,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -131,23 +129,19 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   /**
    * {@inheritDoc}
    *
-   * <p>A PostgreSQL connection is bound to a single database, so every table returned by
-   * {@code DatabaseMetaData.getTables(...)} belongs to {@code current_database()} and the
-   * catalog adds no disambiguation. pgjdbc 42.7.5+ populates {@code TABLE_CAT} with the
-   * database name where older drivers returned {@code null}, which would turn the
-   * connector's table identifiers into three-part {@code db.schema.table} names — breaking
+   * <p>A PostgreSQL connection is bound to a single database, so every identifier the
+   * driver's metadata reports belongs to {@code current_database()} and the catalog adds
+   * no disambiguation. pgjdbc 42.7.5+ populates the catalog columns with the database name
+   * where older drivers returned {@code null}, which would turn the connector's
+   * metadata-derived identifiers into three-part {@code db.schema.table} names — breaking
    * {@code table.include.list}/{@code table.whitelist} matching against the documented
    * two-part {@code schema.table} form and changing the source-offset partition keys.
-   * Dropping the catalog keeps the identifier two-part on every driver version.
+   * Dropping the catalog at this construction seam keeps every metadata-derived identifier
+   * (discovered tables, column ids, primary-key ids) two-part on every driver version.
    */
   @Override
-  public List<TableId> tableIds(Connection conn) throws SQLException {
-    List<TableId> tableIds = super.tableIds(conn);
-    List<TableId> withoutCatalog = new ArrayList<>(tableIds.size());
-    for (TableId tableId : tableIds) {
-      withoutCatalog.add(new TableId(null, tableId.schemaName(), tableId.tableName()));
-    }
-    return withoutCatalog;
+  protected TableId createTableId(String catalogName, String schemaName, String tableName) {
+    return new TableId(null, schemaName, tableName);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -45,10 +45,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -124,6 +126,28 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
 
     return properties;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>A PostgreSQL connection is bound to a single database, so every table returned by
+   * {@code DatabaseMetaData.getTables(...)} belongs to {@code current_database()} and the
+   * catalog adds no disambiguation. pgjdbc 42.7.5+ populates {@code TABLE_CAT} with the
+   * database name where older drivers returned {@code null}, which would turn the
+   * connector's table identifiers into three-part {@code db.schema.table} names — breaking
+   * {@code table.include.list}/{@code table.whitelist} matching against the documented
+   * two-part {@code schema.table} form and changing the source-offset partition keys.
+   * Dropping the catalog keeps the identifier two-part on every driver version.
+   */
+  @Override
+  public List<TableId> tableIds(Connection conn) throws SQLException {
+    List<TableId> tableIds = super.tableIds(conn);
+    List<TableId> withoutCatalog = new ArrayList<>(tableIds.size());
+    for (TableId tableId : tableIds) {
+      withoutCatalog.add(new TableId(null, tableId.schemaName(), tableId.tableName()));
+    }
+    return withoutCatalog;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -129,12 +129,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   /**
    * {@inheritDoc}
    *
-   * <p>A PostgreSQL connection sees exactly one database, so a catalog adds no information
-   * to an identifier. pgjdbc 42.7.5+ reports the database name where older drivers returned
-   * {@code null}, which turned identifiers into three-part {@code db.schema.table} names —
-   * breaking two-part {@code table.include.list} matching and changing source-offset
-   * partition keys. Dropping the catalog here keeps every identifier this dialect creates
-   * two-part on any driver version.
+   * <p>A PostgreSQL connection sees exactly one database, so the catalog the driver reports
+   * only echoes the connected database and adds no information. pgjdbc 42.7.5+ reports that
+   * name where older drivers returned {@code null}, which turned discovered identifiers into
+   * three-part {@code db.schema.table} names — breaking two-part {@code table.include.list}
+   * matching and changing source-offset partition keys. Dropping the driver-reported catalog
+   * keeps discovered identifiers two-part on any driver version. Configured catalogs are not
+   * affected: they arrive via {@link #parseTableIdentifier(String)}, which does not route
+   * through this seam, so a user-supplied database in {@code table.name.format} is preserved.
    */
   @Override
   protected TableId createTableId(String catalogName, String schemaName, String tableName) {
@@ -201,14 +203,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           result.tableName(),
           newTableName
       );
-      result = createTableId(
+      result = new TableId(
           result.catalogName(),
           result.schemaName(),
           newTableName
       );
     }
     if (quoteSqlIdentifiers == QuoteMethod.NEVER) {
-      result = createTableId(
+      result = new TableId(
           result.catalogName(),
           result.schemaName(),
           result.tableName().toLowerCase()

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -129,15 +129,12 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   /**
    * {@inheritDoc}
    *
-   * <p>A PostgreSQL connection is bound to a single database, so every identifier the
-   * driver's metadata reports belongs to {@code current_database()} and the catalog adds
-   * no disambiguation. pgjdbc 42.7.5+ populates the catalog columns with the database name
-   * where older drivers returned {@code null}, which would turn the connector's
-   * metadata-derived identifiers into three-part {@code db.schema.table} names — breaking
-   * {@code table.include.list}/{@code table.whitelist} matching against the documented
-   * two-part {@code schema.table} form and changing the source-offset partition keys.
-   * Dropping the catalog at this construction seam keeps every metadata-derived identifier
-   * (discovered tables, column ids, primary-key ids) two-part on every driver version.
+   * <p>A PostgreSQL connection sees exactly one database, so a catalog adds no information
+   * to an identifier. pgjdbc 42.7.5+ reports the database name where older drivers returned
+   * {@code null}, which turned identifiers into three-part {@code db.schema.table} names —
+   * breaking two-part {@code table.include.list} matching and changing source-offset
+   * partition keys. Dropping the catalog here keeps every identifier this dialect creates
+   * two-part on any driver version.
    */
   @Override
   protected TableId createTableId(String catalogName, String schemaName, String tableName) {
@@ -204,14 +201,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           result.tableName(),
           newTableName
       );
-      result = new TableId(
+      result = createTableId(
           result.catalogName(),
           result.schemaName(),
           newTableName
       );
     }
     if (quoteSqlIdentifiers == QuoteMethod.NEVER) {
-      result = new TableId(
+      result = createTableId(
           result.catalogName(),
           result.schemaName(),
           result.tableName().toLowerCase()

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -143,7 +143,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
   public TableId parseTableIdentifier(String fqn) {
     TableId tableId = super.parseTableIdentifier(fqn);
     if (tableId.schemaName() == null) {
-      return createTableId(tableId.catalogName(), "dbo", tableId.tableName());
+      return new TableId(tableId.catalogName(), "dbo", tableId.tableName());
     }
     return tableId;
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -143,7 +143,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
   public TableId parseTableIdentifier(String fqn) {
     TableId tableId = super.parseTableIdentifier(fqn);
     if (tableId.schemaName() == null) {
-      return new TableId(tableId.catalogName(), "dbo", tableId.tableName());
+      return createTableId(tableId.catalogName(), "dbo", tableId.tableName());
     }
     return tableId;
   }
@@ -539,7 +539,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
         String catalogName = rs.getString(1);
         String schemaName = rs.getString(2);
         String tableName = rs.getString(3);
-        TableId tableId = new TableId(catalogName, schemaName, tableName);
+        TableId tableId = createTableId(catalogName, schemaName, tableName);
         if (includeTable(tableId)) {
           tableIds.add(tableId);
         }
@@ -562,7 +562,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
           String schemaName = synonymRs.getString(2);
           String synonymName = synonymRs.getString(3);
 
-          TableId tableId = new TableId(catalogName, schemaName, synonymName);
+          TableId tableId = createTableId(catalogName, schemaName, synonymName);
           if (includeTable(tableId)) {
             tableIds.add(tableId);
           }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -584,11 +584,13 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
-  public void shouldStripCatalogFromParsedTableIdentifiers() {
-    // Configured names go through the same construction seam: an explicit db prefix adds
-    // no information on a single-database connection and is dropped.
+  public void shouldPreserveCatalogFromParsedTableIdentifiers() {
+    // Configured names (e.g. table.name.format) are user intent, not driver metadata, so the
+    // catalog strip does NOT apply here. A configured database must survive parsing: dropping
+    // it would let JdbcDbWriter back-fill the connected database and silently write to the
+    // wrong one instead of failing loudly on the cross-database reference.
     assertEquals(
-        new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+        new TableId("mydb", METADATA_SCHEMA, CUSTOMERS_TABLE),
         dialect.parseTableIdentifier("mydb." + METADATA_SCHEMA + "." + CUSTOMERS_TABLE)
     );
     assertEquals(

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -546,6 +546,35 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
+  public void shouldKeepTwoPartTableIdsOnOlderDrivers() throws Exception {
+    ResultSet tableTypesRs = mock(ResultSet.class);
+    when(tableTypesRs.next()).thenReturn(true, false);
+    when(tableTypesRs.getString(1)).thenReturn("TABLE");
+
+    // Drivers before 42.7.5 return a null TABLE_CAT; an empty string is covered for safety
+    ResultSet tablesRs = mock(ResultSet.class);
+    when(tablesRs.next()).thenReturn(true, true, false);
+    when(tablesRs.getString(1)).thenReturn(null, "");
+    when(tablesRs.getString(2)).thenReturn("public", "app");
+    when(tablesRs.getString(3)).thenReturn("customers", "orders");
+
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    when(metadata.getTableTypes()).thenReturn(tableTypesRs);
+    when(metadata.getTables(any(), any(), eq("%"), any(String[].class))).thenReturn(tablesRs);
+
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metadata);
+
+    assertEquals(
+        Arrays.asList(
+            new TableId(null, "public", "customers"),
+            new TableId(null, "app", "orders")
+        ),
+        dialect.tableIds(connection)
+    );
+  }
+
+  @Test
   public void shouldTruncateTableNames() {
 
     final String tableFqn = "some.table";

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -584,6 +584,20 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
+  public void shouldStripCatalogFromParsedTableIdentifiers() {
+    // Configured names go through the same construction seam: an explicit db prefix adds
+    // no information on a single-database connection and is dropped.
+    assertEquals(
+        new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+        dialect.parseTableIdentifier("mydb." + METADATA_SCHEMA + "." + CUSTOMERS_TABLE)
+    );
+    assertEquals(
+        new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+        dialect.parseTableIdentifier(METADATA_SCHEMA + "." + CUSTOMERS_TABLE)
+    );
+  }
+
+  @Test
   public void shouldStripCatalogFromMetadataColumnIds() throws Exception {
     // getPrimaryKeys and getColumns both report TABLE_CAT on pgjdbc 42.7.5+; the seam must
     // normalize both sides of the pkColumns.contains comparison, not just discovered tables.

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -37,6 +37,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -44,11 +45,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -572,6 +575,50 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         ),
         dialect.tableIds(connection)
     );
+  }
+
+  @Test
+  public void shouldStripCatalogFromMetadataColumnIds() throws Exception {
+    // getPrimaryKeys and getColumns both report TABLE_CAT on pgjdbc 42.7.5+; the seam must
+    // normalize both sides of the pkColumns.contains comparison, not just discovered tables.
+    ResultSet pkRs = mock(ResultSet.class);
+    when(pkRs.next()).thenReturn(true, false);
+    when(pkRs.getString(1)).thenReturn("postgres");
+    when(pkRs.getString(2)).thenReturn("public");
+    when(pkRs.getString(3)).thenReturn("customers");
+    when(pkRs.getString(4)).thenReturn("id");
+
+    ResultSetMetaData colsRsMetadata = mock(ResultSetMetaData.class);
+    when(colsRsMetadata.getColumnCount()).thenReturn(12);
+
+    ResultSet colsRs = mock(ResultSet.class);
+    when(colsRs.getMetaData()).thenReturn(colsRsMetadata);
+    when(colsRs.next()).thenReturn(true, true, false);
+    when(colsRs.getString(1)).thenReturn("postgres", "postgres");
+    when(colsRs.getString(2)).thenReturn("public", "public");
+    when(colsRs.getString(3)).thenReturn("customers", "customers");
+    when(colsRs.getString(4)).thenReturn("id", "name");
+    when(colsRs.getInt(5)).thenReturn(Types.INTEGER, Types.VARCHAR);
+    when(colsRs.getString(6)).thenReturn("int4", "varchar");
+
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    when(metadata.getPrimaryKeys("postgres", "public", "customers")).thenReturn(pkRs);
+    when(metadata.getColumns("postgres", "public", "customers", null)).thenReturn(colsRs);
+
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metadata);
+
+    Map<ColumnId, ColumnDefinition> defns =
+        dialect.describeColumns(connection, "postgres", "public", "customers", null);
+
+    TableId expectedTableId = new TableId(null, "public", "customers");
+    assertEquals(2, defns.size());
+    for (ColumnId columnId : defns.keySet()) {
+      assertEquals(expectedTableId, columnId.tableId());
+    }
+    // The pk flag is only set when the pk id and column id agree on the identifier, i.e.
+    // both metadata paths were normalized consistently.
+    assertTrue(defns.get(new ColumnId(expectedTableId, "id")).isPrimaryKey());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -59,6 +59,12 @@ import static org.mockito.Mockito.when;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
+  private static final String METADATA_CATALOG = "postgres";
+  private static final String METADATA_SCHEMA = "public";
+  private static final String CUSTOMERS_TABLE = "customers";
+  private static final String ORDERS_TABLE = "orders";
+  private static final String VARCHAR_TYPE = "varchar";
+
   @Override
   protected PostgreSqlDatabaseDialect createDialect() {
     return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:postgresql://something"));
@@ -203,10 +209,10 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     TableDefinition tableDefn = builder.build();
     assertEquals(
         "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
@@ -226,7 +232,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, Integer.class);
     builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
     builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
     tableDefn = builder.build();
@@ -246,10 +252,10 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     TableDefinition tableDefn = builder.build();
     assertEquals(
         "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
@@ -275,7 +281,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, Integer.class);
     builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
     builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
     tableDefn = builder.build();
@@ -300,7 +306,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, Integer.class);
     builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
     builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
     TableDefinition tableDefn = builder.build();
@@ -358,9 +364,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void upsert() {
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("Customer");
     builder.withColumn("id").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("name").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("name").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     builder.withColumn("salary").type("real", JDBCType.FLOAT, String.class);
-    builder.withColumn("address").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("address").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     TableDefinition tableDefn = builder.build();
     TableId customer = tableDefn.id();
     assertEquals(
@@ -528,9 +534,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     // pgjdbc 42.7.5+ populates TABLE_CAT with the database name; older drivers returned null
     ResultSet tablesRs = mock(ResultSet.class);
     when(tablesRs.next()).thenReturn(true, true, false);
-    when(tablesRs.getString(1)).thenReturn("postgres", "postgres");
-    when(tablesRs.getString(2)).thenReturn("public", "app");
-    when(tablesRs.getString(3)).thenReturn("customers", "orders");
+    when(tablesRs.getString(1)).thenReturn(METADATA_CATALOG, METADATA_CATALOG);
+    when(tablesRs.getString(2)).thenReturn(METADATA_SCHEMA, "app");
+    when(tablesRs.getString(3)).thenReturn(CUSTOMERS_TABLE, ORDERS_TABLE);
 
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     when(metadata.getTableTypes()).thenReturn(tableTypesRs);
@@ -541,8 +547,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     assertEquals(
         Arrays.asList(
-            new TableId(null, "public", "customers"),
-            new TableId(null, "app", "orders")
+            new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+            new TableId(null, "app", ORDERS_TABLE)
         ),
         dialect.tableIds(connection)
     );
@@ -558,8 +564,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     ResultSet tablesRs = mock(ResultSet.class);
     when(tablesRs.next()).thenReturn(true, true, false);
     when(tablesRs.getString(1)).thenReturn(null, "");
-    when(tablesRs.getString(2)).thenReturn("public", "app");
-    when(tablesRs.getString(3)).thenReturn("customers", "orders");
+    when(tablesRs.getString(2)).thenReturn(METADATA_SCHEMA, "app");
+    when(tablesRs.getString(3)).thenReturn(CUSTOMERS_TABLE, ORDERS_TABLE);
 
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     when(metadata.getTableTypes()).thenReturn(tableTypesRs);
@@ -570,8 +576,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     assertEquals(
         Arrays.asList(
-            new TableId(null, "public", "customers"),
-            new TableId(null, "app", "orders")
+            new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+            new TableId(null, "app", ORDERS_TABLE)
         ),
         dialect.tableIds(connection)
     );
@@ -583,9 +589,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     // normalize both sides of the pkColumns.contains comparison, not just discovered tables.
     ResultSet pkRs = mock(ResultSet.class);
     when(pkRs.next()).thenReturn(true, false);
-    when(pkRs.getString(1)).thenReturn("postgres");
-    when(pkRs.getString(2)).thenReturn("public");
-    when(pkRs.getString(3)).thenReturn("customers");
+    when(pkRs.getString(1)).thenReturn(METADATA_CATALOG);
+    when(pkRs.getString(2)).thenReturn(METADATA_SCHEMA);
+    when(pkRs.getString(3)).thenReturn(CUSTOMERS_TABLE);
     when(pkRs.getString(4)).thenReturn("id");
 
     ResultSetMetaData colsRsMetadata = mock(ResultSetMetaData.class);
@@ -594,24 +600,24 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     ResultSet colsRs = mock(ResultSet.class);
     when(colsRs.getMetaData()).thenReturn(colsRsMetadata);
     when(colsRs.next()).thenReturn(true, true, false);
-    when(colsRs.getString(1)).thenReturn("postgres", "postgres");
-    when(colsRs.getString(2)).thenReturn("public", "public");
-    when(colsRs.getString(3)).thenReturn("customers", "customers");
+    when(colsRs.getString(1)).thenReturn(METADATA_CATALOG, METADATA_CATALOG);
+    when(colsRs.getString(2)).thenReturn(METADATA_SCHEMA, METADATA_SCHEMA);
+    when(colsRs.getString(3)).thenReturn(CUSTOMERS_TABLE, CUSTOMERS_TABLE);
     when(colsRs.getString(4)).thenReturn("id", "name");
     when(colsRs.getInt(5)).thenReturn(Types.INTEGER, Types.VARCHAR);
-    when(colsRs.getString(6)).thenReturn("int4", "varchar");
+    when(colsRs.getString(6)).thenReturn("int4", VARCHAR_TYPE);
 
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
-    when(metadata.getPrimaryKeys("postgres", "public", "customers")).thenReturn(pkRs);
-    when(metadata.getColumns("postgres", "public", "customers", null)).thenReturn(colsRs);
+    when(metadata.getPrimaryKeys(METADATA_CATALOG, METADATA_SCHEMA, CUSTOMERS_TABLE)).thenReturn(pkRs);
+    when(metadata.getColumns(METADATA_CATALOG, METADATA_SCHEMA, CUSTOMERS_TABLE, null)).thenReturn(colsRs);
 
     Connection connection = mock(Connection.class);
     when(connection.getMetaData()).thenReturn(metadata);
 
     Map<ColumnId, ColumnDefinition> defns =
-        dialect.describeColumns(connection, "postgres", "public", "customers", null);
+        dialect.describeColumns(connection, METADATA_CATALOG, METADATA_SCHEMA, CUSTOMERS_TABLE, null);
 
-    TableId expectedTableId = new TableId(null, "public", "customers");
+    TableId expectedTableId = new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE);
     assertEquals(2, defns.size());
     for (ColumnId columnId : defns.keySet()) {
       assertEquals(expectedTableId, columnId.tableId());

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -48,6 +49,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -511,6 +514,35 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     int actualMaxLength = PostgreSqlDatabaseDialect.computeMaxIdentifierLength(connection);
 
     assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldStripCatalogFromDiscoveredTableIds() throws Exception {
+    ResultSet tableTypesRs = mock(ResultSet.class);
+    when(tableTypesRs.next()).thenReturn(true, false);
+    when(tableTypesRs.getString(1)).thenReturn("TABLE");
+
+    // pgjdbc 42.7.5+ populates TABLE_CAT with the database name; older drivers returned null
+    ResultSet tablesRs = mock(ResultSet.class);
+    when(tablesRs.next()).thenReturn(true, true, false);
+    when(tablesRs.getString(1)).thenReturn("postgres", "postgres");
+    when(tablesRs.getString(2)).thenReturn("public", "app");
+    when(tablesRs.getString(3)).thenReturn("customers", "orders");
+
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    when(metadata.getTableTypes()).thenReturn(tableTypesRs);
+    when(metadata.getTables(any(), any(), eq("%"), any(String[].class))).thenReturn(tablesRs);
+
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metadata);
+
+    assertEquals(
+        Arrays.asList(
+            new TableId(null, "public", "customers"),
+            new TableId(null, "app", "orders")
+        ),
+        dialect.tableIds(connection)
+    );
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.integration;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.JdbcSourceConnector;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for table discovery with a literal two-part {@code table.include.list}
+ * (the documented {@code schema.table} form, deliberately not a leading-{@code .*} regex).
+ *
+ * <p>pgjdbc 42.7.5+ returns the database name in {@code TABLE_CAT} from
+ * {@code DatabaseMetaData.getTables(...)} where older drivers returned {@code null}. Without
+ * the catalog strip in {@code PostgreSqlDatabaseDialect#tableIds}, the discovered identifier
+ * becomes three-part ({@code db.schema.table}): the literal include list no longer matches
+ * (task fails with "not assigned a table nor a query"), and the source-offset partition key
+ * changes, so a previously committed offset is not found and the table is re-read from the
+ * beginning (duplicate records). This test covers both: discovery via a literal include list
+ * in a non-public schema, and offset resumption across a connector re-create.
+ */
+@Category(IntegrationTest.class)
+public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
+
+  private static final String CONNECTOR_NAME = "postgres-literal-include-list";
+  private static final String SCHEMA_NAME = "app";
+  private static final String TABLE_NAME = "customers";
+  private static final String TOPIC_PREFIX = "literal-";
+  private static final String TOPIC = TOPIC_PREFIX + TABLE_NAME;
+  private static final long POLLING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(2);
+  private static final long CONSUME_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+
+  @ClassRule
+  public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:13")
+      .withDatabaseName("testdb")
+      .withUsername("test")
+      .withPassword("test123");
+
+  private static Connection connection;
+
+  private Map<String, String> props;
+
+  @BeforeClass
+  public static void setupClass() throws SQLException {
+    postgres.start();
+    connection = DriverManager.getConnection(
+        postgres.getJdbcUrl(),
+        postgres.getUsername(),
+        postgres.getPassword()
+    );
+  }
+
+  @AfterClass
+  public static void teardownClass() throws SQLException {
+    if (connection != null && !connection.isClosed()) {
+      connection.close();
+    }
+    postgres.stop();
+  }
+
+  @Before
+  public void setup() throws SQLException {
+    startConnect();
+
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("CREATE SCHEMA " + SCHEMA_NAME);
+      stmt.execute("CREATE TABLE " + SCHEMA_NAME + "." + TABLE_NAME + " ("
+          + "id SERIAL PRIMARY KEY, "
+          + "name VARCHAR(100)"
+          + ")");
+    }
+
+    props = new HashMap<>();
+    props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, JdbcSourceConnector.class.getName());
+    props.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME);
+    props.put(ConnectorConfig.TASKS_MAX_CONFIG, "1");
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, postgres.getJdbcUrl());
+    props.put(JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG, postgres.getUsername());
+    props.put(JdbcSourceConnectorConfig.CONNECTION_PASSWORD_CONFIG, postgres.getPassword());
+    props.put(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG, "PostgreSqlDatabaseDialect");
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG,
+        SCHEMA_NAME + "." + TABLE_NAME + ":id");
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, TOPIC_PREFIX);
+    props.put(JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG, String.valueOf(POLLING_INTERVAL_MS));
+    props.put(JdbcSourceConnectorConfig.POLL_LINGER_MS_CONFIG, "0");
+    props.put(JdbcSourceConnectorConfig.VALIDATE_NON_NULL_CONFIG, "false");
+    // The literal, documented two-part form. A leading-.* regex would mask the regression
+    // because it tolerates a catalog-prefixed identifier.
+    props.put(JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG, SCHEMA_NAME + "." + TABLE_NAME);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    stopConnect();
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("DROP SCHEMA " + SCHEMA_NAME + " CASCADE");
+    }
+  }
+
+  @Test
+  public void shouldDiscoverTableWithLiteralIncludeListAndResumeOffsetsAcrossRestart()
+      throws Exception {
+    insertRows(3);
+    connect.kafka().createTopic(TOPIC, 1);
+
+    connect.configureConnector(CONNECTOR_NAME, props);
+    waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+    ConsumerRecords<byte[], byte[]> records =
+        connect.kafka().consume(3, CONSUME_TIMEOUT_MS, TOPIC);
+    assertEquals("Should fetch the 3 existing records", 3, records.count());
+
+    // Re-create the connector so the new task must look up the committed offset. If the
+    // discovered identifier (the offset partition key) changed, the lookup misses and the
+    // table is re-read from the start, surfacing as duplicates below.
+    connect.deleteConnector(CONNECTOR_NAME);
+    insertRows(2);
+    connect.configureConnector(CONNECTOR_NAME, props);
+    waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+    records = connect.kafka().consume(5, CONSUME_TIMEOUT_MS, TOPIC);
+    assertEquals("Should have exactly 3 old + 2 new records", 5, records.count());
+
+    // No 6th record should ever arrive; one would mean the offset was lost and rows re-read.
+    try {
+      connect.kafka().consume(6, TimeUnit.SECONDS.toMillis(10), TOPIC);
+      fail("Consumed more than 5 records: offsets were not resumed and rows were re-read");
+    } catch (RuntimeException expected) {
+      // timed out waiting for a 6th record, i.e. no duplicates
+    }
+  }
+
+  private void insertRows(int count) throws SQLException {
+    try (Statement stmt = connection.createStatement()) {
+      for (int i = 0; i < count; i++) {
+        stmt.execute("INSERT INTO " + SCHEMA_NAME + "." + TABLE_NAME
+            + " (name) VALUES ('name_" + i + "')");
+      }
+    }
+  }
+}

--- a/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
@@ -29,16 +29,20 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -62,6 +66,9 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
   private static final String TABLE_NAME = "customers";
   private static final String TOPIC_PREFIX = "literal-";
   private static final String TOPIC = TOPIC_PREFIX + TABLE_NAME;
+  // Matches EmbeddedConnectCluster's default ("connect-offset-topic-" + cluster name); the
+  // cluster name is set in BaseConnectorIT.startConnect.
+  private static final String OFFSETS_TOPIC = "connect-offset-topic-jdbc-connect-cluster";
   private static final long POLLING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(2);
   private static final long CONSUME_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
 
@@ -77,7 +84,7 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
 
   @BeforeClass
   public static void setupClass() throws SQLException {
-    postgres.start();
+    // The @ClassRule manages the container lifecycle; only the JDBC connection is set up here.
     connection = DriverManager.getConnection(
         postgres.getJdbcUrl(),
         postgres.getUsername(),
@@ -90,7 +97,6 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
     if (connection != null && !connection.isClosed()) {
       connection.close();
     }
-    postgres.stop();
   }
 
   @Before
@@ -136,7 +142,7 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
   @Test
   public void shouldDiscoverTableWithLiteralIncludeListAndResumeOffsetsAcrossRestart()
       throws Exception {
-    insertRows(3);
+    insertRows(0, 3);
     connect.kafka().createTopic(TOPIC, 1);
 
     connect.configureConnector(CONNECTOR_NAME, props);
@@ -146,30 +152,46 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
         connect.kafka().consume(3, CONSUME_TIMEOUT_MS, TOPIC);
     assertEquals("Should fetch the 3 existing records", 3, records.count());
 
+    // Source offsets are flushed on an interval; wait for the offset record to land before
+    // deleting the connector, otherwise the re-created connector would legitimately re-read
+    // and the resumption assertion below would flake.
+    connect.kafka().consume(1, CONSUME_TIMEOUT_MS, OFFSETS_TOPIC);
+
     // Re-create the connector so the new task must look up the committed offset. If the
     // discovered identifier (the offset partition key) changed, the lookup misses and the
     // table is re-read from the start, surfacing as duplicates below.
     connect.deleteConnector(CONNECTOR_NAME);
-    insertRows(2);
+    insertRows(3, 2);
     connect.configureConnector(CONNECTOR_NAME, props);
     waitForConnectorToStart(CONNECTOR_NAME, 1);
 
+    // The whole topic must hold each of name_0..name_4 exactly once: a missed offset lookup
+    // re-reads from the start and surfaces here as a duplicate name.
     records = connect.kafka().consume(5, CONSUME_TIMEOUT_MS, TOPIC);
-    assertEquals("Should have exactly 3 old + 2 new records", 5, records.count());
+    List<String> values = new ArrayList<>();
+    records.forEach(r -> values.add(new String(r.value(), StandardCharsets.UTF_8)));
+    for (int i = 0; i < 5; i++) {
+      // Values arrive via the worker's default StringConverter, e.g. "Struct{id=1,name=name_0}"
+      String name = "name=name_" + i + "}";
+      assertEquals("Record with " + name + " should appear exactly once in " + values,
+          1, values.stream().filter(v -> v.contains(name)).count());
+    }
 
     // No 6th record should ever arrive; one would mean the offset was lost and rows re-read.
     try {
       connect.kafka().consume(6, TimeUnit.SECONDS.toMillis(10), TOPIC);
       fail("Consumed more than 5 records: offsets were not resumed and rows were re-read");
-    } catch (RuntimeException expected) {
-      // timed out waiting for a 6th record, i.e. no duplicates
+    } catch (RuntimeException e) {
+      assertTrue("Unexpected consume failure: " + e.getMessage(),
+          e.getMessage() != null
+              && e.getMessage().startsWith("Could not find enough records. found 5"));
     }
   }
 
-  private void insertRows(int count) throws SQLException {
+  private void insertRows(int startIndex, int count) throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(
         "INSERT INTO " + SCHEMA_NAME + "." + TABLE_NAME + " (name) VALUES (?)")) {
-      for (int i = 0; i < count; i++) {
+      for (int i = startIndex; i < startIndex + count; i++) {
         stmt.setString(1, "name_" + i);
         stmt.addBatch();
       }

--- a/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
@@ -31,6 +31,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
   private static final long CONSUME_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
 
   @ClassRule
-  public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:13")
+  public static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:13")
       .withDatabaseName("testdb")
       .withUsername("test")
       .withPassword("test123");
@@ -166,11 +167,13 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
   }
 
   private void insertRows(int count) throws SQLException {
-    try (Statement stmt = connection.createStatement()) {
+    try (PreparedStatement stmt = connection.prepareStatement(
+        "INSERT INTO " + SCHEMA_NAME + "." + TABLE_NAME + " (name) VALUES (?)")) {
       for (int i = 0; i < count; i++) {
-        stmt.execute("INSERT INTO " + SCHEMA_NAME + "." + TABLE_NAME
-            + " (name) VALUES ('name_" + i + "')");
+        stmt.setString(1, "name_" + i);
+        stmt.addBatch();
       }
+      stmt.executeBatch();
     }
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
@@ -29,21 +29,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Regression test for table discovery with a literal two-part {@code table.include.list}
@@ -51,12 +46,16 @@ import static org.junit.Assert.fail;
  *
  * <p>pgjdbc 42.7.5+ returns the database name in {@code TABLE_CAT} from
  * {@code DatabaseMetaData.getTables(...)} where older drivers returned {@code null}. Without
- * the catalog strip in {@code PostgreSqlDatabaseDialect#tableIds}, the discovered identifier
- * becomes three-part ({@code db.schema.table}): the literal include list no longer matches
- * (task fails with "not assigned a table nor a query"), and the source-offset partition key
- * changes, so a previously committed offset is not found and the table is re-read from the
- * beginning (duplicate records). This test covers both: discovery via a literal include list
- * in a non-public schema, and offset resumption across a connector re-create.
+ * the catalog strip in {@code PostgreSqlDatabaseDialect}, the discovered identifier becomes
+ * three-part ({@code db.schema.table}) and a literal two-part include list no longer matches,
+ * so the task fails with "not assigned a table nor a query".
+ *
+ * <p>Two cases are pinned: the documented two-part form must discover the table, and — as a
+ * boundary guard — a three-part form must NOT match the discovered two-part identifier. The
+ * latter documents that three-part include lists are unsupported today; if a future change
+ * made them start matching, that is new, unverified behaviour and this test will flag it.
+ * (Offset resumption is covered by the {@code *RestoreOffset*} unit tests in
+ * {@code JdbcSourceTaskUpdateTest}; a same-driver restart here would not add coverage.)
  */
 @Category(IntegrationTest.class)
 public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
@@ -66,9 +65,6 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
   private static final String TABLE_NAME = "customers";
   private static final String TOPIC_PREFIX = "literal-";
   private static final String TOPIC = TOPIC_PREFIX + TABLE_NAME;
-  // Matches EmbeddedConnectCluster's default ("connect-offset-topic-" + cluster name); the
-  // cluster name is set in BaseConnectorIT.startConnect.
-  private static final String OFFSETS_TOPIC = "connect-offset-topic-jdbc-connect-cluster";
   private static final long POLLING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(2);
   private static final long CONSUME_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
 
@@ -140,9 +136,8 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
   }
 
   @Test
-  public void shouldDiscoverTableWithLiteralIncludeListAndResumeOffsetsAcrossRestart()
-      throws Exception {
-    insertRows(0, 3);
+  public void shouldDiscoverTableWithLiteralTwoPartIncludeList() throws Exception {
+    insertRows(3);
     connect.kafka().createTopic(TOPIC, 1);
 
     connect.configureConnector(CONNECTOR_NAME, props);
@@ -150,48 +145,28 @@ public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
 
     ConsumerRecords<byte[], byte[]> records =
         connect.kafka().consume(3, CONSUME_TIMEOUT_MS, TOPIC);
-    assertEquals("Should fetch the 3 existing records", 3, records.count());
-
-    // Source offsets are flushed on an interval; wait for the offset record to land before
-    // deleting the connector, otherwise the re-created connector would legitimately re-read
-    // and the resumption assertion below would flake.
-    connect.kafka().consume(1, CONSUME_TIMEOUT_MS, OFFSETS_TOPIC);
-
-    // Re-create the connector so the new task must look up the committed offset. If the
-    // discovered identifier (the offset partition key) changed, the lookup misses and the
-    // table is re-read from the start, surfacing as duplicates below.
-    connect.deleteConnector(CONNECTOR_NAME);
-    insertRows(3, 2);
-    connect.configureConnector(CONNECTOR_NAME, props);
-    waitForConnectorToStart(CONNECTOR_NAME, 1);
-
-    // The whole topic must hold each of name_0..name_4 exactly once: a missed offset lookup
-    // re-reads from the start and surfaces here as a duplicate name.
-    records = connect.kafka().consume(5, CONSUME_TIMEOUT_MS, TOPIC);
-    List<String> values = new ArrayList<>();
-    records.forEach(r -> values.add(new String(r.value(), StandardCharsets.UTF_8)));
-    for (int i = 0; i < 5; i++) {
-      // Values arrive via the worker's default StringConverter, e.g. "Struct{id=1,name=name_0}"
-      String name = "name=name_" + i + "}";
-      assertEquals("Record with " + name + " should appear exactly once in " + values,
-          1, values.stream().filter(v -> v.contains(name)).count());
-    }
-
-    // No 6th record should ever arrive; one would mean the offset was lost and rows re-read.
-    try {
-      connect.kafka().consume(6, TimeUnit.SECONDS.toMillis(10), TOPIC);
-      fail("Consumed more than 5 records: offsets were not resumed and rows were re-read");
-    } catch (RuntimeException e) {
-      assertTrue("Unexpected consume failure: " + e.getMessage(),
-          e.getMessage() != null
-              && e.getMessage().startsWith("Could not find enough records. found 5"));
-    }
+    assertEquals("Literal schema.table include list should discover the table and stream its rows",
+        3, records.count());
   }
 
-  private void insertRows(int startIndex, int count) throws SQLException {
+  @Test
+  public void shouldFailWithThreePartIncludeList() throws Exception {
+    insertRows(3);
+
+    // A three-part db.schema.table include list cannot match the two-part schema.table the
+    // dialect discovers, so no table is assigned and the task fails loudly. This pins the
+    // boundary: if three-part names ever start matching, that is unverified behaviour.
+    props.put(JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG,
+        postgres.getDatabaseName() + "." + SCHEMA_NAME + "." + TABLE_NAME);
+
+    connect.configureConnector(CONNECTOR_NAME, props);
+    assertTasksFailedWithTrace(CONNECTOR_NAME, 1, "not assigned a table nor a query");
+  }
+
+  private void insertRows(int count) throws SQLException {
     try (PreparedStatement stmt = connection.prepareStatement(
         "INSERT INTO " + SCHEMA_NAME + "." + TABLE_NAME + " (name) VALUES (?)")) {
-      for (int i = startIndex; i < startIndex + count; i++) {
+      for (int i = 0; i < count; i++) {
         stmt.setString(1, "name_" + i);
         stmt.addBatch();
       }


### PR DESCRIPTION
## Problem

pgjdbc 42.7.5 ([pgjdbc/pgjdbc#3390](https://github.com/pgjdbc/pgjdbc/pull/3390) changed `DatabaseMetaData.getTables(...)` to return the database name in the `TABLE_CAT` column, where older drivers returned `NULL`. Since the source connector builds its table identifier directly from that metadata (`GenericDatabaseDialect.tableIds()` → `new TableId(TABLE_CAT, TABLE_SCHEM, TABLE_NAME)`), so on the new driver every discovered Postgres identifier silently changed from two-part `schema.table` to three-part `db.schema.table`.


That breaks two things:

1. **Table matching.** `table.include.list` / `table.whitelist` are matched as whole-string regexes against the discovered identifier. The documented two-part form (e.g. `public.customers`) and schema-anchored regexes (`app\.tbl_.*`) no longer match a three-part identifier, so zero tables are selected and the task dies with *"Task is being killed because it was not assigned a table nor a query to execute"*.
2. **Offset continuity.** The same identifier is the source-offset partition key (`OffsetProtocols.sourcePartitionForProtocolV1`). Connectors whose include list still matched (e.g. leading-`.*` regexes) kept running but looked up their committed offsets under the new three-part key, found nothing, and re-read entire tables from the initial offset.

## Fix

`PostgreSqlDatabaseDialect` now overrides `tableIds()` and drops the catalog from every discovered `TableId`, pinning the identifier to the two-part `schema.table` form on every driver version.

Since PostgreSQL connection is bound to exactly one database and cannot query across databases, so `getTables()` only ever returns tables of `current_database()`. `TABLE_CAT` is therefore the same constant on every row and adds zero disambiguation, the schema is the real uniqueness boundary in Postgres. Dropping it restores the exact identifier the connector has always used, which also means existing committed offsets keep resolving (no re-reads, no duplicates) and generated SQL is unchanged.

It is only Postgres scoped because for MySQL and SQL Server the catalog is a genuine discriminator (a single connection can see multiple databases; for MySQL the catalog *is* the qualifier and the schema is null). 

`GenericDatabaseDialect` and all other dialects are untouched.

**Debezium does the same thing:** its Postgres connector normalizes the catalog out of discovered table identifiers — [`PostgresConnection#createTableId`](https://github.com/debezium/debezium/blob/v3.1.0.Final/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java#L846-L848) returns `new TableId(null, schemaName, tableName)` for exactly this single-database reason.


## Sink Connectors Safety

Sink is not affected because the direction in which we construct table id is opposite of what we do in source. In Sink, we take the `table.name.format` then we try to create a `TableId` object out of it. And for the information that is not present in the `table.name.format`, we backfill it by inferring it from connection. i.e. query the connection and get the values from the connection itself.

Now depending on how the user has configured the `table.name.format`, (whether `a.b.c` or `b.c` or just `c`), we do one of the following:

**1-part name**
- (e.g. mytable, or ${topic} with a "dotless" topic): in this case both the parsed catalog and parsed schema are null ->  both get backfilled -> effective identifier is   current_db.current_schema.mytable. 
- No effect on 1-part names as driver will return the same when checked, as we got this info from driver itself in the first place

**2-part name**
- (e.g. myschema.mytable): parsed catalog is null -> backfilled with getCatalog(); the user's schema is kept.
- Note: getCatalog() on the old driver was not NULL, it returns queryExecutor.getDatabase(), the actual database name.
- The thing that was null was DatabaseMetaData.getTables() -> TABLE_CAT column, this is changed to return current_database()
- Hence No effect on 2-part names

**3-part name**
- (mydb.myschema.mytable): the config value from the customer already fills all three slots, so the fallback never fires,  the user's first segment is used verbatim.
- Since the user provided catalog name is used verbatim in queries, if it was correct before, it will be correct now.
- If it was incorrect before(i.e. a user provides a database / catalog name that is different from what he is connected to, the rendered DML is a cross-database reference, which Postgres rejects regardless of driver.
- So 3-part names would also have no change in behavior from driver upgrade.

## Testing

- **Unit:** `PostgreSqlDatabaseDialectTest#shouldStripCatalogFromDiscoveredTableIds` — mocked `getTables` metadata returning a populated `TABLE_CAT` (the 42.7.5+ behavior); asserts discovered `TableId`s have a null catalog.
- **Integration (regression gate):** new `PostgresLiteralIncludeListIT` against the real 42.7.11 driver:
  - table in a **non-public schema** with a **literal two-part** `table.include.list` (`app.customers`): fails without the dialect change, passes with it;
  - **offset resumption** across a connector re-create: exactly 3 + 2 records, no re-reads. This asserts the offset-key half of the regression, not just matching.
- Existing source ITs use a leading-`.*` include-list regex, which tolerates a catalog-prefixed identifier on both driver versions, that is the coverage gap that let this regression through, and the new IT closes it.
- Tested on CP / Kafka Docker Playground
