### PR TITLE
INC-11312: Strip catalog from Postgres-discovered TableIds + bump pgjdbc to 42.7.11 (CVE-2026-42198) — backport to 10.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>8.4.1.jre8</mssqlserver.jdbc.driver.version>
-        <postgresql.version>42.4.4</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -445,6 +445,25 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return false;
   }
 
+  /**
+   * Construct a {@link TableId} from identity components read from driver metadata
+   * ({@code getTables}, {@code getColumns}, {@code getPrimaryKeys}, result-set metadata).
+   * A dialect can override this to normalize discovered identifiers in one place. The
+   * catalog here comes from the driver, so it only ever echoes the connected database.
+   *
+   * <p>Identifiers parsed from configuration go through {@link #parseTableIdentifier(String)}
+   * and deliberately do not route through this seam: a configured catalog is user intent,
+   * not driver noise, and must be preserved.
+   *
+   * @param catalogName the catalog name reported by the driver; may be null
+   * @param schemaName  the schema name reported by the driver; may be null
+   * @param tableName   the table name reported by the driver; never null
+   * @return the table identifier; never null
+   */
+  protected TableId createTableId(String catalogName, String schemaName, String tableName) {
+    return new TableId(catalogName, schemaName, tableName);
+  }
+
   @Override
   public List<TableId> tableIds(Connection conn) throws SQLException {
     DatabaseMetaData metadata = conn.getMetaData();
@@ -458,7 +477,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         String catalogName = rs.getString(1);
         String schemaName = rs.getString(2);
         String tableName = rs.getString(3);
-        TableId tableId = new TableId(catalogName, schemaName, tableName);
+        TableId tableId = createTableId(catalogName, schemaName, tableName);
         if (includeTable(tableId)) {
           tableIds.add(tableId);
         }
@@ -709,7 +728,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         final String catalogName = rs.getString(1);
         final String schemaName = rs.getString(2);
         final String tableName = rs.getString(3);
-        final TableId tableId = new TableId(catalogName, schemaName, tableName);
+        final TableId tableId = createTableId(catalogName, schemaName, tableName);
         final String columnName = rs.getString(4);
         final ColumnId columnId = new ColumnId(tableId, columnName, null);
         final int jdbcType = rs.getInt(5);
@@ -801,7 +820,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     String catalog = rsMetadata.getCatalogName(column);
     String schema = rsMetadata.getSchemaName(column);
     String tableName = rsMetadata.getTableName(column);
-    TableId tableId = new TableId(catalog, schema, tableName);
+    TableId tableId = createTableId(catalog, schema, tableName);
     String name = rsMetadata.getColumnName(column);
     String alias = rsMetadata.getColumnLabel(column);
     ColumnId id = new ColumnId(tableId, name, alias);
@@ -860,7 +879,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         String catalogName = rs.getString(1);
         String schemaName = rs.getString(2);
         String tableName = rs.getString(3);
-        TableId tableId = new TableId(catalogName, schemaName, tableName);
+        TableId tableId = createTableId(catalogName, schemaName, tableName);
         final String colName = rs.getString(4);
         ColumnId columnId = new ColumnId(tableId, colName);
         pkColumns.add(columnId);

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -101,6 +101,23 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>A PostgreSQL connection sees exactly one database, so the catalog the driver reports
+   * only echoes the connected database and adds no information. pgjdbc 42.7.5+ reports that
+   * name where older drivers returned {@code null}, which turned discovered identifiers into
+   * three-part {@code db.schema.table} names — breaking two-part {@code table.include.list}
+   * matching and changing source-offset partition keys. Dropping the driver-reported catalog
+   * keeps discovered identifiers two-part on any driver version. Configured catalogs are not
+   * affected: they arrive via {@link #parseTableIdentifier(String)}, which does not route
+   * through this seam, so a user-supplied database in {@code table.name.format} is preserved.
+   */
+  @Override
+  protected TableId createTableId(String catalogName, String schemaName, String tableName) {
+    return new TableId(null, schemaName, tableName);
+  }
+
   @Override
   public String resolveSynonym(Connection connection, String synonymName) throws SQLException {
     throw new SQLException("PostgreSQL does not support synonyms. Please use views instead.");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -522,7 +522,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
         String catalogName = rs.getString(1);
         String schemaName = rs.getString(2);
         String tableName = rs.getString(3);
-        TableId tableId = new TableId(catalogName, schemaName, tableName);
+        TableId tableId = createTableId(catalogName, schemaName, tableName);
         if (includeTable(tableId)) {
           tableIds.add(tableId);
         }
@@ -545,7 +545,7 @@ public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
           String schemaName = synonymRs.getString(2);
           String synonymName = synonymRs.getString(3);
 
-          TableId tableId = new TableId(catalogName, schemaName, synonymName);
+          TableId tableId = createTableId(catalogName, schemaName, synonymName);
           if (includeTable(tableId)) {
             tableIds.add(tableId);
           }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -33,9 +33,11 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -43,14 +45,24 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
+
+  private static final String METADATA_CATALOG = "postgres";
+  private static final String METADATA_SCHEMA = "public";
+  private static final String CUSTOMERS_TABLE = "customers";
+  private static final String ORDERS_TABLE = "orders";
+  private static final String VARCHAR_TYPE = "varchar";
 
   @Override
   protected PostgreSqlDatabaseDialect createDialect() {
@@ -196,10 +208,10 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     TableDefinition tableDefn = builder.build();
     assertEquals(
         "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
@@ -219,7 +231,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, Integer.class);
     builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
     builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
     tableDefn = builder.build();
@@ -239,10 +251,10 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
-    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     TableDefinition tableDefn = builder.build();
     assertEquals(
         "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
@@ -268,7 +280,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, Integer.class);
     builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
     builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
     tableDefn = builder.build();
@@ -293,7 +305,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
     builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("columnA").type(VARCHAR_TYPE, JDBCType.VARCHAR, Integer.class);
     builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
     builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
     TableDefinition tableDefn = builder.build();
@@ -351,9 +363,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void upsert() {
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("Customer");
     builder.withColumn("id").type("int", JDBCType.INTEGER, Integer.class);
-    builder.withColumn("name").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("name").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     builder.withColumn("salary").type("real", JDBCType.FLOAT, String.class);
-    builder.withColumn("address").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("address").type(VARCHAR_TYPE, JDBCType.VARCHAR, String.class);
     TableDefinition tableDefn = builder.build();
     TableId customer = tableDefn.id();
     assertEquals(
@@ -510,6 +522,124 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     int actualMaxLength = PostgreSqlDatabaseDialect.computeMaxIdentifierLength(connection);
 
     assertEquals(Integer.MAX_VALUE, actualMaxLength);
+  }
+
+  @Test
+  public void shouldStripCatalogFromDiscoveredTableIds() throws Exception {
+    ResultSet tableTypesRs = mock(ResultSet.class);
+    when(tableTypesRs.next()).thenReturn(true, false);
+    when(tableTypesRs.getString(1)).thenReturn("TABLE");
+
+    // pgjdbc 42.7.5+ populates TABLE_CAT with the database name; older drivers returned null
+    ResultSet tablesRs = mock(ResultSet.class);
+    when(tablesRs.next()).thenReturn(true, true, false);
+    when(tablesRs.getString(1)).thenReturn(METADATA_CATALOG, METADATA_CATALOG);
+    when(tablesRs.getString(2)).thenReturn(METADATA_SCHEMA, "app");
+    when(tablesRs.getString(3)).thenReturn(CUSTOMERS_TABLE, ORDERS_TABLE);
+
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    when(metadata.getTableTypes()).thenReturn(tableTypesRs);
+    when(metadata.getTables(any(), any(), eq("%"), any(String[].class))).thenReturn(tablesRs);
+
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metadata);
+
+    assertEquals(
+        Arrays.asList(
+            new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+            new TableId(null, "app", ORDERS_TABLE)
+        ),
+        dialect.tableIds(connection)
+    );
+  }
+
+  @Test
+  public void shouldKeepTwoPartTableIdsOnOlderDrivers() throws Exception {
+    ResultSet tableTypesRs = mock(ResultSet.class);
+    when(tableTypesRs.next()).thenReturn(true, false);
+    when(tableTypesRs.getString(1)).thenReturn("TABLE");
+
+    // Drivers before 42.7.5 return a null TABLE_CAT; an empty string is covered for safety
+    ResultSet tablesRs = mock(ResultSet.class);
+    when(tablesRs.next()).thenReturn(true, true, false);
+    when(tablesRs.getString(1)).thenReturn(null, "");
+    when(tablesRs.getString(2)).thenReturn(METADATA_SCHEMA, "app");
+    when(tablesRs.getString(3)).thenReturn(CUSTOMERS_TABLE, ORDERS_TABLE);
+
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    when(metadata.getTableTypes()).thenReturn(tableTypesRs);
+    when(metadata.getTables(any(), any(), eq("%"), any(String[].class))).thenReturn(tablesRs);
+
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metadata);
+
+    assertEquals(
+        Arrays.asList(
+            new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+            new TableId(null, "app", ORDERS_TABLE)
+        ),
+        dialect.tableIds(connection)
+    );
+  }
+
+  @Test
+  public void shouldPreserveCatalogFromParsedTableIdentifiers() {
+    // Configured names (e.g. table.name.format) are user intent, not driver metadata, so the
+    // catalog strip does NOT apply here. A configured database must survive parsing: dropping
+    // it would let JdbcDbWriter back-fill the connected database and silently write to the
+    // wrong one instead of failing loudly on the cross-database reference.
+    assertEquals(
+        new TableId("mydb", METADATA_SCHEMA, CUSTOMERS_TABLE),
+        dialect.parseTableIdentifier("mydb." + METADATA_SCHEMA + "." + CUSTOMERS_TABLE)
+    );
+    assertEquals(
+        new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE),
+        dialect.parseTableIdentifier(METADATA_SCHEMA + "." + CUSTOMERS_TABLE)
+    );
+  }
+
+  @Test
+  public void shouldStripCatalogFromMetadataColumnIds() throws Exception {
+    // getPrimaryKeys and getColumns both report TABLE_CAT on pgjdbc 42.7.5+; the seam must
+    // normalize both sides of the pkColumns.contains comparison, not just discovered tables.
+    ResultSet pkRs = mock(ResultSet.class);
+    when(pkRs.next()).thenReturn(true, false);
+    when(pkRs.getString(1)).thenReturn(METADATA_CATALOG);
+    when(pkRs.getString(2)).thenReturn(METADATA_SCHEMA);
+    when(pkRs.getString(3)).thenReturn(CUSTOMERS_TABLE);
+    when(pkRs.getString(4)).thenReturn("id");
+
+    ResultSetMetaData colsRsMetadata = mock(ResultSetMetaData.class);
+    when(colsRsMetadata.getColumnCount()).thenReturn(12);
+
+    ResultSet colsRs = mock(ResultSet.class);
+    when(colsRs.getMetaData()).thenReturn(colsRsMetadata);
+    when(colsRs.next()).thenReturn(true, true, false);
+    when(colsRs.getString(1)).thenReturn(METADATA_CATALOG, METADATA_CATALOG);
+    when(colsRs.getString(2)).thenReturn(METADATA_SCHEMA, METADATA_SCHEMA);
+    when(colsRs.getString(3)).thenReturn(CUSTOMERS_TABLE, CUSTOMERS_TABLE);
+    when(colsRs.getString(4)).thenReturn("id", "name");
+    when(colsRs.getInt(5)).thenReturn(Types.INTEGER, Types.VARCHAR);
+    when(colsRs.getString(6)).thenReturn("int4", VARCHAR_TYPE);
+
+    DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+    when(metadata.getPrimaryKeys(METADATA_CATALOG, METADATA_SCHEMA, CUSTOMERS_TABLE)).thenReturn(pkRs);
+    when(metadata.getColumns(METADATA_CATALOG, METADATA_SCHEMA, CUSTOMERS_TABLE, null)).thenReturn(colsRs);
+
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metadata);
+
+    Map<ColumnId, ColumnDefinition> defns =
+        dialect.describeColumns(connection, METADATA_CATALOG, METADATA_SCHEMA, CUSTOMERS_TABLE, null);
+
+    TableId expectedTableId = new TableId(null, METADATA_SCHEMA, CUSTOMERS_TABLE);
+    assertEquals(2, defns.size());
+    for (ColumnId columnId : defns.keySet()) {
+      assertEquals(expectedTableId, columnId.tableId());
+    }
+    // The pk flag is only set when the pk id and column id agree on the identifier, i.e.
+    // both metadata paths were normalized consistently.
+    assertTrue(defns.get(new ColumnId(expectedTableId, "id")).isPrimaryKey());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/integration/PostgresLiteralIncludeListIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.integration;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.JdbcSourceConnector;
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression test for table discovery with a literal two-part {@code table.include.list}
+ * (the documented {@code schema.table} form, deliberately not a leading-{@code .*} regex).
+ *
+ * <p>pgjdbc 42.7.5+ returns the database name in {@code TABLE_CAT} from
+ * {@code DatabaseMetaData.getTables(...)} where older drivers returned {@code null}. Without
+ * the catalog strip in {@code PostgreSqlDatabaseDialect}, the discovered identifier becomes
+ * three-part ({@code db.schema.table}) and a literal two-part include list no longer matches,
+ * so the task fails with "not assigned a table nor a query".
+ *
+ * <p>Two cases are pinned: the documented two-part form must discover the table, and — as a
+ * boundary guard — a three-part form must NOT match the discovered two-part identifier. The
+ * latter documents that three-part include lists are unsupported today; if a future change
+ * made them start matching, that is new, unverified behaviour and this test will flag it.
+ * (Offset resumption is covered by the {@code *RestoreOffset*} unit tests in
+ * {@code JdbcSourceTaskUpdateTest}; a same-driver restart here would not add coverage.)
+ */
+@Category(IntegrationTest.class)
+public class PostgresLiteralIncludeListIT extends BaseConnectorIT {
+
+  private static final String CONNECTOR_NAME = "postgres-literal-include-list";
+  private static final String SCHEMA_NAME = "app";
+  private static final String TABLE_NAME = "customers";
+  private static final String TOPIC_PREFIX = "literal-";
+  private static final String TOPIC = TOPIC_PREFIX + TABLE_NAME;
+  private static final long POLLING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(2);
+  private static final long CONSUME_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+
+  @ClassRule
+  public static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:13")
+      .withDatabaseName("testdb")
+      .withUsername("test")
+      .withPassword("test123");
+
+  private static Connection connection;
+
+  private Map<String, String> props;
+
+  @BeforeClass
+  public static void setupClass() throws SQLException {
+    // The @ClassRule manages the container lifecycle; only the JDBC connection is set up here.
+    connection = DriverManager.getConnection(
+        postgres.getJdbcUrl(),
+        postgres.getUsername(),
+        postgres.getPassword()
+    );
+  }
+
+  @AfterClass
+  public static void teardownClass() throws SQLException {
+    if (connection != null && !connection.isClosed()) {
+      connection.close();
+    }
+  }
+
+  @Before
+  public void setup() throws SQLException {
+    startConnect();
+
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("CREATE SCHEMA " + SCHEMA_NAME);
+      stmt.execute("CREATE TABLE " + SCHEMA_NAME + "." + TABLE_NAME + " ("
+          + "id SERIAL PRIMARY KEY, "
+          + "name VARCHAR(100)"
+          + ")");
+    }
+
+    props = new HashMap<>();
+    props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, JdbcSourceConnector.class.getName());
+    props.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME);
+    props.put(ConnectorConfig.TASKS_MAX_CONFIG, "1");
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, postgres.getJdbcUrl());
+    props.put(JdbcSourceConnectorConfig.CONNECTION_USER_CONFIG, postgres.getUsername());
+    props.put(JdbcSourceConnectorConfig.CONNECTION_PASSWORD_CONFIG, postgres.getPassword());
+    props.put(JdbcSourceConnectorConfig.DIALECT_NAME_CONFIG, "PostgreSqlDatabaseDialect");
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
+    props.put(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_MAPPING_CONFIG,
+        SCHEMA_NAME + "." + TABLE_NAME + ":id");
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, TOPIC_PREFIX);
+    props.put(JdbcSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG, String.valueOf(POLLING_INTERVAL_MS));
+    props.put(JdbcSourceConnectorConfig.POLL_LINGER_MS_CONFIG, "0");
+    props.put(JdbcSourceConnectorConfig.VALIDATE_NON_NULL_CONFIG, "false");
+    // The literal, documented two-part form. A leading-.* regex would mask the regression
+    // because it tolerates a catalog-prefixed identifier.
+    props.put(JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG, SCHEMA_NAME + "." + TABLE_NAME);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    stopConnect();
+    try (Statement stmt = connection.createStatement()) {
+      stmt.execute("DROP SCHEMA " + SCHEMA_NAME + " CASCADE");
+    }
+  }
+
+  @Test
+  public void shouldDiscoverTableWithLiteralTwoPartIncludeList() throws Exception {
+    insertRows(3);
+    connect.kafka().createTopic(TOPIC, 1);
+
+    connect.configureConnector(CONNECTOR_NAME, props);
+    waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+    ConsumerRecords<byte[], byte[]> records =
+        connect.kafka().consume(3, CONSUME_TIMEOUT_MS, TOPIC);
+    assertEquals("Literal schema.table include list should discover the table and stream its rows",
+        3, records.count());
+  }
+
+  @Test
+  public void shouldFailWithThreePartIncludeList() throws Exception {
+    insertRows(3);
+
+    // A three-part db.schema.table include list cannot match the two-part schema.table the
+    // dialect discovers, so no table is assigned and the task fails loudly. This pins the
+    // boundary: if three-part names ever start matching, that is unverified behaviour.
+    props.put(JdbcSourceConnectorConfig.TABLE_INCLUDE_LIST_CONFIG,
+        postgres.getDatabaseName() + "." + SCHEMA_NAME + "." + TABLE_NAME);
+
+    connect.configureConnector(CONNECTOR_NAME, props);
+    assertTasksFailedWithTrace(CONNECTOR_NAME, 1, "not assigned a table nor a query");
+  }
+
+  private void insertRows(int count) throws SQLException {
+    try (PreparedStatement stmt = connection.prepareStatement(
+        "INSERT INTO " + SCHEMA_NAME + "." + TABLE_NAME + " (name) VALUES (?)")) {
+      for (int i = 0; i < count; i++) {
+        stmt.setString(1, "name_" + i);
+        stmt.addBatch();
+      }
+      stmt.executeBatch();
+    }
+  }
+}


### PR DESCRIPTION
Backport of  #1648 to the `10.8.x` Check that PR body for complete information.
