### PR TITLE
Add fail-fast validation to incrementing.column.name in query mode for incrementing/timestamp+incrementing modes

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -382,10 +382,14 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
       String msg = String.format(
           "'%s' must be provided when using mode '%s' or '%s' with a custom query. "
           + "The incrementing column cannot be auto-discovered in query mode because there "
-          + "is no table to inspect.",
+          + "is no table to inspect. Note that '%s' is not applied in query mode (it maps "
+          + "columns by table-name regex, and a custom query has no underlying table to match), "
+          + "so '%s' must be set explicitly.",
           JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG,
           JdbcSourceConnectorConfig.MODE_INCREMENTING,
-          JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+          JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING,
+          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG,
+          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG);
       addConfigError(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG, msg);
       log.error(msg);
       return false;

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -365,22 +365,12 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
   }
 
   /**
-   * Require an explicit {@code incrementing.column.name} in query mode for modes that track an
-   * incrementing column.
+   * Require an explicit {@code incrementing.column.name} for {@code incrementing} /
+   * {@code timestamp+incrementing} modes in query mode, where the column cannot be auto-discovered
+   * (no {@code TableId}) and an empty value NPEs on every poll (INC-10982).
    *
-   * <p>In query mode the querier is constructed without a {@code TableId}, so the connector
-   * cannot auto-discover the incrementing column from table metadata the way it can in table
-   * mode. For mode {@code incrementing} / {@code timestamp+incrementing} with an empty
-   * {@code incrementing.column.name}, {@code TimestampIncrementingTableQuerier
-   * .findDefaultAutoIncrementingColumn} dereferences the null {@code TableId} and hits an
-   * unrecoverable {@link NullPointerException} on every poll (the task is killed and restarted
-   * indefinitely). Fail fast at validation time so the misconfiguration is caught at create /
-   * validate.
-   *
-   * <p>This is scoped to the incrementing column only. A missing {@code timestamp.column.name}
-   * (pure {@code timestamp} mode, or {@code timestamp+incrementing} with the incrementing column
-   * set) does <em>not</em> NPE — {@code TimestampTableQuerier} passes {@code null} for the
-   * incrementing column so the auto-discovery branch is skipped — so it is not rejected here.
+   * <p>Scoped to the incrementing column only: a missing {@code timestamp.column.name} does not
+   * NPE, so it is not rejected here.
    */
   private boolean validateQueryModeIncrementingColumnRequired() {
     if (!config.getQuery().isPresent() || !config.modeUsesIncrementingColumn()) {

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -88,8 +88,7 @@ public class JdbcSourceConnectorValidation {
       boolean validationResult = validateMultiConfigs()
           && validateLegacyNewConfigCompatibility()
           && validateQueryConfigs()
-          && validateMappingConfigsNotUsedWithQuery()
-          && validateQueryModeColumnRequirements()
+          && validateQueryModeIncrementingColumnRequired()
           && validateQuerySemantics();
 
       if (validationResult && isUsingNewConfigs()) {
@@ -364,102 +363,43 @@ public class JdbcSourceConnectorValidation {
   }
 
   /**
-   * Reject column <em>mapping</em> configs when a custom query is configured.
-   *
-   * <p>{@code timestamp.column.mapping} / {@code incrementing.column.mapping} map columns by
-   * table-name regex and are only honored on the table-filtering path (they require a
-   * {@code table.include.list}, which cannot be combined with a query). In query mode there is
-   * no table for the regex to match, so these mappings are silently ignored at runtime and the
-   * connector falls back to the legacy {@code *.column.name} configs. Rather than letting a user
-   * believe a mapping is in effect, reject it up front with a dedicated, distinct error that
-   * points them at the supported name config for query mode.
-   */
-  private boolean validateMappingConfigsNotUsedWithQuery() {
-    if (!config.getQuery().isPresent()) {
-      return true;
-    }
-
-    boolean valid = true;
-
-    List<String> incrementingColumnMapping = config.getIncrementingColumnMapping();
-    if (incrementingColumnMapping != null && !incrementingColumnMapping.isEmpty()) {
-      String msg = String.format(
-          "'%s' is not supported with a custom query. Column mappings match columns by "
-          + "table-name regex, which does not apply in query mode. Use '%s' instead.",
-          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG,
-          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG);
-      addConfigError(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG, msg);
-      log.error(msg);
-      valid = false;
-    }
-
-    List<String> timestampColumnsMapping = config.getTimestampColumnMapping();
-    if (timestampColumnsMapping != null && !timestampColumnsMapping.isEmpty()) {
-      String msg = String.format(
-          "'%s' is not supported with a custom query. Column mappings match columns by "
-          + "table-name regex, which does not apply in query mode. Use '%s' instead.",
-          JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG,
-          JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
-      addConfigError(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, msg);
-      log.error(msg);
-      valid = false;
-    }
-
-    return valid;
-  }
-
-  /**
-   * Validate that, in query mode, the mode-dependent column names are explicitly provided.
+   * Require an explicit {@code incrementing.column.name} in query mode for modes that track an
+   * incrementing column.
    *
    * <p>In query mode the querier is constructed without a {@code TableId}, so the connector
    * cannot auto-discover the incrementing column from table metadata the way it can in table
-   * mode. With mode {@code incrementing} / {@code timestamp+incrementing} and an empty
-   * {@code incrementing.column.name}, or mode {@code timestamp} / {@code timestamp+incrementing}
-   * and an empty {@code timestamp.column.name}, the connector hits an unrecoverable
-   * {@link NullPointerException} on every poll (the task is killed and restarted indefinitely).
-   * Fail fast at validation time instead so the misconfiguration is caught at create / validate.
+   * mode. For mode {@code incrementing} / {@code timestamp+incrementing} with an empty
+   * {@code incrementing.column.name}, {@code TimestampIncrementingTableQuerier
+   * .findDefaultAutoIncrementingColumn} dereferences the null {@code TableId} and hits an
+   * unrecoverable {@link NullPointerException} on every poll (the task is killed and restarted
+   * indefinitely). Fail fast at validation time so the misconfiguration is caught at create /
+   * validate.
+   *
+   * <p>This is scoped to the incrementing column only. A missing {@code timestamp.column.name}
+   * (pure {@code timestamp} mode, or {@code timestamp+incrementing} with the incrementing column
+   * set) does <em>not</em> NPE — {@code TimestampTableQuerier} passes {@code null} for the
+   * incrementing column so the auto-discovery branch is skipped — so it is not rejected here.
    */
-  private boolean validateQueryModeColumnRequirements() {
-    if (!config.getQuery().isPresent()) {
+  private boolean validateQueryModeIncrementingColumnRequired() {
+    if (!config.getQuery().isPresent() || !config.modeUsesIncrementingColumn()) {
       return true;
     }
 
-    boolean valid = true;
-
-    if (config.modeUsesIncrementingColumn()) {
-      String incrementingColumnName = config.getIncrementingColumnName();
-      if (incrementingColumnName == null || incrementingColumnName.trim().isEmpty()) {
-        String msg = String.format(
-            "'%s' must be provided when using mode '%s' or '%s' with a custom query. "
-            + "The incrementing column cannot be auto-discovered in query mode because there "
-            + "is no table to inspect.",
-            JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG,
-            JdbcSourceConnectorConfig.MODE_INCREMENTING,
-            JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
-        addConfigError(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG, msg);
-        log.error(msg);
-        valid = false;
-      }
+    String incrementingColumnName = config.getIncrementingColumnName();
+    if (incrementingColumnName == null || incrementingColumnName.trim().isEmpty()) {
+      String msg = String.format(
+          "'%s' must be provided when using mode '%s' or '%s' with a custom query. "
+          + "The incrementing column cannot be auto-discovered in query mode because there "
+          + "is no table to inspect.",
+          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG,
+          JdbcSourceConnectorConfig.MODE_INCREMENTING,
+          JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+      addConfigError(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG, msg);
+      log.error(msg);
+      return false;
     }
 
-    if (config.modeUsesTimestampColumn()) {
-      List<String> timestampColumnName = config.getTimestampColumnName();
-      boolean hasTimestampColumn = timestampColumnName != null
-          && timestampColumnName.stream()
-              .anyMatch(col -> col != null && !col.trim().isEmpty());
-      if (!hasTimestampColumn) {
-        String msg = String.format(
-            "'%s' must be provided when using mode '%s' or '%s' with a custom query.",
-            JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG,
-            JdbcSourceConnectorConfig.MODE_TIMESTAMP,
-            JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
-        addConfigError(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG, msg);
-        log.error(msg);
-        valid = false;
-      }
-    }
-
-    return valid;
+    return true;
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -88,6 +88,7 @@ public class JdbcSourceConnectorValidation {
       boolean validationResult = validateMultiConfigs()
           && validateLegacyNewConfigCompatibility()
           && validateQueryConfigs()
+          && validateMappingConfigsNotUsedWithQuery()
           && validateQueryModeColumnRequirements()
           && validateQuerySemantics();
 
@@ -360,6 +361,51 @@ public class JdbcSourceConnectorValidation {
     }
 
     return true;
+  }
+
+  /**
+   * Reject column <em>mapping</em> configs when a custom query is configured.
+   *
+   * <p>{@code timestamp.column.mapping} / {@code incrementing.column.mapping} map columns by
+   * table-name regex and are only honored on the table-filtering path (they require a
+   * {@code table.include.list}, which cannot be combined with a query). In query mode there is
+   * no table for the regex to match, so these mappings are silently ignored at runtime and the
+   * connector falls back to the legacy {@code *.column.name} configs. Rather than letting a user
+   * believe a mapping is in effect, reject it up front with a dedicated, distinct error that
+   * points them at the supported name config for query mode.
+   */
+  private boolean validateMappingConfigsNotUsedWithQuery() {
+    if (!config.getQuery().isPresent()) {
+      return true;
+    }
+
+    boolean valid = true;
+
+    List<String> incrementingColumnMapping = config.getIncrementingColumnMapping();
+    if (incrementingColumnMapping != null && !incrementingColumnMapping.isEmpty()) {
+      String msg = String.format(
+          "'%s' is not supported with a custom query. Column mappings match columns by "
+          + "table-name regex, which does not apply in query mode. Use '%s' instead.",
+          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG,
+          JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+      addConfigError(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG, msg);
+      log.error(msg);
+      valid = false;
+    }
+
+    List<String> timestampColumnsMapping = config.getTimestampColumnMapping();
+    if (timestampColumnsMapping != null && !timestampColumnsMapping.isEmpty()) {
+      String msg = String.format(
+          "'%s' is not supported with a custom query. Column mappings match columns by "
+          + "table-name regex, which does not apply in query mode. Use '%s' instead.",
+          JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG,
+          JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG);
+      addConfigError(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_MAPPING_CONFIG, msg);
+      log.error(msg);
+      valid = false;
+    }
+
+    return valid;
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -88,6 +88,7 @@ public class JdbcSourceConnectorValidation {
       boolean validationResult = validateMultiConfigs()
           && validateLegacyNewConfigCompatibility()
           && validateQueryConfigs()
+          && validateQueryModeColumnRequirements()
           && validateQuerySemantics();
 
       if (validationResult && isUsingNewConfigs()) {
@@ -359,6 +360,60 @@ public class JdbcSourceConnectorValidation {
     }
 
     return true;
+  }
+
+  /**
+   * Validate that, in query mode, the mode-dependent column names are explicitly provided.
+   *
+   * <p>In query mode the querier is constructed without a {@code TableId}, so the connector
+   * cannot auto-discover the incrementing column from table metadata the way it can in table
+   * mode. With mode {@code incrementing} / {@code timestamp+incrementing} and an empty
+   * {@code incrementing.column.name}, or mode {@code timestamp} / {@code timestamp+incrementing}
+   * and an empty {@code timestamp.column.name}, the connector hits an unrecoverable
+   * {@link NullPointerException} on every poll (the task is killed and restarted indefinitely).
+   * Fail fast at validation time instead so the misconfiguration is caught at create / validate.
+   */
+  private boolean validateQueryModeColumnRequirements() {
+    if (!config.getQuery().isPresent()) {
+      return true;
+    }
+
+    boolean valid = true;
+
+    if (config.modeUsesIncrementingColumn()) {
+      String incrementingColumnName = config.getIncrementingColumnName();
+      if (incrementingColumnName == null || incrementingColumnName.trim().isEmpty()) {
+        String msg = String.format(
+            "'%s' must be provided when using mode '%s' or '%s' with a custom query. "
+            + "The incrementing column cannot be auto-discovered in query mode because there "
+            + "is no table to inspect.",
+            JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG,
+            JdbcSourceConnectorConfig.MODE_INCREMENTING,
+            JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+        addConfigError(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG, msg);
+        log.error(msg);
+        valid = false;
+      }
+    }
+
+    if (config.modeUsesTimestampColumn()) {
+      List<String> timestampColumnName = config.getTimestampColumnName();
+      boolean hasTimestampColumn = timestampColumnName != null
+          && timestampColumnName.stream()
+              .anyMatch(col -> col != null && !col.trim().isEmpty());
+      if (!hasTimestampColumn) {
+        String msg = String.format(
+            "'%s' must be provided when using mode '%s' or '%s' with a custom query.",
+            JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG,
+            JdbcSourceConnectorConfig.MODE_TIMESTAMP,
+            JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+        addConfigError(JdbcSourceConnectorConfig.TIMESTAMP_COLUMN_NAME_CONFIG, msg);
+        log.error(msg);
+        valid = false;
+      }
+    }
+
+    return valid;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -937,8 +937,7 @@ public class JdbcSourceConnectorValidationTest {
 
   @Test
   public void validate_withQueryAndTimestampIncrementingModeAndEmptyColumns_setsError() {
-    // Exact repro from the incident: mode=timestamp+incrementing, custom query,
-    // empty incrementing.column.name and empty timestamp.column.name.
+    // Exact incident repro: mode=timestamp+incrementing, custom query, both column names blank.
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "");
@@ -949,113 +948,276 @@ public class JdbcSourceConnectorValidationTest {
     assertErrors(2);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
     assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
-    assertErrorMatches(
-        INCREMENTING_COLUMN_NAME_CONFIG,
-        ".*must be provided when using mode.*with a custom query.*");
-    assertErrorMatches(
-        TIMESTAMP_COLUMN_NAME_CONFIG,
+    assertErrorMatches(INCREMENTING_COLUMN_NAME_CONFIG,
+        ".*incrementing column cannot be auto-discovered in query mode.*");
+    assertErrorMatches(TIMESTAMP_COLUMN_NAME_CONFIG,
         ".*must be provided when using mode.*with a custom query.*");
   }
 
   @Test
-  public void validate_withQueryAndIncrementingModeAndMissingIncrementingColumn_setsError() {
+  public void validate_withQueryAndIncrementingModeMissingColumn_setsError() {
+    // Covers every way the incrementing column can be "missing" in query mode (incrementing /
+    // timestamp+incrementing both auto-discover, which NPEs without a table): unset, blank,
+    // whitespace-only, and via query.masked.
+
+    // incrementing.column.name not set at all.
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    // incrementing.column.name not set at all
-
     validate();
-
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
-    assertErrorMatches(
-        INCREMENTING_COLUMN_NAME_CONFIG,
+    assertErrorMatches(INCREMENTING_COLUMN_NAME_CONFIG,
         ".*incrementing column cannot be auto-discovered in query mode.*");
-  }
 
-  @Test
-  public void validate_withQueryAndIncrementingModeAndEmptyIncrementingColumn_setsError() {
+    // whitespace-only incrementing.column.name (trim path).
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "   ");
-
     validate();
-
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
-  }
 
-  @Test
-  public void validate_withQueryMaskedAndIncrementingModeAndMissingColumn_setsError() {
+    // query.masked resolves to query mode the same way as query.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
-    // incrementing.column.name not set at all
-
     validate();
-
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
   }
 
   @Test
-  public void validate_withQueryAndTimestampModeAndMissingTimestampColumn_setsError() {
+  public void validate_withQueryAndTimestampModeMissingColumn_setsError() {
+    // Covers every way the timestamp column can be "missing" in query mode: unset, whitespace,
+    // and via query.masked.
+
+    // timestamp.column.name not set at all.
     props.put(MODE_CONFIG, MODE_TIMESTAMP);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    // timestamp.column.name not set at all
-
     validate();
-
     assertErrors(1);
     assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
-    assertErrorMatches(
-        TIMESTAMP_COLUMN_NAME_CONFIG,
+    assertErrorMatches(TIMESTAMP_COLUMN_NAME_CONFIG,
         ".*must be provided when using mode.*with a custom query.*");
+
+    // whitespace-only timestamp.column.name (trim path).
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "   ");
+    validate();
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+
+    // query.masked resolves to query mode the same way as query.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
+    validate();
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
   }
 
   @Test
-  public void validate_withQueryAndTimestampIncrementingModeAndAllColumns_noErrors() {
+  public void validate_withQueryAndTimestampIncrementingModePartialColumns_setsError() {
+    // timestamp+incrementing needs BOTH columns; providing only one must still flag the other.
+
+    // only incrementing.column.name provided -> timestamp error remains.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    validate();
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+
+    // only timestamp.column.name provided -> incrementing error remains.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
+    validate();
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryAndRequiredColumnsProvided_noErrors() {
+    // All valid query-mode configurations must pass: each ts/inc mode with its required name
+    // config, and bulk mode (which needs no column).
+
+    // timestamp+incrementing with both names.
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
     props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
-
     validate();
-
     assertNoErrors();
-  }
 
-  @Test
-  public void validate_withQueryAndIncrementingModeAndIncrementingColumn_noErrors() {
+    // incrementing with incrementing.column.name.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-
     validate();
-
     assertNoErrors();
-  }
 
-  @Test
-  public void validate_withQueryAndBulkModeAndNoColumns_noErrors() {
-    // Bulk mode does not require any incrementing/timestamp column, even in query mode.
+    // timestamp with timestamp.column.name.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
+    validate();
+    assertNoErrors();
+
+    // bulk mode requires no column, even in query mode.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_BULK);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-
     validate();
-
     assertNoErrors();
   }
 
   @Test
-  public void validate_withQueryAndTimestampIncrementingModeAndOnlyIncrementingColumn_setsError() {
+  public void validate_withQueryAndIncrementingColumnMapping_setsMappingNotSupportedError() {
+    // incrementing.column.mapping maps columns by table-name regex and is unsupported with a
+    // custom query regardless of mode / query form. It must be rejected with a dedicated error
+    // on the mapping config, pointing the user at incrementing.column.name.
+
+    // incrementing mode.
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
+    validate();
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
+    assertErrorMatches(INCREMENTING_COLUMN_MAPPING_CONFIG,
+        "'incrementing.column.mapping' is not supported with a custom query.*"
+            + "Use 'incrementing.column.name' instead.");
+
+    // query.masked variant.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
+    validate();
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
+
+    // mode-independent: rejected even in bulk mode.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
+    validate();
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryAndTimestampColumnMapping_setsMappingNotSupportedError() {
+    // timestamp.columns.mapping is likewise unsupported with a custom query, across modes and
+    // query forms. (incrementing.column.name is supplied where needed so the only flagged
+    // problem is the timestamp mapping.)
+
+    // timestamp mode.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
+    validate();
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
+    assertErrorMatches(TIMESTAMP_COLUMN_MAPPING_CONFIG,
+        "'timestamp.columns.mapping' is not supported with a custom query.*"
+            + "Use 'timestamp.column.name' instead.");
+
+    // timestamp+incrementing mode (incrementing name supplied to isolate the mapping error).
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    // timestamp.column.name missing
+    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
+    validate();
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
+
+    // query.masked variant.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
+    validate();
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryAndBothColumnMappings_setsMappingNotSupportedErrors() {
+    // Both mapping configs set with a query -> one dedicated error on each.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
+    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
 
     validate();
 
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+    assertErrors(2);
+    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
+    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
+    assertErrorMatches(INCREMENTING_COLUMN_MAPPING_CONFIG,
+        ".*is not supported with a custom query.*");
+    assertErrorMatches(TIMESTAMP_COLUMN_MAPPING_CONFIG,
+        ".*is not supported with a custom query.*");
+  }
+
+  @Test
+  public void validate_withTableModeAndMappingsNoQuery_unaffectedByQueryModeChecks_noErrors() {
+    // Both query-mode guards must be no-ops when no query is configured: mapping-based configs
+    // on the table-filtering (table.include.list) path remain fully valid for ts/inc modes.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(TABLE_INCLUDE_LIST_CONFIG, "database.schema.table.*");
+    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
+    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
+
+    validate();
+
+    assertNoErrors();
   }
 
   // ========== Semantic Query Validation Tests ==========

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -974,88 +974,96 @@ public class JdbcSourceConnectorValidationTest {
   // (INC-10982): in query mode an empty incrementing.column.name with an incrementing-tracking
   // mode makes TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn NPE on every
   // poll. The check is scoped to that one shape; everything else is left to existing validation.
+  // (Base props are set in beforeEach.)
 
   @Test
-  public void validate_withQueryAndIncrementingColumnMissing_setsError() {
-    // The rejected (NPE-causing) shape: query + incrementing-tracking mode + no usable
-    // incrementing.column.name, across the empty/whitespace/query.masked forms and both modes.
-
+  public void validate_withQueryAndIncrementingModeAndUnsetColumn_setsError() {
     // incrementing mode, incrementing.column.name not set at all.
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+
     validate();
+
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
     assertErrorMatches(INCREMENTING_COLUMN_NAME_CONFIG,
         ".*incrementing column cannot be auto-discovered in query mode.*");
+  }
 
+  @Test
+  public void validate_withQueryAndIncrementingModeAndWhitespaceColumn_setsError() {
     // incrementing mode, whitespace-only incrementing.column.name (trim path).
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "   ");
+
     validate();
+
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+  }
 
+  @Test
+  public void validate_withQueryMaskedAndIncrementingModeAndMissingColumn_setsError() {
     // query.masked resolves to query mode the same way as query.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
+
     validate();
+
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+  }
 
-    // incident repro: timestamp+incrementing with both names blank -> only the incrementing
+  @Test
+  public void validate_withQueryAndTimestampIncrementingModeAndEmptyColumns_setsError() {
+    // Incident repro: timestamp+incrementing with both names blank -> only the incrementing
     // error (the timestamp side does not NPE and is no longer rejected).
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "");
     props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "");
+
     validate();
+
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
   }
 
   @Test
-  public void validate_withQueryAndIncrementingColumnProvided_noErrors() {
+  public void validate_withQueryAndIncrementingModeAndColumn_noErrors() {
     // incrementing mode with incrementing.column.name.
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    validate();
-    assertNoErrors();
 
-    // timestamp+incrementing with only the incrementing name set (timestamp missing) -> runs
-    // today (tracks by the incrementing column), so it must NOT be rejected.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
     validate();
+
     assertNoErrors();
   }
 
   @Test
-  public void validate_withQueryAndNonIncrementingMode_noErrors() {
+  public void validate_withQueryAndTimestampIncrementingModeAndOnlyIncrementingColumn_noErrors() {
+    // timestamp+incrementing with only the incrementing name set (timestamp missing) -> runs
+    // today (tracks by the incrementing column), so it must NOT be rejected.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryAndTimestampModeWithoutColumn_noErrors() {
     // The check applies only to incrementing-tracking modes: timestamp mode without a column
     // does not NPE and must NOT be rejected (it runs today).
     props.put(MODE_CONFIG, MODE_TIMESTAMP);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+
     validate();
+
     assertNoErrors();
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -929,38 +929,20 @@ public class JdbcSourceConnectorValidationTest {
     );
   }
 
-  // ========== Query-Mode Column Requirement Tests ==========
-  // These guard against the runtime NPE (INC-10982) that occurs when a custom query is
-  // configured with an incrementing/timestamp mode but no incrementing.column.name /
-  // timestamp.column.name. In query mode the querier has no TableId to auto-discover from,
-  // so TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn NPEs on every poll.
+  // ========== Query-Mode Incrementing-Column Requirement Tests ==========
+  // These guard against the runtime NPE (INC-10982): in query mode the querier has no TableId to
+  // auto-discover from, so an empty incrementing.column.name with an incrementing-tracking mode
+  // makes TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn NPE on every poll.
+  // Only this incrementing case crashes; a missing timestamp.column.name does not NPE (pure
+  // timestamp mode passes null for the incrementing column), and the unsupported-in-query-mode
+  // column mapping configs are silently ignored at runtime, so neither is rejected here.
 
   @Test
-  public void validate_withQueryAndTimestampIncrementingModeAndEmptyColumns_setsError() {
-    // Exact incident repro: mode=timestamp+incrementing, custom query, both column names blank.
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "");
-    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "");
+  public void validate_withQueryAndIncrementingColumnMissing_setsError() {
+    // The only rejected (NPE-causing) shape: query + incrementing-tracking mode + no usable
+    // incrementing.column.name. Covered across every "missing" form and both modes.
 
-    validate();
-
-    assertErrors(2);
-    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
-    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
-    assertErrorMatches(INCREMENTING_COLUMN_NAME_CONFIG,
-        ".*incrementing column cannot be auto-discovered in query mode.*");
-    assertErrorMatches(TIMESTAMP_COLUMN_NAME_CONFIG,
-        ".*must be provided when using mode.*with a custom query.*");
-  }
-
-  @Test
-  public void validate_withQueryAndIncrementingModeMissingColumn_setsError() {
-    // Covers every way the incrementing column can be "missing" in query mode (incrementing /
-    // timestamp+incrementing both auto-discover, which NPEs without a table): unset, blank,
-    // whitespace-only, and via query.masked.
-
-    // incrementing.column.name not set at all.
+    // incrementing mode, incrementing.column.name not set at all.
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     validate();
@@ -969,7 +951,7 @@ public class JdbcSourceConnectorValidationTest {
     assertErrorMatches(INCREMENTING_COLUMN_NAME_CONFIG,
         ".*incrementing column cannot be auto-discovered in query mode.*");
 
-    // whitespace-only incrementing.column.name (trim path).
+    // incrementing mode, whitespace-only incrementing.column.name (trim path).
     props.clear();
     props.put("name", "jdbc-connector");
     props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
@@ -991,59 +973,22 @@ public class JdbcSourceConnectorValidationTest {
     validate();
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
-  }
 
-  @Test
-  public void validate_withQueryAndTimestampModeMissingColumn_setsError() {
-    // Covers every way the timestamp column can be "missing" in query mode: unset, whitespace,
-    // and via query.masked.
-
-    // timestamp.column.name not set at all.
-    props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    validate();
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
-    assertErrorMatches(TIMESTAMP_COLUMN_NAME_CONFIG,
-        ".*must be provided when using mode.*with a custom query.*");
-
-    // whitespace-only timestamp.column.name (trim path).
+    // incident repro: timestamp+incrementing with both names blank -> only the incrementing
+    // error (the timestamp side does not NPE and is no longer rejected).
     props.clear();
     props.put("name", "jdbc-connector");
     props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
     props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "   ");
-    validate();
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
-
-    // query.masked resolves to query mode the same way as query.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
-    validate();
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
-  }
-
-  @Test
-  public void validate_withQueryAndTimestampIncrementingModePartialColumns_setsError() {
-    // timestamp+incrementing needs BOTH columns; providing only one must still flag the other.
-
-    // only incrementing.column.name provided -> timestamp error remains.
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "");
     validate();
     assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
 
-    // only timestamp.column.name provided -> incrementing error remains.
+    // timestamp+incrementing with only the timestamp name set -> incrementing error remains.
     props.clear();
     props.put("name", "jdbc-connector");
     props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
@@ -1054,14 +999,34 @@ public class JdbcSourceConnectorValidationTest {
     validate();
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+
+    // a column mapping does not substitute for the required name: still the NPE error.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
+    validate();
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
   }
 
   @Test
-  public void validate_withQueryAndRequiredColumnsProvided_noErrors() {
-    // All valid query-mode configurations must pass: each ts/inc mode with its required name
-    // config, and bulk mode (which needs no column).
+  public void validate_withQueryAndIncrementingColumnProvided_noErrors() {
+    // incrementing mode with incrementing.column.name.
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    validate();
+    assertNoErrors();
 
     // timestamp+incrementing with both names.
+    props.clear();
+    props.put("name", "jdbc-connector");
+    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
+    props.put(CONNECTION_USER_CONFIG, "testUser");
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
@@ -1069,18 +1034,30 @@ public class JdbcSourceConnectorValidationTest {
     validate();
     assertNoErrors();
 
-    // incrementing with incrementing.column.name.
+    // timestamp+incrementing with only the incrementing name set (timestamp missing) -> runs
+    // today (tracks by the incrementing column), so it must NOT be rejected.
     props.clear();
     props.put("name", "jdbc-connector");
     props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
     props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
     validate();
     assertNoErrors();
+  }
 
-    // timestamp with timestamp.column.name.
+  @Test
+  public void validate_withQueryAndTimestampOrBulkModeWithoutColumns_noErrors() {
+    // A missing timestamp.column.name does not NPE; these run today, so they must NOT be rejected.
+
+    // timestamp mode with no timestamp.column.name.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    validate();
+    assertNoErrors();
+
+    // timestamp mode with a timestamp.column.name.
     props.clear();
     props.put("name", "jdbc-connector");
     props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
@@ -1103,65 +1080,19 @@ public class JdbcSourceConnectorValidationTest {
   }
 
   @Test
-  public void validate_withQueryAndIncrementingColumnMapping_setsMappingNotSupportedError() {
-    // incrementing.column.mapping maps columns by table-name regex and is unsupported with a
-    // custom query regardless of mode / query form. It must be rejected with a dedicated error
-    // on the mapping config, pointing the user at incrementing.column.name.
+  public void validate_withQueryAndColumnMappings_noErrors() {
+    // Column mapping configs are silently ignored in query mode (no table for the regex to
+    // match); a connector can run today with this combination, so validation must NOT fail it.
 
-    // incrementing mode.
-    props.put(MODE_CONFIG, MODE_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-    validate();
-    assertErrors(1);
-    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
-    assertErrorMatches(INCREMENTING_COLUMN_MAPPING_CONFIG,
-        "'incrementing.column.mapping' is not supported with a custom query.*"
-            + "Use 'incrementing.column.name' instead.");
-
-    // query.masked variant.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_INCREMENTING);
-    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-    validate();
-    assertErrors(1);
-    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
-
-    // mode-independent: rejected even in bulk mode.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-    validate();
-    assertErrors(1);
-    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
-  }
-
-  @Test
-  public void validate_withQueryAndTimestampColumnMapping_setsMappingNotSupportedError() {
-    // timestamp.columns.mapping is likewise unsupported with a custom query, across modes and
-    // query forms. (incrementing.column.name is supplied where needed so the only flagged
-    // problem is the timestamp mapping.)
-
-    // timestamp mode.
+    // timestamp mode + timestamp.columns.mapping, no name -> no error (timestamp not required).
     props.put(MODE_CONFIG, MODE_TIMESTAMP);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
     validate();
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
-    assertErrorMatches(TIMESTAMP_COLUMN_MAPPING_CONFIG,
-        "'timestamp.columns.mapping' is not supported with a custom query.*"
-            + "Use 'timestamp.column.name' instead.");
+    assertNoErrors();
 
-    // timestamp+incrementing mode (incrementing name supplied to isolate the mapping error).
+    // timestamp+incrementing + incrementing.column.name + both mappings -> no error (the name
+    // satisfies the NPE guard; the mappings are accepted and ignored).
     props.clear();
     props.put("name", "jdbc-connector");
     props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
@@ -1169,46 +1100,15 @@ public class JdbcSourceConnectorValidationTest {
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
-    validate();
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
-
-    // query.masked variant.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
-    validate();
-    assertErrors(1);
-    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
-  }
-
-  @Test
-  public void validate_withQueryAndBothColumnMappings_setsMappingNotSupportedErrors() {
-    // Both mapping configs set with a query -> one dedicated error on each.
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
     props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
-
     validate();
-
-    assertErrors(2);
-    assertErrors(INCREMENTING_COLUMN_MAPPING_CONFIG, 1);
-    assertErrors(TIMESTAMP_COLUMN_MAPPING_CONFIG, 1);
-    assertErrorMatches(INCREMENTING_COLUMN_MAPPING_CONFIG,
-        ".*is not supported with a custom query.*");
-    assertErrorMatches(TIMESTAMP_COLUMN_MAPPING_CONFIG,
-        ".*is not supported with a custom query.*");
+    assertNoErrors();
   }
 
   @Test
-  public void validate_withTableModeAndMappingsNoQuery_unaffectedByQueryModeChecks_noErrors() {
-    // Both query-mode guards must be no-ops when no query is configured: mapping-based configs
+  public void validate_withTableModeAndMappingsNoQuery_unaffectedByQueryModeCheck_noErrors() {
+    // The query-mode guard must be a no-op when no query is configured: mapping-based configs
     // on the table-filtering (table.include.list) path remain fully valid for ts/inc modes.
     props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
     props.put(TABLE_INCLUDE_LIST_CONFIG, "database.schema.table.*");

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -970,17 +970,15 @@ public class JdbcSourceConnectorValidationTest {
   }
 
   // ========== Query-Mode Incrementing-Column Requirement Tests ==========
-  // These guard against the runtime NPE (INC-10982): in query mode the querier has no TableId to
-  // auto-discover from, so an empty incrementing.column.name with an incrementing-tracking mode
-  // makes TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn NPE on every poll.
-  // Only this incrementing case crashes; a missing timestamp.column.name does not NPE (pure
-  // timestamp mode passes null for the incrementing column), and the unsupported-in-query-mode
-  // column mapping configs are silently ignored at runtime, so neither is rejected here.
+  // These exercise validateQueryModeIncrementingColumnRequired, which guards the runtime NPE
+  // (INC-10982): in query mode an empty incrementing.column.name with an incrementing-tracking
+  // mode makes TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn NPE on every
+  // poll. The check is scoped to that one shape; everything else is left to existing validation.
 
   @Test
   public void validate_withQueryAndIncrementingColumnMissing_setsError() {
-    // The only rejected (NPE-causing) shape: query + incrementing-tracking mode + no usable
-    // incrementing.column.name. Covered across every "missing" form and both modes.
+    // The rejected (NPE-causing) shape: query + incrementing-tracking mode + no usable
+    // incrementing.column.name, across the empty/whitespace/query.masked forms and both modes.
 
     // incrementing mode, incrementing.column.name not set at all.
     props.put(MODE_CONFIG, MODE_INCREMENTING);
@@ -1027,30 +1025,6 @@ public class JdbcSourceConnectorValidationTest {
     validate();
     assertErrors(1);
     assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
-
-    // timestamp+incrementing with only the timestamp name set -> incrementing error remains.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
-    validate();
-    assertErrors(1);
-    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
-
-    // a column mapping does not substitute for the required name: still the NPE error.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-    validate();
-    assertErrors(1);
-    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
   }
 
   @Test
@@ -1059,18 +1033,6 @@ public class JdbcSourceConnectorValidationTest {
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    validate();
-    assertNoErrors();
-
-    // timestamp+incrementing with both names.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
     validate();
     assertNoErrors();
 
@@ -1088,75 +1050,12 @@ public class JdbcSourceConnectorValidationTest {
   }
 
   @Test
-  public void validate_withQueryAndTimestampOrBulkModeWithoutColumns_noErrors() {
-    // A missing timestamp.column.name does not NPE; these run today, so they must NOT be rejected.
-
-    // timestamp mode with no timestamp.column.name.
+  public void validate_withQueryAndNonIncrementingMode_noErrors() {
+    // The check applies only to incrementing-tracking modes: timestamp mode without a column
+    // does not NPE and must NOT be rejected (it runs today).
     props.put(MODE_CONFIG, MODE_TIMESTAMP);
     props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
     validate();
-    assertNoErrors();
-
-    // timestamp mode with a timestamp.column.name.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
-    validate();
-    assertNoErrors();
-
-    // bulk mode requires no column, even in query mode.
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    validate();
-    assertNoErrors();
-  }
-
-  @Test
-  public void validate_withQueryAndColumnMappings_noErrors() {
-    // Column mapping configs are silently ignored in query mode (no table for the regex to
-    // match); a connector can run today with this combination, so validation must NOT fail it.
-
-    // timestamp mode + timestamp.columns.mapping, no name -> no error (timestamp not required).
-    props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
-    validate();
-    assertNoErrors();
-
-    // timestamp+incrementing + incrementing.column.name + both mappings -> no error (the name
-    // satisfies the NPE guard; the mappings are accepted and ignored).
-    props.clear();
-    props.put("name", "jdbc-connector");
-    props.put(CONNECTION_URL_CONFIG, "jdbc:postgresql://localhost:5432/testdb");
-    props.put(CONNECTION_USER_CONFIG, "testUser");
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
-    validate();
-    assertNoErrors();
-  }
-
-  @Test
-  public void validate_withTableModeAndMappingsNoQuery_unaffectedByQueryModeCheck_noErrors() {
-    // The query-mode guard must be a no-op when no query is configured: mapping-based configs
-    // on the table-filtering (table.include.list) path remain fully valid for ts/inc modes.
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(TABLE_INCLUDE_LIST_CONFIG, "database.schema.table.*");
-    props.put(TIMESTAMP_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:[ts_col1|ts_col2]");
-    props.put(INCREMENTING_COLUMN_MAPPING_CONFIG, "database.schema.table_test.*:inc_col1");
-
-    validate();
-
     assertNoErrors();
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -929,6 +929,135 @@ public class JdbcSourceConnectorValidationTest {
     );
   }
 
+  // ========== Query-Mode Column Requirement Tests ==========
+  // These guard against the runtime NPE (INC-10982) that occurs when a custom query is
+  // configured with an incrementing/timestamp mode but no incrementing.column.name /
+  // timestamp.column.name. In query mode the querier has no TableId to auto-discover from,
+  // so TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn NPEs on every poll.
+
+  @Test
+  public void validate_withQueryAndTimestampIncrementingModeAndEmptyColumns_setsError() {
+    // Exact repro from the incident: mode=timestamp+incrementing, custom query,
+    // empty incrementing.column.name and empty timestamp.column.name.
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "");
+
+    validate();
+
+    assertErrors(2);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+    assertErrorMatches(
+        INCREMENTING_COLUMN_NAME_CONFIG,
+        ".*must be provided when using mode.*with a custom query.*");
+    assertErrorMatches(
+        TIMESTAMP_COLUMN_NAME_CONFIG,
+        ".*must be provided when using mode.*with a custom query.*");
+  }
+
+  @Test
+  public void validate_withQueryAndIncrementingModeAndMissingIncrementingColumn_setsError() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    // incrementing.column.name not set at all
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+    assertErrorMatches(
+        INCREMENTING_COLUMN_NAME_CONFIG,
+        ".*incrementing column cannot be auto-discovered in query mode.*");
+  }
+
+  @Test
+  public void validate_withQueryAndIncrementingModeAndEmptyIncrementingColumn_setsError() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "   ");
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryMaskedAndIncrementingModeAndMissingColumn_setsError() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM dbo.SomeTable");
+    // incrementing.column.name not set at all
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(INCREMENTING_COLUMN_NAME_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryAndTimestampModeAndMissingTimestampColumn_setsError() {
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    // timestamp.column.name not set at all
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+    assertErrorMatches(
+        TIMESTAMP_COLUMN_NAME_CONFIG,
+        ".*must be provided when using mode.*with a custom query.*");
+  }
+
+  @Test
+  public void validate_withQueryAndTimestampIncrementingModeAndAllColumns_noErrors() {
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "modified_at");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryAndIncrementingModeAndIncrementingColumn_noErrors() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryAndBulkModeAndNoColumns_noErrors() {
+    // Bulk mode does not require any incrementing/timestamp column, even in query mode.
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryAndTimestampIncrementingModeAndOnlyIncrementingColumn_setsError() {
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM dbo.SomeTable");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    // timestamp.column.name missing
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(TIMESTAMP_COLUMN_NAME_CONFIG, 1);
+  }
+
   // ========== Semantic Query Validation Tests ==========
 
   @Test


### PR DESCRIPTION
## Problem
In query mode the table querier is constructed with a null `TableId`. For `mode=incrementing` or `timestamp+incrementing` with an empty `incrementing.column.name`, `TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn` tries to auto-discover the column and dereferences the null `TableId`, throwing an unrecoverable `NullPointerException` on every poll (INC-10982). The task is killed and restarted indefinitely, yet the misconfiguration is silently accepted at create / `config/validate` time.

```
java.lang.NullPointerException: Cannot invoke
  "io.confluent.connect.jdbc.util.TableId.catalogName()" because "this.tableId" is null
    at TimestampIncrementingTableQuerier.findDefaultAutoIncrementingColumn(:203)
    at TimestampIncrementingTableQuerier.createPreparedStatement(:140)
```

## Solution
Add `validateQueryModeIncrementingColumnRequired()` to `JdbcSourceConnectorValidation`, in the validation chain after `validateQueryConfigs()` and before the DB-touching `validateQuerySemantics()` so it fails fast without needing a connection.

When a custom query (`query` or `query.masked`) is configured **and** the mode tracks an incrementing column (`incrementing` / `timestamp+incrementing`), require a non-empty `incrementing.column.name`. The error is attached to the `incrementing.column.name` config with an actionable message, so the misconfiguration is rejected at create / `config/validate`.

**Scope (deliberately narrow, per review feedback):**
- Limited to the **incrementing column only**, because that is the only shape that NPEs. A missing `timestamp.column.name` does **not** crash — `TimestampTableQuerier` passes `null` for the incrementing column, so the auto-discovery branch is skipped. Such connectors run today (pure `timestamp` re-reads without advancing offset; `timestamp+incrementing` with the incrementing column set tracks correctly), so they are intentionally **not** rejected — avoiding flipping currently-running connectors to a validation error on the next config roll.
- Column mapping configs (`incrementing.column.mapping` / `timestamp.columns.mapping`) are **not** rejected with a query either; they are silently ignored at runtime, and connectors run with that combination today.

This keeps the change strictly NPE-prevention and **not stricter-than-before** for any config that currently runs, so no mothership audit is required to ship.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Tests in `JdbcSourceConnectorValidationTest`, scoped to the new check:
- **Rejected:** `query` + `incrementing` / `timestamp+incrementing` + empty `incrementing.column.name` — covering unset, whitespace-only, `query.masked`, and the `timestamp+incrementing` both-columns-empty incident repro.
- **Allowed (no error):** `incrementing.column.name` provided; `timestamp+incrementing` with only the incrementing column set (timestamp missing); non-incrementing (`timestamp`) mode in query mode.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
Merging to master. Forward-only validation hardening; safe to revert (validation-only, no data-path changes).
