### PR TITLE
Redact JDBC sink SQL exceptions on 10.8.x (backport of #1664, CC-42731)

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -34,6 +34,8 @@ import org.slf4j.LoggerFactory;
 
 public class JdbcDbWriter {
   private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
+  private static final Logger SENSITIVE =
+      LoggerFactory.getLogger("io.confluent.connect.jdbc.sink.Sensitive");
 
   private final JdbcSinkConfig config;
   private final DatabaseDialect dbDialect;
@@ -86,24 +88,29 @@ public class JdbcDbWriter {
       }
       log.trace("Committing transaction");
       connection.commit();
-    } catch (SQLException | TableAlterOrCreateException e) {
-      log.error("Error during write operation. Attempting rollback.", maybeTrim(e));
-      try {
-        connection.rollback();
-        log.info("Successfully rolled back transaction");
-      } catch (SQLException sqle) {
-        log.error("Failed to rollback transaction", maybeTrim(sqle));
-        e.addSuppressed(sqle);
-      } finally {
-        throw e;
-      }
+    } catch (SQLException e) {
+      SENSITIVE.trace("Raw sink write failure (redacted at ERROR)", e);
+      SQLException redactedException = LogUtil.redactSensitiveData(e);
+      rollback(connection, redactedException);
+      throw redactedException;
+    } catch (TableAlterOrCreateException e) {
+      rollback(connection, e);
+      throw e;
     }
     log.info("Completed write operation for {} records to the database", records.size());
   }
 
