### PR TITLE
Add opt-in, admin-configured JDBC URL parameter blocklist

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -62,8 +63,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.FixedScoreProvider;
@@ -281,6 +285,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
 
   @Override
   public Connection getConnection() throws SQLException {
+    validateJdbcUrlParams(jdbcUrl);
     JdbcCredentials jdbcCredentials = jdbcCredentialsProvider.getJdbcCredentials();
     Properties properties = buildAuthenticationProperties(jdbcCredentials);
     properties = addConnectionProperties(properties);
@@ -294,6 +299,77 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
     connections.add(connection);
     return connection;
+  }
+
+  /**
+   * System property naming a comma-separated, case-insensitive list of JDBC URL parameter names
+   * that must not appear in {@code connection.url}. It is set by the worker operator at JVM
+   * startup and cannot be supplied through a connector's REST config, so users cannot change it.
+   * Unset or empty means no restriction, making enforcement entirely opt-in.
+   */
+  public static final String BLOCKED_JDBC_URL_PARAMS_PROPERTY =
+      "jdbc.connection.url.blocked.params";
+
+  /**
+   * Environment-variable fallback for {@link #BLOCKED_JDBC_URL_PARAMS_PROPERTY}.
+   */
+  public static final String BLOCKED_JDBC_URL_PARAMS_ENV_VAR =
+      "JDBC_CONNECTION_URL_BLOCKED_PARAMS";
+
+  // Captures the name of any "name=value" parameter, regardless of the '?', '&', ';', ',' or
+  // MySQL '(...)' property-bag delimiter that introduces it.
+  private static final Pattern JDBC_URL_PARAM_NAME = Pattern.compile("([\\w.%-]+)\\s*=");
+
+  /**
+   * Rejects any {@code connection.url} containing a parameter named in the operator-configured
+   * blocklist ({@link #BLOCKED_JDBC_URL_PARAMS_PROPERTY}). Names are URL-decoded and matched
+   * case-insensitively to defeat encoding and casing evasions. No-op when the blocklist is empty,
+   * so default behaviour is unchanged.
+   *
+   * @param url the JDBC URL to validate; ignored if {@code null}
+   * @throws ConnectException if the URL contains a blocked parameter
+   */
+  protected void validateJdbcUrlParams(String url) {
+    if (url == null) {
+      return;
+    }
+    Set<String> blocked = blockedJdbcUrlParams();
+    if (blocked.isEmpty()) {
+      return;
+    }
+    Matcher matcher = JDBC_URL_PARAM_NAME.matcher(url);
+    while (matcher.find()) {
+      String name = matcher.group(1).trim();
+      if (blocked.contains(decode(name))) {
+        throw new ConnectException("JDBC URL contains blocked connection parameter '" + name
+            + "' which is not permitted by the Connect cluster's configured policy.");
+      }
+    }
+  }
+
+  private static Set<String> blockedJdbcUrlParams() {
+    String configured = System.getProperty(BLOCKED_JDBC_URL_PARAMS_PROPERTY);
+    if (configured == null) {
+      configured = System.getenv(BLOCKED_JDBC_URL_PARAMS_ENV_VAR);
+    }
+    if (configured == null || configured.trim().isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<String> blocked = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    for (String name : configured.split(",")) {
+      if (!name.trim().isEmpty()) {
+        blocked.add(name.trim());
+      }
+    }
+    return blocked;
+  }
+
+  private static String decode(String value) {
+    try {
+      return URLDecoder.decode(value, "UTF-8");
+    } catch (Exception e) {
+      return value;
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -303,40 +303,27 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   /**
-   * System property naming a comma-separated, case-insensitive list of blocked JDBC driver
-   * parameter names. It is set by the worker operator at JVM startup and cannot be supplied
-   * through a connector's REST config, so users cannot change it. Unset or empty means no
-   * restriction, making enforcement entirely opt-in. Applies both to parameters embedded in
-   * {@code connection.url} and to driver properties passed through via {@code connection.*}.
+   * Comma-separated, case-insensitive list of JDBC driver parameter names the operator forbids.
+   * Set on the worker JVM at startup, not via connector config, so users cannot change it;
+   * unset/empty means no restriction. Covers both {@code connection.url} and {@code connection.*}.
    */
   public static final String BLOCKED_JDBC_URL_PARAMS_PROPERTY =
       "jdbc.connection.url.blocked.params";
 
-  /**
-   * Environment-variable fallback for {@link #BLOCKED_JDBC_URL_PARAMS_PROPERTY}.
-   */
-  public static final String BLOCKED_JDBC_URL_PARAMS_ENV_VAR =
-      "JDBC_CONNECTION_URL_BLOCKED_PARAMS";
+  // Environment-variable fallback for BLOCKED_JDBC_URL_PARAMS_PROPERTY.
+  static final String BLOCKED_JDBC_URL_PARAMS_ENV_VAR = "JDBC_CONNECTION_URL_BLOCKED_PARAMS";
 
-  // Captures the name of any "name=value" parameter, regardless of the '?', '&', ';', ',' or
-  // MySQL '(...)' property-bag delimiter that introduces it.
+  // Captures the name in any "name=value" parameter, whatever '?', '&', ';', ',' or MySQL
+  // '(...)' delimiter introduces it.
   private static final Pattern JDBC_URL_PARAM_NAME = Pattern.compile("([\\w.%-]+)\\s*=");
 
   /**
-   * Rejects any {@code connection.url} containing a parameter named in the operator-configured
-   * blocklist ({@link #BLOCKED_JDBC_URL_PARAMS_PROPERTY}). Names are URL-decoded and matched
-   * case-insensitively to defeat encoding and casing evasions. No-op when the blocklist is empty,
-   * so default behaviour is unchanged.
-   *
-   * @param url the JDBC URL to validate; ignored if {@code null}
-   * @throws ConnectException if the URL contains a blocked parameter
+   * Rejects a {@code connection.url} carrying a blocklisted parameter. Names are URL-decoded and
+   * matched case-insensitively; no-op when the blocklist is empty.
    */
   protected void validateJdbcUrlParams(String url) {
-    if (url == null) {
-      return;
-    }
     Set<String> blocked = blockedParams();
-    if (blocked.isEmpty()) {
+    if (url == null || blocked.isEmpty()) {
       return;
     }
     Matcher matcher = JDBC_URL_PARAM_NAME.matcher(url);
@@ -350,20 +337,11 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   /**
-   * Rejects any driver property whose name is in the operator-configured blocklist
-   * ({@link #BLOCKED_JDBC_URL_PARAMS_PROPERTY}). This covers the {@code connection.*} passthrough
-   * (see {@link #addConnectionProperties(Properties)}), which would otherwise let a blocked
-   * parameter reach the driver without appearing in {@code connection.url}. No-op when the
-   * blocklist is empty.
-   *
-   * @param properties the driver properties about to be passed to {@link DriverManager}
-   * @throws ConnectException if a property name is blocked
+   * Rejects a blocklisted driver property, covering the {@code connection.*} passthrough added by
+   * {@link #addConnectionProperties(Properties)}; no-op when the blocklist is empty.
    */
   protected void validateConnectionProperties(Properties properties) {
     Set<String> blocked = blockedParams();
-    if (blocked.isEmpty()) {
-      return;
-    }
     for (Object name : properties.keySet()) {
       if (blocked.contains(name.toString())) {
         throw new ConnectException("JDBC connection property '" + name
@@ -377,13 +355,14 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     if (configured == null) {
       configured = System.getenv(BLOCKED_JDBC_URL_PARAMS_ENV_VAR);
     }
-    if (configured == null || configured.trim().isEmpty()) {
+    if (configured == null) {
       return Collections.emptySet();
     }
     Set<String> blocked = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     for (String name : configured.split(",")) {
-      if (!name.trim().isEmpty()) {
-        blocked.add(name.trim());
+      String trimmed = name.trim();
+      if (!trimmed.isEmpty()) {
+        blocked.add(trimmed);
       }
     }
     return blocked;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -289,6 +289,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     JdbcCredentials jdbcCredentials = jdbcCredentialsProvider.getJdbcCredentials();
     Properties properties = buildAuthenticationProperties(jdbcCredentials);
     properties = addConnectionProperties(properties);
+    validateConnectionProperties(properties);
     // Timeout is 40 seconds to be as long as possible for customer to have a long connection
     // handshake, while still giving enough time to validate once in the follower worker,
     // and again in the leader worker and still be under 90s REST serving timeout
@@ -302,10 +303,11 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   /**
-   * System property naming a comma-separated, case-insensitive list of JDBC URL parameter names
-   * that must not appear in {@code connection.url}. It is set by the worker operator at JVM
-   * startup and cannot be supplied through a connector's REST config, so users cannot change it.
-   * Unset or empty means no restriction, making enforcement entirely opt-in.
+   * System property naming a comma-separated, case-insensitive list of blocked JDBC driver
+   * parameter names. It is set by the worker operator at JVM startup and cannot be supplied
+   * through a connector's REST config, so users cannot change it. Unset or empty means no
+   * restriction, making enforcement entirely opt-in. Applies both to parameters embedded in
+   * {@code connection.url} and to driver properties passed through via {@code connection.*}.
    */
   public static final String BLOCKED_JDBC_URL_PARAMS_PROPERTY =
       "jdbc.connection.url.blocked.params";
@@ -333,7 +335,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     if (url == null) {
       return;
     }
-    Set<String> blocked = blockedJdbcUrlParams();
+    Set<String> blocked = blockedParams();
     if (blocked.isEmpty()) {
       return;
     }
@@ -347,7 +349,30 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     }
   }
 
-  private static Set<String> blockedJdbcUrlParams() {
+  /**
+   * Rejects any driver property whose name is in the operator-configured blocklist
+   * ({@link #BLOCKED_JDBC_URL_PARAMS_PROPERTY}). This covers the {@code connection.*} passthrough
+   * (see {@link #addConnectionProperties(Properties)}), which would otherwise let a blocked
+   * parameter reach the driver without appearing in {@code connection.url}. No-op when the
+   * blocklist is empty.
+   *
+   * @param properties the driver properties about to be passed to {@link DriverManager}
+   * @throws ConnectException if a property name is blocked
+   */
+  protected void validateConnectionProperties(Properties properties) {
+    Set<String> blocked = blockedParams();
+    if (blocked.isEmpty()) {
+      return;
+    }
+    for (Object name : properties.keySet()) {
+      if (blocked.contains(name.toString())) {
+        throw new ConnectException("JDBC connection property '" + name
+            + "' is not permitted by the Connect cluster's configured policy.");
+      }
+    }
+  }
+
+  private static Set<String> blockedParams() {
     String configured = System.getProperty(BLOCKED_JDBC_URL_PARAMS_PROPERTY);
     if (configured == null) {
       configured = System.getenv(BLOCKED_JDBC_URL_PARAMS_ENV_VAR);

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -854,4 +854,46 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
 
     verify(mockConnection, mockStmt, mockMd);
   }
+
+  @Test
+  public void validateJdbcUrlParamsIsNoOpWhenAdminHasNotOptedIn() {
+    // No system property / env var configured => nothing is blocked (opt-in).
+    System.clearProperty(GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY);
+    dialect.validateJdbcUrlParams(
+        "jdbc:mysql://host:3306/db?allowLoadLocalInfile=true");
+    dialect.validateJdbcUrlParams("jdbc:postgresql://host:5432/db");
+    dialect.validateJdbcUrlParams(null);
+  }
+
+  @Test
+  public void validateJdbcUrlParamsBlocksConfiguredParams() {
+    System.setProperty(
+        GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY,
+        "allowLoadLocalInfile, autoDeserialize");
+    try {
+      // Clean URL is allowed.
+      dialect.validateJdbcUrlParams("jdbc:postgresql://host:5432/db?ssl=true");
+
+      // Query-string param.
+      assertThrows(ConnectException.class, () -> dialect.validateJdbcUrlParams(
+          "jdbc:mysql://host:3306/db?allowLoadLocalInfile=true"));
+      // Case-insensitive.
+      assertThrows(ConnectException.class, () -> dialect.validateJdbcUrlParams(
+          "jdbc:mysql://host:3306/db?ALLOWLOADLOCALINFILE=true"));
+      // URL-encoded param name.
+      assertThrows(ConnectException.class, () -> dialect.validateJdbcUrlParams(
+          "jdbc:mysql://host:3306/db?%61llowLoadLocalInfile=true"));
+      // Semicolon-delimited (e.g. SQL Server style).
+      assertThrows(ConnectException.class, () -> dialect.validateJdbcUrlParams(
+          "jdbc:sqlserver://host:1433;autoDeserialize=true"));
+      // Parenthetical property bag (e.g. MySQL authority syntax).
+      assertThrows(ConnectException.class, () -> dialect.validateJdbcUrlParams(
+          "jdbc:mysql://(host=h,allowLoadLocalInfile=true)/db"));
+      // A param NOT on the blocklist is still allowed.
+      dialect.validateJdbcUrlParams(
+          "jdbc:mysql://host:3306/db?allowMultiQueries=true");
+    } finally {
+      System.clearProperty(GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY);
+    }
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -896,4 +896,27 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
       System.clearProperty(GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY);
     }
   }
+
+  @Test
+  public void validateConnectionPropertiesBlocksPassthroughConfigParams() {
+    // A blocked param can also be smuggled as a connection.* passthrough config, not just in the
+    // URL. The property reaches the driver via addConnectionProperties() with the prefix stripped.
+    connProps.put("connection.allowLoadLocalInfile", "true");
+    dialect = createDialect(new JdbcSourceConnectorConfig(connProps));
+    Properties props = dialect.addConnectionProperties(new Properties());
+    assertEquals("true", props.get("allowLoadLocalInfile"));
+
+    // No blocklist configured => passthrough property is allowed.
+    System.clearProperty(GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY);
+    dialect.validateConnectionProperties(props);
+
+    // Blocklist configured => the passthrough property is rejected.
+    System.setProperty(
+        GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY, "allowLoadLocalInfile");
+    try {
+      assertThrows(ConnectException.class, () -> dialect.validateConnectionProperties(props));
+    } finally {
+      System.clearProperty(GenericDatabaseDialect.BLOCKED_JDBC_URL_PARAMS_PROPERTY);
+    }
+  }
 }


### PR DESCRIPTION
## Problem

The user-provided `connection.url` is passed verbatim to `DriverManager.getConnection(...)`, so a user can make use of dangerous JDBC driver parameters through it. For example:

- `allowLoadLocalInfile=true` / `allowUrlInLocalInfile=true` → arbitrary worker file read / SSRF via `LOAD DATA LOCAL INFILE`
- `autoDeserialize=true` → deserialization RCE

Unlike Confluent Cloud, self-managed CP should **not** block these parameters by default, since customers may legitimately use them. It is required to restrict them by opt-in and controlled by the cluster admin and not by the user creating a new connector with exploitable params.

## Solution

Add an **opt-in, admin-configured blocklist** of JDBC URL parameter names, enforced entirely within the connector.

- **Opt-in:** unset/empty ⇒ no restriction, so default behaviour is unchanged.
- **Admin-controlled, not user-controllable:** the blocklist is read from the `jdbc.connection.url.blocked.params` JVM system property (or the `JDBC_CONNECTION_URL_BLOCKED_PARAMS` environment variable), which the worker operator sets at JVM startup. A connector plugin cannot read worker config, and this value cannot be supplied through a connector's REST config — so a tenant can neither see nor change it. Setting it identically on every worker makes it apply cluster-wide.
- **Connector-only, no runtime changes:** the check runs in `GenericDatabaseDialect.getConnection()` — the single point where the URL is handed to the driver — so it covers both config validation and task runtime, for every dialect.

Enforcement behaviour:
- A **new** connector whose `connection.url` contains a blocked parameter is rejected at validation time (HTTP 400, never created).
- A **pre-existing** connector fails its tasks on the next connection attempt once the policy is enabled.

Example worker configuration:

```
KAFKA_OPTS="-Djdbc.connection.url.blocked.params=allowLoadLocalInfile,allowUrlInLocalInfile,autoDeserialize"
```

## Testing

**Unit tests** (`GenericDatabaseDialectTest`):
- `validateJdbcUrlParamsIsNoOpWhenAdminHasNotOptedIn` — no property set ⇒ nothing blocked (including a URL carrying `allowLoadLocalInfile`) and `null` URL is safe.
- `validateJdbcUrlParamsBlocksConfiguredParams` — with a blocklist configured: clean URL allowed; blocked param rejected via query-string, semicolon, and parenthetical-bag syntaxes; case-insensitive and URL-encoded (`%61llow...`) variants rejected; a param not on the list still allowed.

**Manual end-to-end on local Confluent Platform**

| Scenario | Blocklist | Result |
|---|---|---|
| Source, `?allowLoadLocalInfile=true` | off (default) | Created / not blocked — opt-in confirmed ✅ |
| Source, clean URL | on | HTTP 201, RUNNING ✅ |
| Source, `?allowLoadLocalInfile=true` | on | Rejected (HTTP 400): "…blocked connection parameter 'allowLoadLocalInfile'…" ✅ |
| Source, `?%61llowLoadLocalInfile=true` (URL-encoded) | on | Rejected — decoded and caught ✅ |
| Sink, clean URL | on | HTTP 201, RUNNING ✅ |
| Sink, `?autoDeserialize=true` | on | Rejected ✅ |

![Uploading Screenshot 2026-07-03 at 3.05.41 PM.png…]()


![Uploading Screenshot 2026-07-03 at 3.06.00 PM.png…]()

