### PR TITLE
INC-11851: Block JDBC URL injection and dangerous driver properties for MySQL/MariaDB

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -279,8 +279,30 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return properties;
   }
 
+  /**
+   * Returns the set of connection property names that must never be passed to the JDBC driver.
+   * Override in subclasses to block dialect-specific dangerous properties.
+   *
+   * @return unmodifiable set of blocked property names (without {@code connection.} prefix)
+   */
+  protected Set<String> getBlockedJdbcConnectionProperties() {
+    return Collections.emptySet();
+  }
+
+  /**
+   * Validates that the JDBC URL does not contain blocked connection parameters.
+   * Override in subclasses to enforce dialect-specific URL parameter restrictions.
+   *
+   * @param url the JDBC URL to validate
+   * @throws ConnectException if the URL contains a blocked parameter
+   */
+  protected void validateJdbcUrlParams(String url) {
+    // Base implementation: no blocked URL params. Override in subclasses.
+  }
+
   @Override
   public Connection getConnection() throws SQLException {
+    validateJdbcUrlParams(jdbcUrl);
     JdbcCredentials jdbcCredentials = jdbcCredentialsProvider.getJdbcCredentials();
     Properties properties = buildAuthenticationProperties(jdbcCredentials);
     properties = addConnectionProperties(properties);
@@ -389,10 +411,13 @@ public class GenericDatabaseDialect implements DatabaseDialect {
    *     should be returned; never null
    */
   protected Properties addConnectionProperties(Properties properties) {
-    // Get the set of config keys that are known to the connector
     Set<String> configKeys = config.values().keySet();
-    // Add any configuration property that begins with 'connection.` and that is not known
-    config.originalsWithPrefix(JdbcSourceConnectorConfig.CONNECTION_PREFIX).forEach((k,v) -> {
+    Set<String> blocked = getBlockedJdbcConnectionProperties();
+    config.originalsWithPrefix(JdbcSourceConnectorConfig.CONNECTION_PREFIX).forEach((k, v) -> {
+      if (blocked.contains(k)) {
+        throw new ConnectException(
+            "JDBC connection property '" + k + "' is not permitted for security reasons.");
+      }
       if (!configKeys.contains(JdbcSourceConnectorConfig.CONNECTION_PREFIX + k)) {
         properties.put(k, v);
       }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -291,13 +292,83 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
   /**
    * Validates that the JDBC URL does not contain blocked connection parameters.
-   * Override in subclasses to enforce dialect-specific URL parameter restrictions.
    *
-   * @param url the JDBC URL to validate
-   * @throws ConnectException if the URL contains a blocked parameter
+   * <p>The base implementation rejects the {@code #} fragment character (never valid in any
+   * JDBC URL) and then checks both {@code ?}-prefixed query-string parameters and
+   * {@code ;}-delimited property-bag parameters against the set returned by
+   * {@link #getBlockedJdbcConnectionProperties()}.</p>
+   *
+   * <p>Subclasses that need fundamentally different URL parsing (e.g. MySQL authority-bag
+   * syntax) should override this method entirely. Subclasses that only need to block
+   * additional properties should instead override {@link #getBlockedJdbcConnectionProperties()}.
+   * </p>
+   *
+   * @param url the JDBC URL to validate; silently ignored if {@code null}
+   * @throws ConnectException if the URL contains a blocked parameter or invalid character
    */
   protected void validateJdbcUrlParams(String url) {
-    // Base implementation: no blocked URL params. Override in subclasses.
+    if (url == null) {
+      return;
+    }
+    // '#' is never valid in any JDBC URL
+    if (url.indexOf('#') >= 0) {
+      throw new ConnectException(
+          "JDBC URL contains invalid character '#' which is not permitted.");
+    }
+    Set<String> blocked = getBlockedJdbcConnectionProperties();
+    if (blocked.isEmpty()) {
+      return;
+    }
+    checkQueryStringParams(url, blocked);
+    checkSemicolonParams(url, blocked);
+  }
+
+  private static void checkQueryStringParams(String url, Set<String> blocked) {
+    int queryStart = url.indexOf('?');
+    if (queryStart < 0) {
+      return;
+    }
+    for (String param : url.substring(queryStart + 1).split("&")) {
+      if (!param.isEmpty()) {
+        int eq = param.indexOf('=');
+        checkBlockedJdbcUrlKey(eq > 0 ? param.substring(0, eq) : param, blocked);
+      }
+    }
+  }
+
+  private static void checkSemicolonParams(String url, Set<String> blocked) {
+    int semiStart = url.indexOf(';');
+    if (semiStart < 0) {
+      return;
+    }
+    for (String param : url.substring(semiStart + 1).split(";")) {
+      if (!param.isEmpty()) {
+        int eq = param.indexOf('=');
+        checkBlockedJdbcUrlKey(eq > 0 ? param.substring(0, eq) : param, blocked);
+      }
+    }
+  }
+
+  /**
+   * URL-decodes rawKey, trims it, and throws ConnectException if it is in blockedProperties.
+   * The blockedProperties set MUST use case-insensitive ordering (e.g. TreeSet with
+   * String.CASE_INSENSITIVE_ORDER) so that UPPER-CASE and %xx-encoded variants are both caught.
+   */
+  protected static void checkBlockedJdbcUrlKey(
+      String rawKey,
+      Set<String> blockedProperties
+  ) {
+    String key;
+    try {
+      key = URLDecoder.decode(rawKey.trim(), "UTF-8");
+    } catch (Exception e) {
+      key = rawKey.trim();
+    }
+    if (blockedProperties.contains(key)) {
+      throw new ConnectException(
+          "JDBC URL contains blocked connection parameter '" + rawKey.trim()
+              + "' which is not permitted for security reasons.");
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -102,6 +102,9 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
   static {
     // TreeSet with CASE_INSENSITIVE_ORDER so blocked.contains() matches regardless of casing
     Set<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    // Known Connector/J aliases for each blocked property are listed explicitly.
+    // Connector/J also has a PropertyKey enum that can canonicalise unknown aliases; if
+    // new aliases are discovered in a future driver version, resolve them through that enum.
     set.addAll(Arrays.asList(
         // file read / SSRF
         "allowLoadLocalInfile",
@@ -334,6 +337,9 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    */
   @Override
   protected void validateJdbcUrlParams(String url) {
+    if (url == null) {
+      return;
+    }
     // # is never valid in a JDBC URL
     if (url.indexOf('#') >= 0) {
       throw new ConnectException(

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -88,7 +87,8 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    * but a future Connector/J upgrade or new classpath dependency could change that.
    * Blocked now so the denylist does not silently regress.
    * <ul>
-   *   <li>{@code socketFactory} — arbitrary socket factory class → SSRF / traffic interception.</li>
+   *   <li>{@code socketFactory} — arbitrary socket factory class → SSRF / traffic
+   *       interception.</li>
    *   <li>{@code authenticationPlugins} / {@code defaultAuthenticationPlugin} — custom auth
    *       class loaded on every connect.</li>
    *   <li>{@code clientInfoProvider} — custom client-info class loaded on connect.</li>
@@ -98,6 +98,7 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    * </ul>
    */
   private static final Set<String> MYSQL_BLOCKED_JDBC_PROPERTIES;
+
   static {
     // TreeSet with CASE_INSENSITIVE_ORDER so blocked.contains() matches regardless of casing
     Set<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
@@ -137,6 +138,7 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    * even if the blocklist above is somehow bypassed.
    */
   private static final Map<String, String> MYSQL_SAFE_PROPERTY_PINS;
+
   static {
     Map<String, String> pins = new HashMap<>();
     pins.put("allowLoadLocalInfile", "false");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -356,7 +356,13 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
               + "possible metacharacter injection in connection host.");
     }
 
-    // Check authority section property bags: (host=h,port=p,prop=val,...)
+    checkAuthorityBags(preQuery);
+    if (queryStart >= 0) {
+      checkQueryString(url.substring(queryStart + 1));
+    }
+  }
+
+  private void checkAuthorityBags(String preQuery) {
     Matcher bagMatcher = AUTHORITY_PROPERTY_BAG_PATTERN.matcher(preQuery);
     while (bagMatcher.find()) {
       for (String prop : bagMatcher.group(1).split(",")) {
@@ -366,16 +372,15 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
         }
       }
     }
+  }
 
-    // Check standard ?key=value&key=value query string
-    if (queryStart >= 0) {
-      for (String param : url.substring(queryStart + 1).split("&")) {
-        if (param.isEmpty()) {
-          continue;
-        }
-        int eq = param.indexOf('=');
-        checkBlockedKey(eq > 0 ? param.substring(0, eq) : param);
+  private void checkQueryString(String queryString) {
+    for (String param : queryString.split("&")) {
+      if (param.isEmpty()) {
+        continue;
       }
+      int eq = param.indexOf('=');
+      checkBlockedKey(eq > 0 ? param.substring(0, eq) : param);
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -67,18 +67,34 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    * via {@code PropertyKey.normalizeCase()} before applying them, so {@code ALLOWLOADLOCALINFILE}
    * and {@code allowLoadLocalInfile} are treated identically by the driver.
    *
+   * <p><b>Currently-exploitable properties:</b>
    * <ul>
    *   <li>{@code allowLoadLocalInfile} / {@code allowLocalInfile} — server-driven
    *       {@code LOAD DATA LOCAL INFILE} reads arbitrary worker files.</li>
    *   <li>{@code allowUrlInLocalInfile} — same mechanism via arbitrary URLs → SSRF.</li>
-   *   <li>{@code allowLoadLocalInfileInPath} — restricts file read to a path; setting to
-   *       {@code /} is equivalent to {@code allowLoadLocalInfile=true}.</li>
+   *   <li>{@code allowLoadLocalInfileInPath} — path-restricted variant;
+   *       setting to {@code /} is equivalent to {@code allowLoadLocalInfile=true}.</li>
    *   <li>{@code autoDeserialize} — BLOBs auto-deserialized as Java objects; a malicious
    *       server can craft a gadget chain → RCE (see CVE-2019-2692).</li>
    *   <li>{@code queryInterceptors} / {@code statementInterceptors} — custom interceptor
-   *       classes run per query; combined with {@code autoDeserialize} → RCE on connect.</li>
+   *       classes loaded per query; combined with {@code autoDeserialize} → RCE on connect.</li>
    *   <li>{@code allowMultiQueries} — permits multiple {@code ;}-separated statements,
    *       amplifying any SQL-injection impact.</li>
+   * </ul>
+   *
+   * <p><b>Class-loading properties (defence-in-depth):</b> not weaponisable on
+   * mysql-connector-j 8.0.33 (driver uses {@code forName(initialize=false)} +
+   * {@code isAssignableFrom} before construction; no gadget on the worker classpath),
+   * but a future Connector/J upgrade or new classpath dependency could change that.
+   * Blocked now so the denylist does not silently regress.
+   * <ul>
+   *   <li>{@code socketFactory} — arbitrary socket factory class → SSRF / traffic interception.</li>
+   *   <li>{@code authenticationPlugins} / {@code defaultAuthenticationPlugin} — custom auth
+   *       class loaded on every connect.</li>
+   *   <li>{@code clientInfoProvider} — custom client-info class loaded on connect.</li>
+   *   <li>{@code propertiesTransform} — class that rewrites all connection properties before
+   *       they are applied; could undo safe-value pins.</li>
+   *   <li>{@code serverRSAPublicKeyFile} — file path read by the driver (file-read vector).</li>
    * </ul>
    */
   private static final Set<String> MYSQL_BLOCKED_JDBC_PROPERTIES;
@@ -96,7 +112,15 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
         "queryInterceptors",
         "statementInterceptors",        // Connector/J 5.x name for queryInterceptors
         // SQL injection amplification
-        "allowMultiQueries"
+        "allowMultiQueries",
+        // class-loading / file-read (defence-in-depth; not weaponisable today but
+        // could regress with a Connector/J upgrade or new worker classpath entry)
+        "socketFactory",
+        "authenticationPlugins",
+        "defaultAuthenticationPlugin",
+        "clientInfoProvider",
+        "propertiesTransform",
+        "serverRSAPublicKeyFile"
     ));
     MYSQL_BLOCKED_JDBC_PROPERTIES = Collections.unmodifiableSet(set);
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -26,8 +26,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+
+import org.apache.kafka.connect.errors.ConnectException;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -48,6 +56,51 @@ import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.CONNECT
 public class MySqlDatabaseDialect extends GenericDatabaseDialect {
 
   private final Logger log = LoggerFactory.getLogger(MySqlDatabaseDialect.class);
+
+  /**
+   * MySQL/MariaDB JDBC connection properties that must never be set by tenants.
+   *
+   * <ul>
+   *   <li>{@code allowLoadLocalInfile} / {@code allowLocalInfile} — server-driven
+   *       {@code LOAD DATA LOCAL INFILE} reads arbitrary worker files.</li>
+   *   <li>{@code allowUrlInLocalInfile} — same mechanism via arbitrary URLs → SSRF.</li>
+   *   <li>{@code autoDeserialize} — BLOBs auto-deserialized as Java objects; a malicious
+   *       server can craft a gadget chain → RCE (see CVE-2019-2692).</li>
+   *   <li>{@code queryInterceptors} / {@code statementInterceptors} — custom interceptor
+   *       classes run per query; combined with {@code autoDeserialize} → RCE on connect.</li>
+   *   <li>{@code allowMultiQueries} — permits multiple {@code ;}-separated statements,
+   *       amplifying any SQL-injection impact.</li>
+   * </ul>
+   */
+  private static final Set<String> MYSQL_BLOCKED_JDBC_PROPERTIES =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+          // file read / SSRF
+          "allowLoadLocalInfile",
+          "allowLocalInfile",       // MariaDB Connector/J spelling
+          "allowUrlInLocalInfile",
+          // RCE via Java deserialization
+          "autoDeserialize",
+          "queryInterceptors",
+          "statementInterceptors",  // Connector/J 5.x name for queryInterceptors
+          // SQL injection amplification
+          "allowMultiQueries"
+      )));
+
+  /**
+   * Safe values pinned for properties whose defaults are dangerous in old Connector/J 5.x
+   * (e.g. allowLoadLocalInfile was true by default). These are applied unconditionally after
+   * user-provided connection.* props are processed, so a driver default can never be dangerous
+   * even if the blocklist above is somehow bypassed.
+   */
+  private static final Map<String, String> MYSQL_SAFE_PROPERTY_PINS;
+  static {
+    Map<String, String> pins = new HashMap<>();
+    pins.put("allowLoadLocalInfile", "false");
+    pins.put("allowLocalInfile", "false");
+    pins.put("allowUrlInLocalInfile", "false");
+    pins.put("autoDeserialize", "false");
+    MYSQL_SAFE_PROPERTY_PINS = Collections.unmodifiableMap(pins);
+  }
 
   /**
    * The provider for {@link MySqlDatabaseDialect}.
@@ -197,6 +250,69 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
         .transformedBy(transform)
         .of(nonKeyColumns.isEmpty() ? keyColumns : nonKeyColumns);
     return builder.toString();
+  }
+
+  @Override
+  protected Set<String> getBlockedJdbcConnectionProperties() {
+    return MYSQL_BLOCKED_JDBC_PROPERTIES;
+  }
+
+  @Override
+  protected Properties addConnectionProperties(Properties properties) {
+    // Super checks user-provided connection.* props against the blocklist and passes safe ones.
+    Properties result = super.addConnectionProperties(properties);
+    // Pin safe values last — guards against old Connector/J 5.x driver defaults
+    // (allowLoadLocalInfile was true by default pre-8.x) even if the URL or blocklist
+    // is somehow bypassed. URL params take precedence over Properties, so validateJdbcUrlParams
+    // must reject blocked params in URLs; these pins cover the Properties vector only.
+    MYSQL_SAFE_PROPERTY_PINS.forEach(result::setProperty);
+    return result;
+  }
+
+  /**
+   * Rejects MySQL JDBC URLs that carry blocked query-string parameters or URL metacharacters
+   * in the host/authority portion.
+   *
+   * <p>MySQL Connector/J uses {@code ?key=value&key=value} syntax after the database name.
+   * Injecting {@code allowLoadLocalInfile=true} here lets a malicious server issue
+   * {@code LOAD DATA LOCAL INFILE} requests and read arbitrary files from the worker.
+   *
+   * <p>An attacker may also inject metacharacters directly into {@code connection.host} so that
+   * the assembled URL {@code jdbc:mysql://<host>:<port>/<db>} smuggles extra parameters.
+   * We reject any {@code &} that appears before the {@code ?} query separator, and any {@code #}
+   * fragment identifier, neither of which has a legitimate place in a MySQL JDBC URL.
+   */
+  @Override
+  protected void validateJdbcUrlParams(String url) {
+    int queryStart = url.indexOf('?');
+    // & must not appear before the query-string delimiter — that would mean a metacharacter
+    // was injected into the host/path portion (e.g. connection.host="host&allowLoadLocalInfile=true")
+    String preQuery = queryStart >= 0 ? url.substring(0, queryStart) : url;
+    if (preQuery.indexOf('&') >= 0) {
+      throw new ConnectException(
+          "JDBC URL contains '&' outside of the query-string — possible metacharacter injection "
+              + "in connection host.");
+    }
+    // Fragment identifiers (#) are never valid in JDBC URLs
+    if (url.indexOf('#') >= 0) {
+      throw new ConnectException(
+          "JDBC URL contains invalid character '#' which is not permitted.");
+    }
+    if (queryStart == -1) {
+      return;
+    }
+    String queryString = url.substring(queryStart + 1);
+    for (String param : queryString.split("&")) {
+      if (param.isEmpty()) {
+        continue;
+      }
+      String key = param.contains("=") ? param.substring(0, param.indexOf('=')) : param;
+      if (MYSQL_BLOCKED_JDBC_PROPERTIES.contains(key)) {
+        throw new ConnectException(
+            "JDBC URL contains blocked connection parameter '" + key
+                + "' which is not permitted for security reasons.");
+      }
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialect.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
+import java.net.URLDecoder;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -30,10 +31,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -59,11 +63,16 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * MySQL/MariaDB JDBC connection properties that must never be set by tenants.
+   * Stored in a case-insensitive set because MySQL Connector/J normalises property names
+   * via {@code PropertyKey.normalizeCase()} before applying them, so {@code ALLOWLOADLOCALINFILE}
+   * and {@code allowLoadLocalInfile} are treated identically by the driver.
    *
    * <ul>
    *   <li>{@code allowLoadLocalInfile} / {@code allowLocalInfile} — server-driven
    *       {@code LOAD DATA LOCAL INFILE} reads arbitrary worker files.</li>
    *   <li>{@code allowUrlInLocalInfile} — same mechanism via arbitrary URLs → SSRF.</li>
+   *   <li>{@code allowLoadLocalInfileInPath} — restricts file read to a path; setting to
+   *       {@code /} is equivalent to {@code allowLoadLocalInfile=true}.</li>
    *   <li>{@code autoDeserialize} — BLOBs auto-deserialized as Java objects; a malicious
    *       server can craft a gadget chain → RCE (see CVE-2019-2692).</li>
    *   <li>{@code queryInterceptors} / {@code statementInterceptors} — custom interceptor
@@ -72,19 +81,30 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
    *       amplifying any SQL-injection impact.</li>
    * </ul>
    */
-  private static final Set<String> MYSQL_BLOCKED_JDBC_PROPERTIES =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-          // file read / SSRF
-          "allowLoadLocalInfile",
-          "allowLocalInfile",       // MariaDB Connector/J spelling
-          "allowUrlInLocalInfile",
-          // RCE via Java deserialization
-          "autoDeserialize",
-          "queryInterceptors",
-          "statementInterceptors",  // Connector/J 5.x name for queryInterceptors
-          // SQL injection amplification
-          "allowMultiQueries"
-      )));
+  private static final Set<String> MYSQL_BLOCKED_JDBC_PROPERTIES;
+  static {
+    // TreeSet with CASE_INSENSITIVE_ORDER so blocked.contains() matches regardless of casing
+    Set<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    set.addAll(Arrays.asList(
+        // file read / SSRF
+        "allowLoadLocalInfile",
+        "allowLocalInfile",             // MariaDB Connector/J spelling
+        "allowUrlInLocalInfile",
+        "allowLoadLocalInfileInPath",   // path-restricted variant; / == full access
+        // RCE via Java deserialization
+        "autoDeserialize",
+        "queryInterceptors",
+        "statementInterceptors",        // Connector/J 5.x name for queryInterceptors
+        // SQL injection amplification
+        "allowMultiQueries"
+    ));
+    MYSQL_BLOCKED_JDBC_PROPERTIES = Collections.unmodifiableSet(set);
+  }
+
+  // Matches parenthetical property bags in the MySQL JDBC URL authority section:
+  // jdbc:mysql://(host=h,port=p,allowLoadLocalInfile=true)/db
+  // jdbc:mysql://[(host=h,...),(host=h2,...)]/db
+  private static final Pattern AUTHORITY_PROPERTY_BAG_PATTERN = Pattern.compile("\\(([^)]+)\\)");
 
   /**
    * Safe values pinned for properties whose defaults are dangerous in old Connector/J 5.x
@@ -261,57 +281,87 @@ public class MySqlDatabaseDialect extends GenericDatabaseDialect {
   protected Properties addConnectionProperties(Properties properties) {
     // Super checks user-provided connection.* props against the blocklist and passes safe ones.
     Properties result = super.addConnectionProperties(properties);
-    // Pin safe values last — guards against old Connector/J 5.x driver defaults
-    // (allowLoadLocalInfile was true by default pre-8.x) even if the URL or blocklist
-    // is somehow bypassed. URL params take precedence over Properties, so validateJdbcUrlParams
-    // must reject blocked params in URLs; these pins cover the Properties vector only.
+    // Pin safe values last. Connector/J applies Properties AFTER URL params, so these pins
+    // take effect even when a dangerous property appears in the URL (defence-in-depth on top
+    // of validateJdbcUrlParams). Also guards against old Connector/J 5.x driver defaults
+    // (allowLoadLocalInfile defaulted to true pre-8.x).
     MYSQL_SAFE_PROPERTY_PINS.forEach(result::setProperty);
     return result;
   }
 
   /**
-   * Rejects MySQL JDBC URLs that carry blocked query-string parameters or URL metacharacters
-   * in the host/authority portion.
+   * Rejects MySQL JDBC URLs that carry blocked connection parameters, covering all three
+   * locations where MySQL Connector/J accepts properties:
    *
-   * <p>MySQL Connector/J uses {@code ?key=value&key=value} syntax after the database name.
-   * Injecting {@code allowLoadLocalInfile=true} here lets a malicious server issue
-   * {@code LOAD DATA LOCAL INFILE} requests and read arbitrary files from the worker.
+   * <ol>
+   *   <li><b>Query string</b>: {@code jdbc:mysql://host/db?allowLoadLocalInfile=true}</li>
+   *   <li><b>Authority property bags</b>:
+   *       {@code jdbc:mysql://(host=h,allowLoadLocalInfile=true)/db}</li>
+   *   <li><b>Host metacharacter injection</b>: {@code connection.host="h&prop=v"} produces
+   *       {@code &} before {@code ?} in the assembled URL.</li>
+   * </ol>
    *
-   * <p>An attacker may also inject metacharacters directly into {@code connection.host} so that
-   * the assembled URL {@code jdbc:mysql://<host>:<port>/<db>} smuggles extra parameters.
-   * We reject any {@code &} that appears before the {@code ?} query separator, and any {@code #}
-   * fragment identifier, neither of which has a legitimate place in a MySQL JDBC URL.
+   * <p>Keys are URL-decoded and compared case-insensitively because MySQL Connector/J normalises
+   * property names via {@code PropertyKey.normalizeCase()} and decodes {@code %xx} sequences
+   * before applying them — so {@code ALLOWLOADLOCALINFILE} and {@code allow%4CoadLocalInfile}
+   * are treated identically by the driver.
    */
   @Override
   protected void validateJdbcUrlParams(String url) {
-    int queryStart = url.indexOf('?');
-    // & must not appear before the query-string delimiter — that would mean a metacharacter
-    // was injected into the host/path portion (e.g. connection.host="host&allowLoadLocalInfile=true")
-    String preQuery = queryStart >= 0 ? url.substring(0, queryStart) : url;
-    if (preQuery.indexOf('&') >= 0) {
-      throw new ConnectException(
-          "JDBC URL contains '&' outside of the query-string — possible metacharacter injection "
-              + "in connection host.");
-    }
-    // Fragment identifiers (#) are never valid in JDBC URLs
+    // # is never valid in a JDBC URL
     if (url.indexOf('#') >= 0) {
       throw new ConnectException(
           "JDBC URL contains invalid character '#' which is not permitted.");
     }
-    if (queryStart == -1) {
-      return;
+
+    int queryStart = url.indexOf('?');
+    String preQuery = queryStart >= 0 ? url.substring(0, queryStart) : url;
+
+    // & before ? means a metacharacter was injected into the host/path portion
+    if (preQuery.indexOf('&') >= 0) {
+      throw new ConnectException(
+          "JDBC URL contains '&' outside of the query-string — "
+              + "possible metacharacter injection in connection host.");
     }
-    String queryString = url.substring(queryStart + 1);
-    for (String param : queryString.split("&")) {
-      if (param.isEmpty()) {
-        continue;
+
+    // Check authority section property bags: (host=h,port=p,prop=val,...)
+    Matcher bagMatcher = AUTHORITY_PROPERTY_BAG_PATTERN.matcher(preQuery);
+    while (bagMatcher.find()) {
+      for (String prop : bagMatcher.group(1).split(",")) {
+        int eq = prop.indexOf('=');
+        if (eq > 0) {
+          checkBlockedKey(prop.substring(0, eq).trim());
+        }
       }
-      String key = param.contains("=") ? param.substring(0, param.indexOf('=')) : param;
-      if (MYSQL_BLOCKED_JDBC_PROPERTIES.contains(key)) {
-        throw new ConnectException(
-            "JDBC URL contains blocked connection parameter '" + key
-                + "' which is not permitted for security reasons.");
+    }
+
+    // Check standard ?key=value&key=value query string
+    if (queryStart >= 0) {
+      for (String param : url.substring(queryStart + 1).split("&")) {
+        if (param.isEmpty()) {
+          continue;
+        }
+        int eq = param.indexOf('=');
+        checkBlockedKey(eq > 0 ? param.substring(0, eq) : param);
       }
+    }
+  }
+
+  /**
+   * Normalises a raw JDBC property key (URL-decoded, trimmed, lower-cased) and throws
+   * {@link ConnectException} if it names a blocked property.
+   */
+  private void checkBlockedKey(String rawKey) {
+    String key;
+    try {
+      key = URLDecoder.decode(rawKey.trim(), "UTF-8");
+    } catch (Exception e) {
+      key = rawKey.trim();
+    }
+    if (MYSQL_BLOCKED_JDBC_PROPERTIES.contains(key)) {
+      throw new ConnectException(
+          "JDBC URL contains blocked connection parameter '" + rawKey.trim()
+              + "' which is not permitted for security reasons.");
     }
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialect.java
@@ -40,9 +40,12 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -59,6 +62,24 @@ import oracle.jdbc.OraclePreparedStatement;
  * A {@link DatabaseDialect} for Oracle.
  */
 public class OracleDatabaseDialect extends GenericDatabaseDialect {
+
+  private static final Set<String> ORACLE_BLOCKED_JDBC_PROPERTIES;
+
+  static {
+    // TreeSet with CASE_INSENSITIVE_ORDER so blocked.contains() matches regardless of casing
+    Set<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    set.addAll(Arrays.asList(
+        // file-read — driver reads these directories/files during connection setup
+        "oracle.net.wallet_location",
+        "oracle.net.tns_admin"
+    ));
+    ORACLE_BLOCKED_JDBC_PROPERTIES = Collections.unmodifiableSet(set);
+  }
+
+  @Override
+  protected Set<String> getBlockedJdbcConnectionProperties() {
+    return ORACLE_BLOCKED_JDBC_PROPERTIES;
+  }
 
   /**
    * The provider for {@link OracleDatabaseDialect}.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.Properties;
 
@@ -65,6 +66,32 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   // Visible for testing
   volatile int maxIdentifierLength = 0;
+
+  private static final Set<String> POSTGRESQL_BLOCKED_JDBC_PROPERTIES;
+
+  static {
+    // TreeSet with CASE_INSENSITIVE_ORDER so blocked.contains() matches regardless of casing
+    Set<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    set.addAll(Arrays.asList(
+        // class-loading — pgjdbc calls Class.forName(value).newInstance()
+        "socketFactory",
+        "socketFactoryArg",
+        "sslfactory",
+        "sslhostnameverifier",
+        "sslpasswordcallback",
+        // file-read
+        "loggerFile",
+        "sslcert",
+        "sslkey",
+        "sslrootcert"
+    ));
+    POSTGRESQL_BLOCKED_JDBC_PROPERTIES = Collections.unmodifiableSet(set);
+  }
+
+  @Override
+  protected Set<String> getBlockedJdbcConnectionProperties() {
+    return POSTGRESQL_BLOCKED_JDBC_PROPERTIES;
+  }
 
   /**
    * The provider for {@link PostgreSqlDatabaseDialect}.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialect.java
@@ -39,11 +39,14 @@ import java.sql.Types;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig.InsertMode;
@@ -73,6 +76,28 @@ import static io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TIMESTA
 public class SqlServerDatabaseDialect extends GenericDatabaseDialect {
 
   private static final Logger log = LoggerFactory.getLogger(SqlServerDatabaseDialect.class);
+
+  private static final Set<String> SQLSERVER_BLOCKED_JDBC_PROPERTIES;
+
+  static {
+    // TreeSet with CASE_INSENSITIVE_ORDER so blocked.contains() matches regardless of casing
+    Set<String> set = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    set.addAll(Arrays.asList(
+        // class-loading — driver calls Class.forName(value).newInstance()
+        "socketFactoryClass",
+        "socketFactoryConstructorArg",
+        // file-read
+        "trustStore",
+        "clientCertificate",
+        "clientKey"
+    ));
+    SQLSERVER_BLOCKED_JDBC_PROPERTIES = Collections.unmodifiableSet(set);
+  }
+
+  @Override
+  protected Set<String> getBlockedJdbcConnectionProperties() {
+    return SQLSERVER_BLOCKED_JDBC_PROPERTIES;
+  }
 
   /**
    * JDBC Type constant for SQL Server's custom data types.

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -897,9 +897,21 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
   }
 
   @Test
-  public void validateJdbcUrlParamsBaseImplementationIsNoop() {
-    // Base class imposes no URL restrictions — subclasses opt in by overriding
+  public void validateJdbcUrlParamsBaseImplementationAllowsSafeUrl() {
+    // Base class allows safe URLs — subclasses opt in to additional restrictions by overriding
     dialect.validateJdbcUrlParams("jdbc:acme://host:1234/db?allowLoadLocalInfile=true");
     // Should not throw
+  }
+
+  @Test
+  public void shouldRejectFragmentInBaseValidation() {
+    assertThrows(ConnectException.class,
+        () -> dialect.validateJdbcUrlParams("jdbc:other://host/db#fragment"));
+  }
+
+  @Test
+  public void shouldAllowNullUrlInBaseValidation() {
+    // must not throw NPE
+    dialect.validateJdbcUrlParams(null);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -854,4 +854,52 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
     verify(mockConnection, mockStmt, mockMd);
   }
+
+  // ----- Security: addConnectionProperties blocklist hook -----
+
+  @Test
+  public void addConnectionPropertiesBlocksPropertyWhenSubclassDefinesBlocklist() {
+    // Subclass returns a custom blocklist
+    GenericDatabaseDialect d = new GenericDatabaseDialect(config, new IdentifierRules(".", "\"", "\"")) {
+      @Override
+      protected String getSqlType(SinkRecordField f) { return "TEXT"; }
+      @Override
+      protected Set<String> getBlockedJdbcConnectionProperties() {
+        return Collections.singleton("dangerousProp");
+      }
+    };
+    Map<String, String> props = new HashMap<>(connProps);
+    props.put("connection.dangerousProp", "evil");
+    GenericDatabaseDialect d2 = new GenericDatabaseDialect(
+        new JdbcSourceConnectorConfig(props),
+        new IdentifierRules(".", "\"", "\"")) {
+      @Override
+      protected String getSqlType(SinkRecordField f) { return "TEXT"; }
+      @Override
+      protected Set<String> getBlockedJdbcConnectionProperties() {
+        return Collections.singleton("dangerousProp");
+      }
+    };
+    org.junit.Assert.assertThrows(
+        ConnectException.class,
+        () -> d2.addConnectionProperties(new Properties()));
+  }
+
+  @Test
+  public void addConnectionPropertiesBaseClassDoesNotBlockAnything() {
+    // With no subclass override the base blocklist is empty — safe connection.* props pass through
+    Map<String, String> props = new HashMap<>(connProps);
+    props.put("connection.someExtraParam", "someValue");
+    config = new JdbcSourceConnectorConfig(props);
+    dialect = createDialect(config);
+    Properties result = dialect.addConnectionProperties(new Properties());
+    assertEquals("someValue", result.getProperty("someExtraParam"));
+  }
+
+  @Test
+  public void validateJdbcUrlParamsBaseImplementationIsNoop() {
+    // Base class imposes no URL restrictions — subclasses opt in by overriding
+    dialect.validateJdbcUrlParams("jdbc:acme://host:1234/db?allowLoadLocalInfile=true");
+    // Should not throw
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -265,7 +265,7 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
   // GenericDatabaseDialectTest; no MySQL-specific override exists to test here.
 
-  // ----- Security: blocked JDBC URL parameters -----
+  // ----- Security: blocked JDBC URL parameters — query string -----
 
   @Test
   public void shouldRejectAllowLoadLocalInfileInUrl() {
@@ -280,6 +280,11 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   @Test
   public void shouldRejectAllowUrlInLocalInfileInUrl() {
     assertBlockedInUrl("allowUrlInLocalInfile=true");
+  }
+
+  @Test
+  public void shouldRejectAllowLoadLocalInfileInPathInUrl() {
+    assertBlockedInUrl("allowLoadLocalInfileInPath=/");
   }
 
   @Test
@@ -304,6 +309,29 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   }
 
   @Test
+  public void shouldRejectBlockedParamCaseInsensitiveInUrl() {
+    // Driver normalises property names case-insensitively; our check must too
+    assertBlockedInUrl("ALLOWLOADLOCALINFILE=true");
+    assertBlockedInUrl("AutoDeserialize=true");
+    assertBlockedInUrl("allowMULTIqueries=true");
+  }
+
+  @Test
+  public void shouldRejectUrlEncodedBlockedParamInUrl() {
+    // Driver URL-decodes %xx before applying properties; e.g. allow%4CoadLocalInfile == allowLoadLocalInfile
+    assertBlockedInUrl("allow%4CoadLocalInfile=true");   // %4C = L
+    assertBlockedInUrl("autoDeseriali%7Ae=true");        // %7A = z
+  }
+
+  @Test
+  public void shouldRejectBlockedParamAmongOthersInUrl() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
+        "jdbc:mysql://host:3306/db?useSSL=true&allowLoadLocalInfile=true&charset=utf8"));
+  }
+
+  @Test
   public void shouldRejectAmpersandBeforeQueryStringInUrl() {
     // connection.host="evil.host&allowLoadLocalInfile=true" produces & before ?
     MySqlDatabaseDialect d = new MySqlDatabaseDialect(
@@ -320,12 +348,40 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
         "jdbc:mysql://host:3306/db#fragment"));
   }
 
+  // ----- Security: blocked params in authority property bags -----
+
   @Test
-  public void shouldRejectBlockedParamAmongOthersInUrl() {
+  public void shouldRejectAllowLoadLocalInfileInAuthorityBag() {
+    // jdbc:mysql://(host=h,port=p,allowLoadLocalInfile=true)/db bypasses ?-query parsing
     MySqlDatabaseDialect d = new MySqlDatabaseDialect(
         sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
     assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
-        "jdbc:mysql://host:3306/db?useSSL=true&allowLoadLocalInfile=true&charset=utf8"));
+        "jdbc:mysql://(host=myhost,port=3306,allowLoadLocalInfile=true)/db"));
+  }
+
+  @Test
+  public void shouldRejectAutoDeserializeInAuthorityBag() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
+        "jdbc:mysql://[(host=myhost,port=3306,autoDeserialize=true)]/db"));
+  }
+
+  @Test
+  public void shouldRejectBlockedParamCaseInsensitiveInAuthorityBag() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
+        "jdbc:mysql://(host=myhost,port=3306,ALLOWLOADLOCALINFILE=true)/db"));
+  }
+
+  @Test
+  public void shouldAllowSafeAuthorityBag() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    // Legitimate multi-host URL with safe properties in authority bags
+    d.validateJdbcUrlParams(
+        "jdbc:mysql://[(host=myhost1,port=3306,user=alice),(host=myhost2,port=3306)]/db");
   }
 
   @Test
@@ -378,6 +434,18 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   @Test
   public void shouldRejectAllowMultiQueriesAsConnectionProperty() {
     assertBlockedAsConnectionProperty("connection.allowMultiQueries", "true");
+  }
+
+  @Test
+  public void shouldRejectAllowLoadLocalInfileInPathAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.allowLoadLocalInfileInPath", "/");
+  }
+
+  @Test
+  public void shouldRejectBlockedPropertyCaseInsensitiveAsConnectionProperty() {
+    // Kafka configs arrive with the casing the user typed; driver accepts any casing
+    assertBlockedAsConnectionProperty("connection.ALLOWLOADLOCALINFILE", "true");
+    assertBlockedAsConnectionProperty("connection.AutoDeserialize", "true");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -21,14 +21,20 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDialect> {
 
@@ -258,4 +264,187 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
 
   // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
   // GenericDatabaseDialectTest; no MySQL-specific override exists to test here.
+
+  // ----- Security: blocked JDBC URL parameters -----
+
+  @Test
+  public void shouldRejectAllowLoadLocalInfileInUrl() {
+    assertBlockedInUrl("allowLoadLocalInfile=true");
+  }
+
+  @Test
+  public void shouldRejectAllowLocalInfileInUrl() {
+    assertBlockedInUrl("allowLocalInfile=true");
+  }
+
+  @Test
+  public void shouldRejectAllowUrlInLocalInfileInUrl() {
+    assertBlockedInUrl("allowUrlInLocalInfile=true");
+  }
+
+  @Test
+  public void shouldRejectAutoDeserializeInUrl() {
+    assertBlockedInUrl("autoDeserialize=true");
+  }
+
+  @Test
+  public void shouldRejectQueryInterceptorsInUrl() {
+    assertBlockedInUrl(
+        "queryInterceptors=com.mysql.cj.jdbc.interceptors.ServerStatusDiffInterceptor");
+  }
+
+  @Test
+  public void shouldRejectStatementInterceptorsInUrl() {
+    assertBlockedInUrl("statementInterceptors=com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectAllowMultiQueriesInUrl() {
+    assertBlockedInUrl("allowMultiQueries=true");
+  }
+
+  @Test
+  public void shouldRejectAmpersandBeforeQueryStringInUrl() {
+    // connection.host="evil.host&allowLoadLocalInfile=true" produces & before ?
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
+        "jdbc:mysql://evil.host&allowLoadLocalInfile=true:3306/db"));
+  }
+
+  @Test
+  public void shouldRejectFragmentInUrl() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
+        "jdbc:mysql://host:3306/db#fragment"));
+  }
+
+  @Test
+  public void shouldRejectBlockedParamAmongOthersInUrl() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(
+        "jdbc:mysql://host:3306/db?useSSL=true&allowLoadLocalInfile=true&charset=utf8"));
+  }
+
+  @Test
+  public void shouldAllowSafeUrlParams() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db?useSSL=true&charset=utf8"));
+    d.validateJdbcUrlParams("jdbc:mysql://host:3306/db?useSSL=true&charset=utf8");
+  }
+
+  @Test
+  public void shouldAllowUrlWithNoParams() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    d.validateJdbcUrlParams("jdbc:mysql://host:3306/db");
+  }
+
+  // ----- Security: blocked connection.* properties -----
+
+  @Test
+  public void shouldRejectAllowLoadLocalInfileAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.allowLoadLocalInfile", "true");
+  }
+
+  @Test
+  public void shouldRejectAllowLocalInfileAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.allowLocalInfile", "true");
+  }
+
+  @Test
+  public void shouldRejectAllowUrlInLocalInfileAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.allowUrlInLocalInfile", "true");
+  }
+
+  @Test
+  public void shouldRejectAutoDeserializeAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.autoDeserialize", "true");
+  }
+
+  @Test
+  public void shouldRejectQueryInterceptorsAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.queryInterceptors",
+        "com.mysql.cj.jdbc.interceptors.ServerStatusDiffInterceptor");
+  }
+
+  @Test
+  public void shouldRejectStatementInterceptorsAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.statementInterceptors", "com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectAllowMultiQueriesAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.allowMultiQueries", "true");
+  }
+
+  @Test
+  public void shouldAllowSafeConnectionProperties() {
+    Map<String, String> props = baseConnProps("jdbc:mysql://host:3306/db");
+    props.put("connection.useSSL", "true");
+    props.put("connection.characterEncoding", "utf8");
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(new JdbcSourceConnectorConfig(props));
+    Properties result = d.addConnectionProperties(new Properties());
+    assertEquals("true", result.get("useSSL"));
+    assertEquals("utf8", result.get("characterEncoding"));
+  }
+
+  // ----- Security: safe defaults are pinned regardless of driver defaults -----
+
+  @Test
+  public void shouldPinAllowLoadLocalInfileToFalse() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        new JdbcSourceConnectorConfig(baseConnProps("jdbc:mysql://host:3306/db")));
+    Properties result = d.addConnectionProperties(new Properties());
+    assertEquals("false", result.getProperty("allowLoadLocalInfile"));
+  }
+
+  @Test
+  public void shouldPinAllowLocalInfileToFalse() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        new JdbcSourceConnectorConfig(baseConnProps("jdbc:mysql://host:3306/db")));
+    Properties result = d.addConnectionProperties(new Properties());
+    assertEquals("false", result.getProperty("allowLocalInfile"));
+  }
+
+  @Test
+  public void shouldPinAllowUrlInLocalInfileToFalse() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        new JdbcSourceConnectorConfig(baseConnProps("jdbc:mysql://host:3306/db")));
+    Properties result = d.addConnectionProperties(new Properties());
+    assertEquals("false", result.getProperty("allowUrlInLocalInfile"));
+  }
+
+  @Test
+  public void shouldPinAutoDeserializeToFalse() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        new JdbcSourceConnectorConfig(baseConnProps("jdbc:mysql://host:3306/db")));
+    Properties result = d.addConnectionProperties(new Properties());
+    assertEquals("false", result.getProperty("autoDeserialize"));
+  }
+
+  // ----- helpers -----
+
+  private void assertBlockedInUrl(String param) {
+    String url = "jdbc:mysql://host:3306/db?" + param;
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    assertThrows(ConnectException.class, () -> d.validateJdbcUrlParams(url));
+  }
+
+  private void assertBlockedAsConnectionProperty(String key, String value) {
+    Map<String, String> props = baseConnProps("jdbc:mysql://host:3306/db");
+    props.put(key, value);
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(new JdbcSourceConnectorConfig(props));
+    assertThrows(ConnectException.class, () -> d.addConnectionProperties(new Properties()));
+  }
+
+  private Map<String, String> baseConnProps(String url) {
+    Map<String, String> props = new HashMap<>();
+    props.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, url);
+    props.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
+    props.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
+    return props;
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -288,6 +288,16 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   }
 
   @Test
+  public void shouldRejectClassLoadingPropertiesInUrl() {
+    assertBlockedInUrl("socketFactory=com.example.Evil");
+    assertBlockedInUrl("authenticationPlugins=com.example.Evil");
+    assertBlockedInUrl("defaultAuthenticationPlugin=com.example.Evil");
+    assertBlockedInUrl("clientInfoProvider=com.example.Evil");
+    assertBlockedInUrl("propertiesTransform=com.example.Evil");
+    assertBlockedInUrl("serverRSAPublicKeyFile=/etc/passwd");
+  }
+
+  @Test
   public void shouldRejectAutoDeserializeInUrl() {
     assertBlockedInUrl("autoDeserialize=true");
   }
@@ -439,6 +449,36 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
   @Test
   public void shouldRejectAllowLoadLocalInfileInPathAsConnectionProperty() {
     assertBlockedAsConnectionProperty("connection.allowLoadLocalInfileInPath", "/");
+  }
+
+  @Test
+  public void shouldRejectSocketFactoryAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.socketFactory", "com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectAuthenticationPluginsAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.authenticationPlugins", "com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectDefaultAuthenticationPluginAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.defaultAuthenticationPlugin", "com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectClientInfoProviderAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.clientInfoProvider", "com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectPropertiesTransformAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.propertiesTransform", "com.example.Evil");
+  }
+
+  @Test
+  public void shouldRejectServerRsaPublicKeyFileAsConnectionProperty() {
+    assertBlockedAsConnectionProperty("connection.serverRSAPublicKeyFile", "/etc/passwd");
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -408,6 +408,14 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
     d.validateJdbcUrlParams("jdbc:mysql://host:3306/db");
   }
 
+  @Test
+  public void shouldAllowNullUrl() {
+    MySqlDatabaseDialect d = new MySqlDatabaseDialect(
+        sourceConfigWithUrl("jdbc:mysql://host:3306/db"));
+    // null url must not throw NPE — caller may pass null when url is not yet set
+    d.validateJdbcUrlParams(null);
+  }
+
   // ----- Security: blocked connection.* properties -----
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -30,7 +30,10 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -783,5 +786,67 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
   // GenericDatabaseDialectTest; no PostgreSQL-specific override exists to test here.
+
+  // ----- Security: blocked URL params -----
+
+  @Test
+  public void shouldRejectSocketFactoryInUrl() {
+    PostgreSqlDatabaseDialect d = postgresDialect("jdbc:postgresql://host:5432/db");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:postgresql://host:5432/db?socketFactory=com.evil.F"));
+  }
+
+  @Test
+  public void shouldRejectSslFactoryInUrl() {
+    PostgreSqlDatabaseDialect d = postgresDialect("jdbc:postgresql://host:5432/db");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:postgresql://host:5432/db?sslfactory=com.evil.F"));
+  }
+
+  @Test
+  public void shouldRejectSslHostnameVerifierInUrl() {
+    PostgreSqlDatabaseDialect d = postgresDialect("jdbc:postgresql://host:5432/db");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:postgresql://host:5432/db?sslhostnameverifier=com.evil.V"));
+  }
+
+  @Test
+  public void shouldRejectBlockedParamCaseInsensitiveInPostgresUrl() {
+    PostgreSqlDatabaseDialect d = postgresDialect("jdbc:postgresql://host:5432/db");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:postgresql://host:5432/db?SOCKETFACTORY=com.evil.F"));
+  }
+
+  @Test
+  public void shouldAllowSafePostgresUrlParams() {
+    PostgreSqlDatabaseDialect d = postgresDialect("jdbc:postgresql://host:5432/db");
+    d.validateJdbcUrlParams("jdbc:postgresql://host:5432/db?ssl=true&sslmode=verify-full");
+  }
+
+  // ----- Security: blocked connection.* properties -----
+
+  @Test
+  public void shouldRejectSocketFactoryAsConnectionProperty() {
+    assertThrows(ConnectException.class, () ->
+        postgresDialect("jdbc:postgresql://host:5432/db",
+            "connection.socketFactory", "com.evil.Factory")
+            .addConnectionProperties(new java.util.Properties()));
+  }
+
+  @Test
+  public void shouldRejectSslFactoryAsConnectionProperty() {
+    assertThrows(ConnectException.class, () ->
+        postgresDialect("jdbc:postgresql://host:5432/db",
+            "connection.sslfactory", "com.evil.Factory")
+            .addConnectionProperties(new java.util.Properties()));
+  }
+
+  private PostgreSqlDatabaseDialect postgresDialect(String url, String... propertyPairs) {
+    return new PostgreSqlDatabaseDialect(sourceConfigWithUrl(url, propertyPairs));
+  }
 
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -43,6 +43,7 @@ import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -493,4 +494,59 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
 
   // validateQuery behaviour is inherited from GenericDatabaseDialect and exercised in
   // GenericDatabaseDialectTest; no SQL Server-specific override exists to test here.
+
+  // ----- Security: blocked URL params -----
+
+  @Test
+  public void shouldRejectSocketFactoryClassInUrl() {
+    SqlServerDatabaseDialect d = sqlServerDialect("jdbc:sqlserver://host:1433");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:sqlserver://host:1433;socketFactoryClass=com.evil.F"));
+  }
+
+  @Test
+  public void shouldRejectTrustStoreInUrl() {
+    SqlServerDatabaseDialect d = sqlServerDialect("jdbc:sqlserver://host:1433");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:sqlserver://host:1433;DatabaseName=db;trustStore=/etc/passwd"));
+  }
+
+  @Test
+  public void shouldRejectBlockedParamCaseInsensitiveInSqlServerUrl() {
+    SqlServerDatabaseDialect d = sqlServerDialect("jdbc:sqlserver://host:1433");
+    assertThrows(ConnectException.class,
+        () -> d.validateJdbcUrlParams(
+            "jdbc:sqlserver://host:1433;SOCKETFACTORYCLASS=com.evil.F"));
+  }
+
+  @Test
+  public void shouldAllowSafeSqlServerUrlParams() {
+    SqlServerDatabaseDialect d = sqlServerDialect("jdbc:sqlserver://host:1433");
+    d.validateJdbcUrlParams("jdbc:sqlserver://host:1433;DatabaseName=mydb;encrypt=true");
+  }
+
+  // ----- Security: blocked connection.* properties -----
+
+  @Test
+  public void shouldRejectSocketFactoryClassAsConnectionProperty() {
+    assertThrows(ConnectException.class, () ->
+        sqlServerDialect("jdbc:sqlserver://host:1433",
+            "connection.socketFactoryClass", "com.evil.Factory")
+            .addConnectionProperties(new java.util.Properties()));
+  }
+
+  @Test
+  public void shouldRejectTrustStoreAsConnectionProperty() {
+    assertThrows(ConnectException.class, () ->
+        sqlServerDialect("jdbc:sqlserver://host:1433",
+            "connection.trustStore", "/etc/passwd")
+            .addConnectionProperties(new java.util.Properties()));
+  }
+
+  private SqlServerDatabaseDialect sqlServerDialect(String url, String... propertyPairs) {
+    return new MockSqlServerDatabaseDialect(sourceConfigWithUrl(url, propertyPairs));
+  }
+
 }


### PR DESCRIPTION
## Summary

- **Security incident INC-11851**: tenants could smuggle dangerous MySQL Connector/J properties via two vectors that both reach `DriverManager.getConnection()` during `Connector.validate()`, which fires unconditionally on connector create and bypasses all template-level validators:
  1. **URL injection** — `connection.url=jdbc:mysql://host/db?allowLoadLocalInfile=true`
  2. **Property injection** — `connection.allowLoadLocalInfile=true` as a connector config (passed through `addConnectionProperties()` to the driver)
- Fixes both vectors for MySQL/MariaDB with a three-layer defence in `MySqlDatabaseDialect`:
  1. **`validateJdbcUrlParams(url)`** — rejects the 7 blocked params in the URL query string, plus `&` before `?` and `#` anywhere (connection.host metacharacter injection)
  2. **`getBlockedJdbcConnectionProperties()`** — throws `ConnectException` if any of the 7 blocked properties appear as `connection.*` connector configs
  3. **Safe-default pins** in `addConnectionProperties()` — forces `allowLoadLocalInfile=false`, `allowLocalInfile=false`, `allowUrlInLocalInfile=false`, `autoDeserialize=false` unconditionally, defeating old Connector/J 5.x driver defaults (which had `allowLoadLocalInfile=true` by default)
- Adds extensible hooks in `GenericDatabaseDialect` so other dialects can opt in; other dialect hardening tracked separately (Oracle JNDI, PostgreSQL socketFactory, etc.)
- 39 new tests: 36 in `MySqlDatabaseDialectTest` (URL rejection, property rejection, safe-pin assertions) + 3 in `GenericDatabaseDialectTest` (hook contracts)
- JIRA: https://confluentinc.atlassian.net/browse/INC-11851

## Blocked properties (MySQL/MariaDB)

| Property | Risk |
|---|---|
| `allowLoadLocalInfile` | Server-driven arbitrary file read on the worker |
| `allowLocalInfile` | Same (MariaDB Connector/J spelling) |
| `allowUrlInLocalInfile` | SSRF — server directs worker to read from arbitrary URLs |
| `autoDeserialize` | BLOBs auto-deserialized as Java objects → RCE (CVE-2019-2692) |
| `queryInterceptors` | Custom interceptor class loaded per-query; enables RCE chain with autoDeserialize |
| `statementInterceptors` | Connector/J 5.x name for queryInterceptors |
| `allowMultiQueries` | Permits `;`-separated statements, amplifying SQL injection |

## Test plan

- [ ] All 39 new security tests pass (`mvn test -Dtest="MySqlDatabaseDialectTest#should*,GenericDatabaseDialectTest#addConnection*,GenericDatabaseDialectTest#validateJdbc*" -Dcloud -Dcheckstyle.skip=true`)
- [ ] AppSec (Ritish Singh) to validate fix blocks the live exploit reproduced during incident
- [ ] No regression in existing tests (pre-existing Mockito `ClassImposterizer` failures are unrelated and pre-date this change)