-  Throwable maybeTrim(Throwable t) {
-    return (config.trimSensitiveLogsEnabled && t instanceof SQLException)
-        ? LogUtil.trimSensitiveData((SQLException) t) : t;
+  private void rollback(Connection connection, Throwable writeException) {
+    log.error("Error during write operation. Attempting rollback.", writeException);
+    try {
+      connection.rollback();
+      log.info("Successfully rolled back transaction");
+    } catch (SQLException e) {
+      SENSITIVE.trace("Raw rollback failure (redacted at ERROR)", e);
+      SQLException redactedException = LogUtil.redactSensitiveData(e);
+      log.error("Failed to rollback transaction", redactedException);
+      writeException.addSuppressed(redactedException);
+    }
   }
 
   void closeQuietly() {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -44,15 +44,12 @@ public class JdbcSinkTask extends SinkTask {
   JdbcDbWriter writer;
   int remainingRetries;
 
-  boolean shouldTrimSensitiveLogs;
-
   @Override
   public void start(final Map<String, String> props) {
     log.info("Starting JDBC Sink task");
     config = new JdbcSinkConfig(props);
     initWriter();
     remainingRetries = config.maxRetries;
-    shouldTrimSensitiveLogs = config.trimSensitiveLogsEnabled;
     try {
       reporter = context.errantRecordReporter();
     } catch (NoSuchMethodError | NoClassDefFoundError e) {
@@ -97,13 +94,12 @@ public class JdbcSinkTask extends SinkTask {
         throw tace;
       }
     } catch (SQLException sqle) {
-      SQLException trimmedException = shouldTrimSensitiveLogs
-              ? LogUtil.trimSensitiveData(sqle) : sqle;
+      SQLException redactedException = LogUtil.redactSensitiveData(sqle);
       log.warn(
           "Write of {} records failed, remainingRetries={}",
           records.size(),
           remainingRetries,
-          trimmedException
+          redactedException
       );
       int totalExceptions = 0;
       for (Throwable e :sqle) {
@@ -127,7 +123,7 @@ public class JdbcSinkTask extends SinkTask {
                   + "For complete details on each exception, please enable DEBUG logging.",
               totalExceptions);
           int exceptionCount = 1;
-          for (Throwable e : trimmedException) {
+          for (Throwable e : redactedException) {
             log.debug("Exception {}:", exceptionCount++, e);
           }
           throw new ConnectException(sqlAllMessagesException);
@@ -159,13 +155,12 @@ public class JdbcSinkTask extends SinkTask {
 
   private SQLException getAllMessagesException(SQLException sqle) {
     String sqleAllMessages = "Exception chain:" + System.lineSeparator();
-    SQLException trimmedException = shouldTrimSensitiveLogs
-            ? LogUtil.trimSensitiveData(sqle) : sqle;
-    for (Throwable e : trimmedException) {
+    SQLException redactedException = LogUtil.redactSensitiveData(sqle);
+    for (Throwable e : redactedException) {
       sqleAllMessages += e + System.lineSeparator();
     }
     SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
-    sqlAllMessagesException.setNextException(trimmedException);
+    sqlAllMessagesException.setNextException(redactedException);
     return sqlAllMessagesException;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
@@ -23,6 +23,8 @@ import java.sql.SQLException;
  * error information to investigate incidents while at the same time avoid logging sensitive data.
  */
 public class LogUtil {
+  private static final String REDACTED_VALUE = "<redacted>";
+
   public static SQLException trimSensitiveData(SQLException e) {
     return (SQLException) trimSensitiveData((Throwable)e);
   }
@@ -60,6 +62,40 @@ public class LogUtil {
   // contain this phrase (e.g., a trigger's RAISE EXCEPTION message), in which case earliest-wins
   // across both tiers would truncate the reason mid-sentence.
   private static final String BATCH_SUFFIX_FALLBACK = "  Call getNextException ";
+
+  public static SQLException redactSensitiveData(SQLException e) {
+    return (SQLException) redactSensitiveData((Throwable) e);
+  }
+
+  public static Throwable redactSensitiveData(Throwable t) {
+    if (!(t instanceof SQLException)) {
+      return t;
+    }
+
+    if (!(t instanceof BatchUpdateException)) {
+      // t is a SQLException, but not BatchUpdateException.
+      SQLException oldSqlException = (SQLException) t;
+      SQLException newSqlException =
+          new SQLException(
+              REDACTED_VALUE, oldSqlException.getSQLState(), oldSqlException.getErrorCode());
+      newSqlException.setNextException(redactSensitiveData(oldSqlException.getNextException()));
+      newSqlException.setStackTrace(oldSqlException.getStackTrace());
+      return newSqlException;
+    }
+
+    // At this point t is BatchUpdateException; redact its message too.
+    BatchUpdateException oldBatchUpdateException = (BatchUpdateException) t;
+    BatchUpdateException newBatchUpdateException =
+        new BatchUpdateException(
+            REDACTED_VALUE,
+            oldBatchUpdateException.getSQLState(),
+            oldBatchUpdateException.getErrorCode(),
+            oldBatchUpdateException.getUpdateCounts());
+    newBatchUpdateException.setNextException(
+        redactSensitiveData(oldBatchUpdateException.getNextException()));
+    newBatchUpdateException.setStackTrace(oldBatchUpdateException.getStackTrace());
+    return newBatchUpdateException;
+  }
 
   // This implementation assumes it to be Postgres, see toString() of ServerErrorMessage.java
   // as well as the constructor of PSQLException.java with "boolean detail" flag in
@@ -105,5 +141,12 @@ public class LogUtil {
     }
 
     return msg1 + errMsg.substring(errorStartIdx, errorEndIdx);
+  }
+
+  public static String maybeRedact(boolean shouldRedactSensitiveLogs, String msg) {
+    if (shouldRedactSensitiveLogs) {
+      return REDACTED_VALUE;
+    }
+    return String.valueOf(msg);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -29,12 +29,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +47,10 @@ import io.confluent.connect.jdbc.dialect.SqliteDatabaseDialect;
 import io.confluent.connect.jdbc.util.CachedConnectionProvider;
 import io.confluent.connect.jdbc.util.TableDefinition;
 import io.confluent.connect.jdbc.util.TableId;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.WriterAppender;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.*;
@@ -58,10 +64,25 @@ import static org.mockito.Mockito.verify;
 
 public class JdbcDbWriterTest {
 
+  private static final String REDACTED = "<redacted>";
+  private static final String POSTGRES_CANARY = "alice@example.com";
+  private static final String WRITE_CANARY = "write-secret";
+  private static final String ROLLBACK_CANARY = "rollback-secret";
+  private static final String SENSITIVE_LOGGER_NAME =
+      "io.confluent.connect.jdbc.sink.Sensitive";
+
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+  private final Logger writerLogger = Logger.getLogger(JdbcDbWriter.class);
+  private final Logger sensitiveLogger = Logger.getLogger(SENSITIVE_LOGGER_NAME);
 
   private JdbcDbWriter writer = null;
   private DatabaseDialect dialect;
+  private Level writerLogLevel;
+  private StringWriter writerLogOutput;
+  private WriterAppender writerLogAppender;
+  private Level sensitiveLogLevel;
+  private StringWriter sensitiveLogOutput;
+  private WriterAppender sensitiveLogAppender;
 
   @Before
   public void setUp() throws IOException, SQLException {
@@ -70,8 +91,11 @@ public class JdbcDbWriterTest {
 
   @After
   public void tearDown() throws IOException, SQLException {
-    if (writer != null)
+    stopCapturingWriterLogs();
+    stopCapturingSensitiveLogs();
+    if (writer != null) {
       writer.closeQuietly();
+    }
     sqliteHelper.tearDown();
   }
 
@@ -95,43 +119,120 @@ public class JdbcDbWriterTest {
     };
   }
 
-  private class MockRollbackException extends SQLException {
-    public MockRollbackException() {
-      super();
-    }
-  }
-
   @Test
-  public void maybeTrimReturnsExceptionAsIsWhenFlagDisabled() {
+  public void writeRedactsBatchUpdateExceptionBeforeThrowingAndLogging() throws SQLException {
+    String driverMessage =
+        "Batch entry 0 INSERT INTO orders(email) VALUES ('" + POSTGRES_CANARY + "') "
+            + "was aborted: ERROR: duplicate key value violates unique constraint\n"
+            + "  Detail: Key (email)=(" + POSTGRES_CANARY + ") already exists.";
+    BatchUpdateException writeFailure = new BatchUpdateException(
+        driverMessage,
+        "23505",
+        7,
+        new int[]{Statement.EXECUTE_FAILED}
+    );
+    writeFailure.setNextException(
+        new SQLException(
+            "ERROR: duplicate key value. Detail: Key (email)=("
+                + POSTGRES_CANARY
+                + ") already exists.",
+            "23505",
+            7
+        )
+    );
+    SQLException rollbackFailure = new SQLException(
+        "Rollback failed for " + ROLLBACK_CANARY,
+        "08006",
+        17002
+    );
+    Connection mockConnection = mock(Connection.class);
+    doThrow(rollbackFailure).when(mockConnection).rollback();
+
     Map<String, String> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("connection.url", "stub");
+    props.put("auto.create", "true");
+    props.put("auto.evolve", "true");
+    props.put("insert.mode", "upsert");
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
     props.put("trim.sensitive.log", "false");
-    JdbcDbWriter writer = newWriter(props);
-    BatchUpdateException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
-            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
-            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
-            new int[0]);
+    JdbcDbWriter testWriter = newWriterWithMockConnection(props, mockConnection);
+    PreparedStatement mockStatement = mock(PreparedStatement.class);
+    when(dialect.parseTableIdentifier(any())).thenReturn(mock(TableId.class));
+    when(dialect.createPreparedStatement(any(), any())).thenReturn(mockStatement);
+    when(dialect.statementBinder(any(), any(), any(), any(), any(), any(), eq(true)))
+        .thenReturn(mock(PreparedStatementBinder.class));
+    when(mockStatement.executeBatch()).thenThrow(writeFailure);
 
-    Throwable result = writer.maybeTrim(exception);
+    Schema keySchema = Schema.INT64_SCHEMA;
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(valueSchema)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+    SinkRecord record = new SinkRecord(
+        "books",
+        0,
+        keySchema,
+        1L,
+        valueSchema,
+        value,
+        0
+    );
 
-    assertSame(exception, result);
-    assertTrue(result.getMessage().contains("VALUES"));
+    captureWriterLogs();
+    SQLException thrown = assertThrows(
+        SQLException.class,
+        () -> testWriter.write(Collections.singleton(record))
+    );
+
+    verify(mockConnection, times(1)).rollback();
+    assertNotSame(writeFailure, thrown);
+    assertTrue(thrown instanceof BatchUpdateException);
+    assertEquals(REDACTED, thrown.getMessage());
+    assertEquals("23505", thrown.getSQLState());
+    assertEquals(7, thrown.getErrorCode());
+    assertArrayEquals(
+        writeFailure.getUpdateCounts(),
+        ((BatchUpdateException) thrown).getUpdateCounts()
+    );
+    assertArrayEquals(writeFailure.getStackTrace(), thrown.getStackTrace());
+    assertEquals(REDACTED, thrown.getNextException().getMessage());
+    assertEquals("23505", thrown.getNextException().getSQLState());
+    assertEquals(7, thrown.getNextException().getErrorCode());
+    assertEquals(1, thrown.getSuppressed().length);
+    SQLException suppressed = (SQLException) thrown.getSuppressed()[0];
+    assertEquals(REDACTED, suppressed.getMessage());
+    assertEquals("08006", suppressed.getSQLState());
+    assertEquals(17002, suppressed.getErrorCode());
+
+    String logs = capturedWriterLogs();
+    assertTrue(logs.contains(REDACTED));
+    assertFalse(logs.contains(POSTGRES_CANARY));
+    assertFalse(logs.contains(ROLLBACK_CANARY));
   }
 
   @Test
-  public void maybeTrimRedactsBatchUpdateExceptionWhenFlagEnabled() {
-    Map<String, String> props = new HashMap<>();
-    props.put("connection.url", sqliteHelper.sqliteUri());
-    props.put("trim.sensitive.log", "true");
-    JdbcDbWriter writer = newWriter(props);
-    BatchUpdateException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
-            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
-            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
-            new int[0]);
+  public void writeLogsRawFailuresOnlyAtSensitiveTrace() throws SQLException {
+    captureWriterLogs();
+    captureSensitiveLogs();
 
-    Throwable result = writer.maybeTrim(exception);
+    SQLException thrown = verifyConnectionRollback(
+        false,
+        new SQLException(WRITE_CANARY, "42000", 10)
+    );
 
-    assertTrue(!result.getMessage().contains("VALUES"));
+    assertEquals(REDACTED, thrown.getMessage());
+    String writerLogs = capturedWriterLogs();
+    assertTrue(writerLogs.contains(REDACTED));
+    assertFalse(writerLogs.contains(WRITE_CANARY));
+    assertFalse(writerLogs.contains(ROLLBACK_CANARY));
+
+    String sensitiveLogs = capturedSensitiveLogs();
+    assertTrue(sensitiveLogs.contains(WRITE_CANARY));
+    assertTrue(sensitiveLogs.contains(ROLLBACK_CANARY));
   }
 
   @Test
@@ -140,7 +241,12 @@ public class JdbcDbWriterTest {
 
     Throwable[] suppressed = e.getSuppressed();
     assertEquals(suppressed.length, 1);
-    assertTrue(suppressed[0] instanceof MockRollbackException);
+    assertTrue(suppressed[0] instanceof SQLException);
+    SQLException rollbackException = (SQLException) suppressed[0];
+    assertEquals(REDACTED, rollbackException.getMessage());
+    assertEquals("08006", rollbackException.getSQLState());
+    assertEquals(17002, rollbackException.getErrorCode());
+    assertFalse(rollbackException.getMessage().contains(ROLLBACK_CANARY));
   }
 
   @Test
@@ -152,11 +258,20 @@ public class JdbcDbWriterTest {
   }
 
   private SQLException verifyConnectionRollback(boolean succeedOnRollBack) throws SQLException {
+    return verifyConnectionRollback(succeedOnRollBack, new SQLException());
+  }
+
+  private SQLException verifyConnectionRollback(
+      boolean succeedOnRollBack,
+      SQLException writeFailure
+  ) throws SQLException {
     Connection mockConnection = mock(Connection.class);
 
-    doThrow(new SQLException()).when(mockConnection).commit();
+    doThrow(writeFailure).when(mockConnection).commit();
     if (!succeedOnRollBack) {
-      doThrow(new MockRollbackException()).when(mockConnection).rollback();
+      doThrow(new SQLException(ROLLBACK_CANARY, "08006", 17002))
+          .when(mockConnection)
+          .rollback();
     }
 
     Map<String, String> props = new HashMap<>();
@@ -201,6 +316,49 @@ public class JdbcDbWriterTest {
 
     verify(mockConnection, times(1)).rollback();
     return e;
+  }
+
+  private void captureWriterLogs() {
+    writerLogLevel = writerLogger.getLevel();
+    writerLogOutput = new StringWriter();
+    writerLogAppender = new WriterAppender(new PatternLayout("%m%n"), writerLogOutput);
+    writerLogger.setLevel(Level.ERROR);
+    writerLogger.addAppender(writerLogAppender);
+  }
+
+  private String capturedWriterLogs() {
+    return writerLogOutput.toString();
+  }
+
+  private void captureSensitiveLogs() {
+    sensitiveLogLevel = sensitiveLogger.getLevel();
+    sensitiveLogOutput = new StringWriter();
+    sensitiveLogAppender =
+        new WriterAppender(new PatternLayout("%m%n"), sensitiveLogOutput);
+    sensitiveLogger.setLevel(Level.TRACE);
+    sensitiveLogger.addAppender(sensitiveLogAppender);
+  }
+
+  private String capturedSensitiveLogs() {
+    return sensitiveLogOutput.toString();
+  }
+
+  private void stopCapturingWriterLogs() {
+    if (writerLogAppender != null) {
+      writerLogger.removeAppender(writerLogAppender);
+      writerLogAppender.close();
+      writerLogger.setLevel(writerLogLevel);
+      writerLogAppender = null;
+    }
+  }
+
+  private void stopCapturingSensitiveLogs() {
+    if (sensitiveLogAppender != null) {
+      sensitiveLogger.removeAppender(sensitiveLogAppender);
+      sensitiveLogAppender.close();
+      sensitiveLogger.setLevel(sensitiveLogLevel);
+      sensitiveLogAppender = null;
+    }
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -16,20 +16,22 @@
 package io.confluent.connect.jdbc.sink;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.sql.BatchUpdateException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +51,11 @@ import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.WriterAppender;
+import org.easymock.Capture;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
 import org.junit.Before;
@@ -57,9 +64,19 @@ import org.junit.Test;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 
 public class JdbcSinkTaskTest extends EasyMockSupport {
+  private static final String REDACTED = "<redacted>";
+  private static final String RETRY_CANARY = "retry-secret";
+  private static final String SQL_SERVER_CANARY = "sqlserver-secret@example.com";
+  private static final String MYSQL_CANARY = "mysql-secret@example.com";
+
   private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
   private final JdbcDbWriter mockWriter = createMock(JdbcDbWriter.class);
   private final SinkTaskContext ctx = createMock(SinkTaskContext.class);
+  private final Logger taskLogger = Logger.getLogger(JdbcSinkTask.class);
+
+  private Level taskLogLevel;
+  private StringWriter taskLogOutput;
+  private WriterAppender taskLogAppender;
 
   private static final Schema SCHEMA = SchemaBuilder.struct().name("com.example.Person")
       .field("firstName", Schema.STRING_SCHEMA)
@@ -90,6 +107,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
 
   @After
   public void tearDown() throws IOException, SQLException {
+    stopCapturingTaskLogs();
     sqliteHelper.tearDown();
   }
 
@@ -234,9 +252,9 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     List<SinkRecord> records = createRecordsList(1);
 
     mockWriter.write(records);
-    SQLException chainedException = new SQLException("cause 1");
-    chainedException.setNextException(new SQLException("cause 2"));
-    chainedException.setNextException(new SQLException("cause 3"));
+    SQLException chainedException = new SQLException(RETRY_CANARY + "-1", "42000", 10);
+    chainedException.setNextException(new SQLException(RETRY_CANARY + "-2", "42001", 20));
+    chainedException.setNextException(new SQLException(RETRY_CANARY + "-3", "42002", 30));
     expectLastCall().andThrow(chainedException).times(1 + maxRetries);
 
     ctx.timeout(retryBackoffMs);
@@ -258,59 +276,32 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     Map<String, String> props = setupBasicProps(maxRetries, retryBackoffMs);
     task.start(props);
 
-    try {
-      task.put(records);
-      fail();
-    } catch (RetriableException expected) {
-      assertEquals(SQLException.class, expected.getCause().getClass());
-      int i = 0;
-      for (Throwable t : (SQLException) expected.getCause()) {
-        ++i;
-        StringWriter sw = new StringWriter();
-        t.printStackTrace(new PrintWriter(sw));
-        System.out.println("Chained exception " + i + ": " + sw);
-      }
-    }
+    RetriableException firstRetry =
+        assertThrows(RetriableException.class, () -> task.put(records));
+    assertTaskExceptionRedacted(firstRetry, RETRY_CANARY, "42000", 10);
 
-    try {
-      task.put(records);
-      fail();
-    } catch (RetriableException expected) {
-      assertEquals(SQLException.class, expected.getCause().getClass());
-      int i = 0;
-      for (Throwable t : (SQLException) expected.getCause()) {
-        ++i;
-        StringWriter sw = new StringWriter();
-        t.printStackTrace(new PrintWriter(sw));
-        System.out.println("Chained exception " + i + ": " + sw);
-      }
-    }
+    RetriableException secondRetry =
+        assertThrows(RetriableException.class, () -> task.put(records));
+    assertTaskExceptionRedacted(secondRetry, RETRY_CANARY, "42000", 10);
 
-    try {
-      task.put(records);
-      fail();
-    } catch (RetriableException e) {
-      fail("Non-retriable exception expected");
-    } catch (ConnectException expected) {
-      assertEquals(SQLException.class, expected.getCause().getClass());
-      int i = 0;
-      for (Throwable t : (SQLException) expected.getCause()) {
-        ++i;
-        StringWriter sw = new StringWriter();
-        t.printStackTrace(new PrintWriter(sw));
-        System.out.println("Chained exception " + i + ": " + sw);
-      }
-    }
+    ConnectException exhausted =
+        assertThrows(ConnectException.class, () -> task.put(records));
+    assertFalse(exhausted instanceof RetriableException);
+    assertTaskExceptionRedacted(exhausted, RETRY_CANARY, "42000", 10);
 
     verifyAll();
   }
 
   @Test
-  public void errorReporting() throws SQLException {
+  public void errorReportingRedactsPlainSqlException() throws SQLException {
     List<SinkRecord> records = createRecordsList(1);
 
     mockWriter.write(records);
-    SQLException exception = new SQLException("cause 1");
+    SQLException exception = new SQLException(
+        "Duplicate entry '" + MYSQL_CANARY + "' for key 'email'",
+        "23000",
+        1062
+    );
     expectLastCall().andThrow(exception);
     mockWriter.closeQuietly();
     expectLastCall();
@@ -325,15 +316,30 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     };
     task.initialize(ctx);
     ErrantRecordReporter reporter = createMock(ErrantRecordReporter.class);
+    Capture<Throwable> reportedException = Capture.newInstance();
     expect(ctx.errantRecordReporter()).andReturn(reporter);
-    expect(reporter.report(anyObject(), anyObject())).andReturn(CompletableFuture.completedFuture(null));
+    expect(reporter.report(anyObject(), capture(reportedException)))
+        .andReturn(CompletableFuture.completedFuture(null));
     mockWriter.closeQuietly();
     expectLastCall();
     replayAll();
 
     Map<String, String> props = setupBasicProps(0, 0);
     task.start(props);
+    captureTaskLogs();
     task.put(records);
+
+    assertTrue(reportedException.hasCaptured());
+    assertTrue(reportedException.getValue() instanceof SQLException);
+    assertRedactedSqlException(
+        (SQLException) reportedException.getValue(),
+        MYSQL_CANARY,
+        "23000",
+        1062
+    );
+    String logs = capturedTaskLogs();
+    assertTrue(logs.contains(REDACTED));
+    assertFalse(logs.contains(MYSQL_CANARY));
     verifyAll();
   }
 
@@ -477,40 +483,111 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     task.put(records);
     verifyAll();
   }
-  @Test
-  public void testGetAllMessagesExceptionWithoutTrim() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    JdbcSinkTask task = new JdbcSinkTask();
-    SQLException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
-            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
-            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
-            new int[0]);
-    String exceptedExceptionMessage = "Exception chain:" + System.lineSeparator() + exception + System.lineSeparator();
-    Method privateMethod = JdbcSinkTask.class.getDeclaredMethod("getAllMessagesException", SQLException.class);
-    task.shouldTrimSensitiveLogs = false;
-    privateMethod.setAccessible(true);
-
-    SQLException result = (SQLException) privateMethod.invoke(task, exception);
-    assertEquals(exceptedExceptionMessage, result.getMessage());
-
-    privateMethod.setAccessible(false);
-  }
 
   @Test
-  public void testGetAllMessagesExceptionTrimmed() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    JdbcSinkTask task = new JdbcSinkTask();
-    SQLException exception = new BatchUpdateException("Batch entry 0 INSERT INTO \"abc\" (\"c1\",\"c2\",\"c3\",\"c4\") " +
-            "VALUES ('1','2','3',NULL) was aborted: ERROR: null value in column \"c4\" violates not-null constraint\n" +
-            "  Detail: Failing row contains (1, 2, 3, null).  Call getNextException to see other errors in the batch.",
-            new int[0]);
-    Method privateMethod = JdbcSinkTask.class.getDeclaredMethod("getAllMessagesException", SQLException.class);
-    privateMethod.setAccessible(true);
-    task.shouldTrimSensitiveLogs = true;
+  public void putRedactsNonPostgresBatchExceptionBeforeThrowingAndLogging()
+      throws SQLException {
+    List<SinkRecord> records = createRecordsList(1);
+    BatchUpdateException exception = new BatchUpdateException(
+        "Violation of UNIQUE KEY constraint 'UQ_email'. Cannot insert duplicate key in object "
+            + "'dbo.orders'. The duplicate key value is (" + SQL_SERVER_CANARY + ").",
+        "23000",
+        2627,
+        new int[]{Statement.EXECUTE_FAILED}
+    );
 
-    SQLException result = (SQLException) privateMethod.invoke(task, exception);
-    assertTrue(!result.getLocalizedMessage().contains("VALUES"));
+    mockWriter.write(records);
+    expectLastCall().andThrow(exception);
 
-    privateMethod.setAccessible(false);
+    JdbcSinkTask task = new JdbcSinkTask() {
+      @Override
+      void initWriter() {
+        this.writer = mockWriter;
+      }
+    };
+    task.initialize(ctx);
+    expect(ctx.errantRecordReporter()).andReturn(null);
+    replayAll();
+
+    Map<String, String> props = setupBasicProps(0, 0);
+    task.start(props);
+    captureTaskLogs();
+    ConnectException thrown =
+        assertThrows(ConnectException.class, () -> task.put(records));
+
+    SQLException redacted = assertTaskExceptionRedacted(
+        thrown,
+        SQL_SERVER_CANARY,
+        "23000",
+        2627
+    );
+    assertTrue(redacted instanceof BatchUpdateException);
+    assertArrayEquals(
+        exception.getUpdateCounts(),
+        ((BatchUpdateException) redacted).getUpdateCounts()
+    );
+    assertArrayEquals(exception.getStackTrace(), redacted.getStackTrace());
+    String logs = capturedTaskLogs();
+    assertTrue(logs.contains(REDACTED));
+    assertFalse(logs.contains(SQL_SERVER_CANARY));
+    verifyAll();
   }
+
+  private SQLException assertTaskExceptionRedacted(
+      Throwable taskException,
+      String sensitiveValue,
+      String sqlState,
+      int errorCode
+  ) {
+    assertTrue(taskException.getCause() instanceof SQLException);
+    return assertRedactedSqlException(
+        (SQLException) taskException.getCause(),
+        sensitiveValue,
+        sqlState,
+        errorCode
+    );
+  }
+
+  private SQLException assertRedactedSqlException(
+      SQLException allMessagesException,
+      String sensitiveValue,
+      String sqlState,
+      int errorCode
+  ) {
+    assertTrue(allMessagesException.getMessage().contains(REDACTED));
+    assertFalse(allMessagesException.getMessage().contains(sensitiveValue));
+    SQLException redactedException = allMessagesException.getNextException();
+    assertNotNull(redactedException);
+    assertEquals(sqlState, redactedException.getSQLState());
+    assertEquals(errorCode, redactedException.getErrorCode());
+    for (Throwable current : redactedException) {
+      assertEquals(REDACTED, current.getMessage());
+      assertFalse(current.getMessage().contains(sensitiveValue));
+    }
+    return redactedException;
+  }
+
+  private void captureTaskLogs() {
+    taskLogLevel = taskLogger.getLevel();
+    taskLogOutput = new StringWriter();
+    taskLogAppender = new WriterAppender(new PatternLayout("%m%n"), taskLogOutput);
+    taskLogger.setLevel(Level.DEBUG);
+    taskLogger.addAppender(taskLogAppender);
+  }
+
+  private String capturedTaskLogs() {
+    return taskLogOutput.toString();
+  }
+
+  private void stopCapturingTaskLogs() {
+    if (taskLogAppender != null) {
+      taskLogger.removeAppender(taskLogAppender);
+      taskLogAppender.close();
+      taskLogger.setLevel(taskLogLevel);
+      taskLogAppender = null;
+    }
+  }
+
   private List<SinkRecord> createRecordsList(int batchSize) {
     List<SinkRecord> records = new ArrayList<>();
     for (int i = 0; i < batchSize; i++) {
@@ -524,6 +601,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     props.put(JdbcSinkConfig.CONNECTION_URL, "stub");
     props.put(JdbcSinkConfig.MAX_RETRIES, String.valueOf(maxRetries));
     props.put(JdbcSinkConfig.RETRY_BACKOFF_MS, String.valueOf(retryBackoffMs));
+    props.put(JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED, "false");
     return props;
   }
 }


### PR DESCRIPTION
## Summary

Backports the minimum-viable JDBC sink SQL exception redaction from #1664 to the
supported `10.8.x` release line for INC-12079 / CC-42731. The behavior is identical
to the `10.9.x` MVP:

- Replace every sink `SQLException` message handed off through normal connector logs,
  exceptions thrown to the Connect runtime, and DLQ reporting with the literal
  `<redacted>`.
- Preserve SQLState, vendor error code, `SQLException` versus
  `BatchUpdateException` type, batch update counts, exception chaining, and stack
  traces.
- Keep the original driver exception available only when the dedicated
  `io.confluent.connect.jdbc.sink.Sensitive` logger is explicitly enabled at TRACE.
  That logger is off by default.
- Leave `TableAlterOrCreateException` behavior and the existing
  `trim.sensitive.log` configuration compatibility unchanged.

PR #1664 remains the `10.9.x` change and its branch is untouched.

## Why this backport is correct and safe

`10.8.x` is an affected, supported release line, but it does not contain the
`LogUtil` redaction plumbing used by #1664. This PR therefore has two deliberately
separate commits:

1. An additive backport of the self-contained `LogUtil` redaction foundation already
   shipping and validated on `10.9.x`: the `<redacted>` constant,
   `redactSensitiveData(...)`, `maybeRedact(...)`, and their five focused tests.
2. The exact four-file sink MVP from #1664 at `ea927d1f`.

Before applying the sink commit, the four affected sink source and test files were
verified byte-identical between the current `10.8.x` and `10.9.x` base tips. The
port therefore introduces no release-line adaptation, dialect change, new
configuration, or new production class beyond the additive utility foundation.

A real KDP local-Docker E2E of the `10.9.x` MVP already demonstrated that customer
row values do not leak into the worker log, failed-task trace, or DLQ error headers.
It also confirmed that the raw driver message is recoverable only through TRACE on
`io.confluent.connect.jdbc.sink.Sensitive`.

## Validation

Run with `JAVA_HOME=/opt/homebrew/opt/openjdk@11`:

- `mvn -o clean package -DskipTests`: `BUILD SUCCESS`; zero Checkstyle violations.
- `mvn -o test -Dtest=LogUtilTest,JdbcDbWriterTest,JdbcSinkTaskTest`:
  45 tests run, 0 failures, 0 errors, 0 skipped.
  - `LogUtilTest`: 21
  - `JdbcDbWriterTest`: 15
  - `JdbcSinkTaskTest`: 9
