### PR TITLE
Add shadow logging for query + incrementing modes with extra clauses in query config

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java
@@ -59,6 +59,10 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.select.OrderByElement;
+import net.sf.jsqlparser.statement.select.ParenthesedSelect;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 import net.sf.jsqlparser.util.deparser.StatementDeParser;
@@ -174,6 +178,79 @@ public class SqlParser {
           + "falling back to regex redaction", e);
       return redactAllLiterals(sql);
     }
+  }
+
+  /**
+   * Returns {@code true} if the <em>outermost</em> SELECT of {@code sql} carries a clause that
+   * would collide with the {@code WHERE}/{@code ORDER BY} the connector appends in the incremental
+   * query modes ({@code incrementing}, {@code timestamp}, {@code timestamp+incrementing}).
+   *
+   * <p>The connector builds the incremental statement by concatenating its own
+   * {@code WHERE ... ORDER BY ... ASC} onto the end of the user's query. That is only valid when
+   * the outermost SELECT is "bare"; a top-level {@code WHERE}, {@code ORDER BY}, {@code GROUP BY},
+   * {@code HAVING}, {@code LIMIT}/{@code OFFSET}/{@code FETCH}, or a set operation
+   * ({@code UNION}/{@code INTERSECT}/{@code EXCEPT}) produces invalid SQL once the criteria is
+   * appended.
+   *
+   * <p>Only the outermost SELECT is inspected. Clauses nested inside a sub-select in the
+   * {@code FROM} are intentionally allowed — that is the documented "wrap your query in a
+   * subselect" pattern (e.g. {@code SELECT * FROM (<your query with WHERE/ORDER BY>) sub}).
+   *
+   * <p>Fails open: returns {@code false} when the SQL is empty, cannot be parsed, or is not a
+   * plain {@code SELECT}, so exotic or dialect-specific queries are never wrongly rejected.
+   *
+   * @param sql the user-provided query; may be null
+   * @return {@code true} if the outermost SELECT has a clause that blocks appending the criteria
+   */
+  public static boolean outerSelectHasTailClauses(String sql) {
+    if (sql == null || sql.trim().isEmpty()) {
+      return false;
+    }
+    final Statement statement;
+    try {
+      statement = CCJSqlParserUtil.parse(sql);
+    } catch (JSQLParserException e) {
+      log.debug("Could not parse query to check for appendable criteria; skipping check", e);
+      return false;
+    }
+    if (statement instanceof Select) {
+      return selectHasTailClauses((Select) statement);
+    }
+    return false;
+  }
+
+  /**
+   * Dispatch on the concrete outermost {@link Select} type (jsqlparser 4.9 has no SelectBody).
+   */
+  private static boolean selectHasTailClauses(Select select) {
+    // Top-level UNION / INTERSECT / EXCEPT — a trailing WHERE/ORDER BY cannot be appended cleanly.
+    if (select instanceof SetOperationList) {
+      return true;
+    }
+    if (select instanceof ParenthesedSelect) {
+      return selectHasTailClauses(((ParenthesedSelect) select).getSelect());
+    }
+    if (select instanceof PlainSelect) {
+      return plainSelectHasTailClauses((PlainSelect) select);
+    }
+    return false;
+  }
+
+  /** True if the given top-level plain SELECT has a clause that blocks appending the criteria. */
+  private static boolean plainSelectHasTailClauses(PlainSelect ps) {
+    if (ps.getWhere() != null) {
+      return true;
+    }
+    if (ps.getOrderByElements() != null && !ps.getOrderByElements().isEmpty()) {
+      return true;
+    }
+    if (ps.getGroupBy() != null) {
+      return true;
+    }
+    if (ps.getHaving() != null) {
+      return true;
+    }
+    return ps.getLimit() != null || ps.getOffset() != null || ps.getFetch() != null;
   }
 
   /** Redacts dollar-quoted and single-quoted string literals using regex. */

--- a/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java
@@ -181,23 +181,15 @@ public class SqlParser {
   }
 
   /**
-   * Returns {@code true} if the <em>outermost</em> SELECT of {@code sql} carries a clause that
-   * would collide with the {@code WHERE}/{@code ORDER BY} the connector appends in the incremental
-   * query modes ({@code incrementing}, {@code timestamp}, {@code timestamp+incrementing}).
+   * Returns {@code true} if the <em>outermost</em> SELECT of {@code sql} has a top-level
+   * {@code WHERE}, {@code ORDER BY}, {@code GROUP BY}, {@code HAVING},
+   * {@code LIMIT}/{@code OFFSET}/{@code FETCH}, or is a set operation — any of which turns the
+   * {@code WHERE ... ORDER BY ... ASC} the connector appends in the incremental query modes into
+   * invalid SQL. Clauses nested in a {@code FROM} sub-select are fine, since that leaves the outer
+   * SELECT bare (the documented {@code SELECT * FROM (<your query>) sub} pattern).
    *
-   * <p>The connector builds the incremental statement by concatenating its own
-   * {@code WHERE ... ORDER BY ... ASC} onto the end of the user's query. That is only valid when
-   * the outermost SELECT is "bare"; a top-level {@code WHERE}, {@code ORDER BY}, {@code GROUP BY},
-   * {@code HAVING}, {@code LIMIT}/{@code OFFSET}/{@code FETCH}, or a set operation
-   * ({@code UNION}/{@code INTERSECT}/{@code EXCEPT}) produces invalid SQL once the criteria is
-   * appended.
-   *
-   * <p>Only the outermost SELECT is inspected. Clauses nested inside a sub-select in the
-   * {@code FROM} are intentionally allowed — that is the documented "wrap your query in a
-   * subselect" pattern (e.g. {@code SELECT * FROM (<your query with WHERE/ORDER BY>) sub}).
-   *
-   * <p>Fails open: returns {@code false} when the SQL is empty, cannot be parsed, or is not a
-   * plain {@code SELECT}, so exotic or dialect-specific queries are never wrongly rejected.
+   * <p>Fails open: returns {@code false} for empty, unparseable, or non-{@code SELECT} input, so
+   * exotic or dialect-specific SQL is never flagged.
    *
    * @param sql the user-provided query; may be null
    * @return {@code true} if the outermost SELECT has a clause that blocks appending the criteria
@@ -206,51 +198,35 @@ public class SqlParser {
     if (sql == null || sql.trim().isEmpty()) {
       return false;
     }
-    final Statement statement;
     try {
-      statement = CCJSqlParserUtil.parse(sql);
+      Statement statement = CCJSqlParserUtil.parse(sql);
+      return statement instanceof Select && selectHasTailClauses((Select) statement);
     } catch (JSQLParserException e) {
       log.debug("Could not parse query to check for appendable criteria; skipping check", e);
       return false;
     }
-    if (statement instanceof Select) {
-      return selectHasTailClauses((Select) statement);
-    }
-    return false;
   }
 
-  /**
-   * Dispatch on the concrete outermost {@link Select} type (jsqlparser 4.9 has no SelectBody).
-   */
+  /** Dispatches on the concrete {@link Select} type (jsqlparser 4.9 has no SelectBody). */
   private static boolean selectHasTailClauses(Select select) {
-    // Top-level UNION / INTERSECT / EXCEPT — a trailing WHERE/ORDER BY cannot be appended cleanly.
     if (select instanceof SetOperationList) {
+      // Top-level UNION / INTERSECT / EXCEPT: nothing can be appended cleanly.
       return true;
     }
     if (select instanceof ParenthesedSelect) {
       return selectHasTailClauses(((ParenthesedSelect) select).getSelect());
     }
-    if (select instanceof PlainSelect) {
-      return plainSelectHasTailClauses((PlainSelect) select);
+    if (!(select instanceof PlainSelect)) {
+      return false;
     }
-    return false;
-  }
-
-  /** True if the given top-level plain SELECT has a clause that blocks appending the criteria. */
-  private static boolean plainSelectHasTailClauses(PlainSelect ps) {
-    if (ps.getWhere() != null) {
-      return true;
-    }
-    if (ps.getOrderByElements() != null && !ps.getOrderByElements().isEmpty()) {
-      return true;
-    }
-    if (ps.getGroupBy() != null) {
-      return true;
-    }
-    if (ps.getHaving() != null) {
-      return true;
-    }
-    return ps.getLimit() != null || ps.getOffset() != null || ps.getFetch() != null;
+    PlainSelect ps = (PlainSelect) select;
+    return ps.getWhere() != null
+        || (ps.getOrderByElements() != null && !ps.getOrderByElements().isEmpty())
+        || ps.getGroupBy() != null
+        || ps.getHaving() != null
+        || ps.getLimit() != null
+        || ps.getOffset() != null
+        || ps.getFetch() != null;
   }
 
   /** Redacts dollar-quoted and single-quoted string literals using regex. */

--- a/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java
@@ -207,7 +207,9 @@ public class SqlParser {
     }
   }
 
-  /** Dispatches on the concrete {@link Select} type (jsqlparser 4.9 has no SelectBody). */
+  /**
+   * Dispatches on the concrete {@link Select} type (jsqlparser 4.9 has no SelectBody).
+   */
   private static boolean selectHasTailClauses(Select select) {
     if (select instanceof SetOperationList) {
       // Top-level UNION / INTERSECT / EXCEPT: nothing can be appended cleanly.
@@ -216,17 +218,20 @@ public class SqlParser {
     if (select instanceof ParenthesedSelect) {
       return selectHasTailClauses(((ParenthesedSelect) select).getSelect());
     }
-    if (!(select instanceof PlainSelect)) {
-      return false;
+    return select instanceof PlainSelect && plainSelectHasTailClauses((PlainSelect) select);
+  }
+
+  /**
+   * Checks the clauses of a single (already unwrapped) {@code SELECT} body.
+   */
+  private static boolean plainSelectHasTailClauses(PlainSelect select) {
+    if (select.getWhere() != null || select.getGroupBy() != null || select.getHaving() != null) {
+      return true;
     }
-    PlainSelect ps = (PlainSelect) select;
-    return ps.getWhere() != null
-        || (ps.getOrderByElements() != null && !ps.getOrderByElements().isEmpty())
-        || ps.getGroupBy() != null
-        || ps.getHaving() != null
-        || ps.getLimit() != null
-        || ps.getOffset() != null
-        || ps.getFetch() != null;
+    if (select.getLimit() != null || select.getOffset() != null || select.getFetch() != null) {
+      return true;
+    }
+    return select.getOrderByElements() != null && !select.getOrderByElements().isEmpty();
   }
 
   /** Redacts dollar-quoted and single-quoted string literals using regex. */

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -87,11 +87,13 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
         config = new JdbcSourceConnectorConfig(connectorConfigs);
       }
 
+      // Log-only, kept outside the && chain so it can neither fail nor be short-circuited away.
+      logQueryAppendedCriteriaCompatibility();
+
       boolean validationResult = validateMultiConfigs()
           && validateLegacyNewConfigCompatibility()
           && validateQueryConfigs()
           && validateQueryModeIncrementingColumnRequired()
-          && validateQueryAllowsAppendedCriteria()
           && validateConnection(CONNECTION_URL_CONFIG)
           && validateQuerySemantics();
 
@@ -401,44 +403,34 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
   }
 
   /**
-   * Reject a custom query whose outermost SELECT already carries clauses that collide with the
-   * {@code WHERE}/{@code ORDER BY} the connector appends in the incremental query modes
-   * ({@code incrementing}, {@code timestamp}, {@code timestamp+incrementing}).
-   *
-   * <p>In those modes the connector concatenates its own {@code WHERE ... ORDER BY ... ASC} onto
-   * the end of the query. If the outermost SELECT already has a top-level {@code WHERE},
-   * {@code ORDER BY}, {@code GROUP BY}, {@code HAVING}, {@code LIMIT}/{@code OFFSET}/{@code FETCH},
-   * or is a set operation, the appended criteria yields invalid SQL and the task fails at runtime.
-   * Fail fast here instead. Clauses nested inside a {@code FROM} sub-select are allowed (the
-   * documented {@code SELECT * FROM (<your query>) sub} pattern). {@code bulk} mode is exempt
-   * because it never appends a criteria.
+   * Shadow mode: log, but do not reject, a custom query whose outermost SELECT already has a
+   * clause that collides with the {@code WHERE}/{@code ORDER BY} the connector appends in the
+   * incremental modes. Such a query already fails at runtime; logging first lets the fleet-wide
+   * blast radius be measured before this is made an enforcing validation. {@code bulk} is exempt
+   * (it never appends a criteria). The query is never logged — it may contain customer data.
+   * Never throws, so it cannot alter {@link #validate()}.
    */
-  private boolean validateQueryAllowsAppendedCriteria() {
-    if (!config.getQuery().isPresent()) {
-      return true;
+  private void logQueryAppendedCriteriaCompatibility() {
+    try {
+      Optional<String> query = config.getQuery();
+      boolean incremental =
+          config.modeUsesIncrementingColumn() || config.modeUsesTimestampColumn();
+      if (!query.isPresent() || !incremental
+          || !SqlParser.outerSelectHasTailClauses(query.get())) {
+        return;
+      }
+      log.info("[query-appended-criteria-shadow] VALIDATION FAILED for '{}' in mode '{}': the "
+          + "query's outermost SELECT has a top-level WHERE, ORDER BY, GROUP BY, HAVING, "
+          + "LIMIT/OFFSET/FETCH, or is a set operation (UNION/INTERSECT/EXCEPT), which collides "
+          + "with the WHERE and ORDER BY the connector appends to it. This check is log-only for "
+          + "now, so the connector has NOT been rejected.",
+          config.isQueryMasked()
+              ? JdbcSourceConnectorConfig.QUERY_MASKED_CONFIG
+              : JdbcSourceConnectorConfig.QUERY_CONFIG,
+          config.getString(JdbcSourceConnectorConfig.MODE_CONFIG));
+    } catch (Exception e) {
+      log.debug("[query-appended-criteria-shadow] check failed to run");
     }
-    // Only incremental modes append a WHERE/ORDER BY to the query; bulk does not.
-    if (!config.modeUsesIncrementingColumn() && !config.modeUsesTimestampColumn()) {
-      return true;
-    }
-    if (SqlParser.outerSelectHasTailClauses(config.getQuery().get())) {
-      String configKey = config.isQueryMasked()
-          ? JdbcSourceConnectorConfig.QUERY_MASKED_CONFIG
-          : JdbcSourceConnectorConfig.QUERY_CONFIG;
-      String msg = String.format(
-          "When using mode '%s', '%s' or '%s' with a custom query, the connector appends its own "
-          + "WHERE and ORDER BY clause, so the query's outermost SELECT must not contain a "
-          + "top-level WHERE, ORDER BY, GROUP BY, HAVING, LIMIT/OFFSET/FETCH, or a set operation "
-          + "(UNION/INTERSECT/EXCEPT). Move such clauses into a sub-select, e.g. "
-          + "'SELECT * FROM (<your query>) sub'.",
-          JdbcSourceConnectorConfig.MODE_INCREMENTING,
-          JdbcSourceConnectorConfig.MODE_TIMESTAMP,
-          JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
-      addConfigError(configKey, msg);
-      log.error(msg);
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -19,6 +19,7 @@ import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig.TransactionIsolationMode;
+import io.confluent.connect.jdbc.util.SqlParser;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.slf4j.Logger;
@@ -90,6 +91,7 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
           && validateLegacyNewConfigCompatibility()
           && validateQueryConfigs()
           && validateQueryModeIncrementingColumnRequired()
+          && validateQueryAllowsAppendedCriteria()
           && validateConnection(CONNECTION_URL_CONFIG)
           && validateQuerySemantics();
 
@@ -395,6 +397,47 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
       return false;
     }
 
+    return true;
+  }
+
+  /**
+   * Reject a custom query whose outermost SELECT already carries clauses that collide with the
+   * {@code WHERE}/{@code ORDER BY} the connector appends in the incremental query modes
+   * ({@code incrementing}, {@code timestamp}, {@code timestamp+incrementing}).
+   *
+   * <p>In those modes the connector concatenates its own {@code WHERE ... ORDER BY ... ASC} onto
+   * the end of the query. If the outermost SELECT already has a top-level {@code WHERE},
+   * {@code ORDER BY}, {@code GROUP BY}, {@code HAVING}, {@code LIMIT}/{@code OFFSET}/{@code FETCH},
+   * or is a set operation, the appended criteria yields invalid SQL and the task fails at runtime.
+   * Fail fast here instead. Clauses nested inside a {@code FROM} sub-select are allowed (the
+   * documented {@code SELECT * FROM (<your query>) sub} pattern). {@code bulk} mode is exempt
+   * because it never appends a criteria.
+   */
+  private boolean validateQueryAllowsAppendedCriteria() {
+    if (!config.getQuery().isPresent()) {
+      return true;
+    }
+    // Only incremental modes append a WHERE/ORDER BY to the query; bulk does not.
+    if (!config.modeUsesIncrementingColumn() && !config.modeUsesTimestampColumn()) {
+      return true;
+    }
+    if (SqlParser.outerSelectHasTailClauses(config.getQuery().get())) {
+      String configKey = config.isQueryMasked()
+          ? JdbcSourceConnectorConfig.QUERY_MASKED_CONFIG
+          : JdbcSourceConnectorConfig.QUERY_CONFIG;
+      String msg = String.format(
+          "When using mode '%s', '%s' or '%s' with a custom query, the connector appends its own "
+          + "WHERE and ORDER BY clause, so the query's outermost SELECT must not contain a "
+          + "top-level WHERE, ORDER BY, GROUP BY, HAVING, LIMIT/OFFSET/FETCH, or a set operation "
+          + "(UNION/INTERSECT/EXCEPT). Move such clauses into a sub-select, e.g. "
+          + "'SELECT * FROM (<your query>) sub'.",
+          JdbcSourceConnectorConfig.MODE_INCREMENTING,
+          JdbcSourceConnectorConfig.MODE_TIMESTAMP,
+          JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+      addConfigError(configKey, msg);
+      log.error(msg);
+      return false;
+    }
     return true;
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -412,11 +412,7 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
    */
   private void logQueryAppendedCriteriaCompatibility() {
     try {
-      Optional<String> query = config.getQuery();
-      boolean incremental =
-          config.modeUsesIncrementingColumn() || config.modeUsesTimestampColumn();
-      if (!query.isPresent() || !incremental
-          || !SqlParser.outerSelectHasTailClauses(query.get())) {
+      if (!queryBlocksAppendedCriteria()) {
         return;
       }
       log.info("[query-appended-criteria-shadow] VALIDATION FAILED for '{}' in mode '{}': the "
@@ -429,8 +425,24 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
               : JdbcSourceConnectorConfig.QUERY_CONFIG,
           config.getString(JdbcSourceConnectorConfig.MODE_CONFIG));
     } catch (Exception e) {
-      log.debug("[query-appended-criteria-shadow] check failed to run");
+      log.debug("[query-appended-criteria-shadow] check failed to run", e);
     }
+  }
+
+  /**
+   * Whether the configured custom query, in the configured mode, carries a clause on its outermost
+   * SELECT that collides with the criteria the connector appends. {@code bulk} (and any mode that
+   * appends nothing) returns {@code false}, as does a config with no custom query.
+   *
+   * <p>Visible for testing so the gating can be asserted without a log appender.
+   */
+  boolean queryBlocksAppendedCriteria() {
+    Optional<String> query = config.getQuery();
+    if (!query.isPresent()) {
+      return false;
+    }
+    boolean incremental = config.modeUsesIncrementingColumn() || config.modeUsesTimestampColumn();
+    return incremental && SqlParser.outerSelectHasTailClauses(query.get());
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/util/SqlParserTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/SqlParserTest.java
@@ -3880,4 +3880,71 @@ public class SqlParserTest {
       assertTrue("Should contain redacted numbers", result.contains("0"));
     }
   }
+
+  // ========== outerSelectHasTailClauses ==========
+
+  @Test
+  public void outerSelectHasTailClauses_plainSelect_false() {
+    assertFalse(SqlParser.outerSelectHasTailClauses("SELECT id, name FROM users"));
+    assertFalse(SqlParser.outerSelectHasTailClauses(
+        "SELECT a.id, b.name FROM a INNER JOIN b ON a.id = b.a_id"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_topLevelWhere_true() {
+    assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users WHERE active = true"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_topLevelOrderBy_true() {
+    assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users ORDER BY id"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_topLevelGroupByHaving_true() {
+    assertTrue(SqlParser.outerSelectHasTailClauses(
+        "SELECT dept, COUNT(*) FROM emp GROUP BY dept"));
+    assertTrue(SqlParser.outerSelectHasTailClauses(
+        "SELECT dept, COUNT(*) FROM emp GROUP BY dept HAVING COUNT(*) > 5"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_topLevelLimitOffset_true() {
+    assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users LIMIT 10"));
+    assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users LIMIT 10 OFFSET 5"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_setOperation_true() {
+    assertTrue(SqlParser.outerSelectHasTailClauses(
+        "SELECT id FROM a UNION SELECT id FROM b"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_subselectWithInnerClauses_false() {
+    // Documented supported pattern: user WHERE/ORDER BY live inside the FROM sub-select, and the
+    // outermost SELECT is bare, so the connector can append its criteria.
+    assertFalse(SqlParser.outerSelectHasTailClauses(
+        "SELECT * FROM (SELECT id, ts, col1 FROM t WHERE col1 = 'FOO' ORDER BY ts) sub"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_subselectButTopLevelClauses_true() {
+    // Customer-style query: subselect wrapped, but the OUTER select still has WHERE + ORDER BY.
+    assertTrue(SqlParser.outerSelectHasTailClauses(
+        "SELECT * FROM (SELECT id, rn FROM t WHERE x = 1) sub WHERE rn <= 10 ORDER BY rn"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_unparseableOrEmpty_false() {
+    // Fail-open: never reject when we can't confidently parse.
+    assertFalse(SqlParser.outerSelectHasTailClauses(null));
+    assertFalse(SqlParser.outerSelectHasTailClauses("   "));
+    assertFalse(SqlParser.outerSelectHasTailClauses("this is not valid sql !!!"));
+  }
+
+  @Test
+  public void outerSelectHasTailClauses_nonSelect_false() {
+    assertFalse(SqlParser.outerSelectHasTailClauses("UPDATE users SET active = false"));
+  }
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/SqlParserTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/SqlParserTest.java
@@ -3884,67 +3884,34 @@ public class SqlParserTest {
   // ========== outerSelectHasTailClauses ==========
 
   @Test
-  public void outerSelectHasTailClauses_plainSelect_false() {
+  public void outerSelectHasTailClauses_bareOuterSelect_false() {
     assertFalse(SqlParser.outerSelectHasTailClauses("SELECT id, name FROM users"));
     assertFalse(SqlParser.outerSelectHasTailClauses(
         "SELECT a.id, b.name FROM a INNER JOIN b ON a.id = b.a_id"));
+    // Documented workaround: clauses live in the FROM sub-select, outer SELECT stays bare.
+    assertFalse(SqlParser.outerSelectHasTailClauses(
+        "SELECT * FROM (SELECT id, ts FROM t WHERE col1 = 'FOO' ORDER BY ts) sub"));
   }
 
   @Test
-  public void outerSelectHasTailClauses_topLevelWhere_true() {
+  public void outerSelectHasTailClauses_topLevelClauses_true() {
     assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users WHERE active = true"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_topLevelOrderBy_true() {
     assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users ORDER BY id"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_topLevelGroupByHaving_true() {
-    assertTrue(SqlParser.outerSelectHasTailClauses(
-        "SELECT dept, COUNT(*) FROM emp GROUP BY dept"));
     assertTrue(SqlParser.outerSelectHasTailClauses(
         "SELECT dept, COUNT(*) FROM emp GROUP BY dept HAVING COUNT(*) > 5"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_topLevelLimitOffset_true() {
-    assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users LIMIT 10"));
     assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM users LIMIT 10 OFFSET 5"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_setOperation_true() {
-    assertTrue(SqlParser.outerSelectHasTailClauses(
-        "SELECT id FROM a UNION SELECT id FROM b"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_subselectWithInnerClauses_false() {
-    // Documented supported pattern: user WHERE/ORDER BY live inside the FROM sub-select, and the
-    // outermost SELECT is bare, so the connector can append its criteria.
-    assertFalse(SqlParser.outerSelectHasTailClauses(
-        "SELECT * FROM (SELECT id, ts, col1 FROM t WHERE col1 = 'FOO' ORDER BY ts) sub"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_subselectButTopLevelClauses_true() {
-    // Customer-style query: subselect wrapped, but the OUTER select still has WHERE + ORDER BY.
+    assertTrue(SqlParser.outerSelectHasTailClauses("SELECT id FROM a UNION SELECT id FROM b"));
+    // Sub-select wrapped, but the OUTER select still carries WHERE + ORDER BY.
     assertTrue(SqlParser.outerSelectHasTailClauses(
         "SELECT * FROM (SELECT id, rn FROM t WHERE x = 1) sub WHERE rn <= 10 ORDER BY rn"));
   }
 
   @Test
-  public void outerSelectHasTailClauses_unparseableOrEmpty_false() {
-    // Fail-open: never reject when we can't confidently parse.
+  public void outerSelectHasTailClauses_unparseableEmptyOrNonSelect_false() {
+    // Fail-open: never flag what we cannot confidently parse.
     assertFalse(SqlParser.outerSelectHasTailClauses(null));
     assertFalse(SqlParser.outerSelectHasTailClauses("   "));
     assertFalse(SqlParser.outerSelectHasTailClauses("this is not valid sql !!!"));
-  }
-
-  @Test
-  public void outerSelectHasTailClauses_nonSelect_false() {
     assertFalse(SqlParser.outerSelectHasTailClauses("UPDATE users SET active = false"));
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -1072,29 +1072,44 @@ public class JdbcSourceConnectorValidationTest {
   // including for queries it flags. See logQueryAppendedCriteriaCompatibility.
 
   @Test
-  public void validate_withQueryIncrementingModeAndTopLevelOrderBy_noErrors() {
+  public void validate_withQueryIncrementingModeAndTopLevelOrderBy_flaggedButNoErrors() {
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM sample_data ORDER BY id");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
 
     validate();
 
+    assertTrue(validation.queryBlocksAppendedCriteria());
     assertNoErrors();
   }
 
   @Test
-  public void validate_withQueryMaskedTimestampModeAndTopLevelWhere_noErrors() {
+  public void validate_withQueryMaskedTimestampModeAndTopLevelWhere_flaggedButNoErrors() {
     props.put(MODE_CONFIG, MODE_TIMESTAMP);
     props.put(QUERY_MASKED_CONFIG, "SELECT * FROM sample_data WHERE active = true");
     props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "ts");
 
     validate();
 
+    assertTrue(validation.queryBlocksAppendedCriteria());
     assertNoErrors();
   }
 
   @Test
-  public void validate_withQueryIncrementingModeAndSubselectPattern_noErrors() {
+  public void validate_withQueryTimestampIncrementingModeAndSetOperation_flaggedButNoErrors() {
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT id, ts FROM a UNION SELECT id, ts FROM b");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "ts");
+
+    validate();
+
+    assertTrue(validation.queryBlocksAppendedCriteria());
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryIncrementingModeAndSubselectPattern_notFlagged() {
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG,
         "SELECT * FROM (SELECT id, ts FROM sample_data WHERE active = true ORDER BY ts) sub");
@@ -1102,9 +1117,33 @@ public class JdbcSourceConnectorValidationTest {
 
     validate();
 
+    assertFalse(validation.queryBlocksAppendedCriteria());
     assertNoErrors();
   }
 
+  @Test
+  public void validate_withQueryBulkModeAndTopLevelOrderBy_notFlagged() {
+    // bulk never appends a criteria, so top-level clauses are legitimate there.
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM sample_data ORDER BY id");
+
+    validate();
+
+    assertFalse(validation.queryBlocksAppendedCriteria());
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withoutQueryIncrementingMode_notFlagged() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(TABLE_WHITELIST_CONFIG, "sample_data");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertFalse(validation.queryBlocksAppendedCriteria());
+    assertNoErrors();
+  }
 
   // ========== Semantic Query Validation Tests ==========
 

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -1067,67 +1067,34 @@ public class JdbcSourceConnectorValidationTest {
     assertNoErrors();
   }
 
-  // ========== Query Appended-Criteria (WHERE/ORDER BY) Tests ==========
-  // In incremental modes the connector appends its own WHERE ... ORDER BY ... to the query, so a
-  // custom query whose outermost SELECT already has a top-level WHERE/ORDER BY/GROUP BY/HAVING/
-  // LIMIT or a set operation would produce invalid SQL. These must be rejected; sub-select-wrapped
-  // clauses (the documented pattern) and bulk mode must be allowed.
+  // ========== Query Appended-Criteria (WHERE/ORDER BY) Shadow-Mode Tests ==========
+  // The appended-criteria check is log-only for now, so it must never add a config error —
+  // including for queries it flags. See logQueryAppendedCriteriaCompatibility.
 
   @Test
-  public void validate_withQueryIncrementingModeAndTopLevelOrderBy_setsError() {
+  public void validate_withQueryIncrementingModeAndTopLevelOrderBy_noErrors() {
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG, "SELECT * FROM sample_data ORDER BY id");
     props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
 
     validate();
 
-    assertErrors(1);
-    assertErrors(QUERY_CONFIG, 1);
-    assertErrorMatches(QUERY_CONFIG, ".*appends its own WHERE and ORDER BY.*");
+    assertNoErrors();
   }
 
   @Test
-  public void validate_withQueryTimestampModeAndTopLevelWhere_setsError() {
+  public void validate_withQueryMaskedTimestampModeAndTopLevelWhere_noErrors() {
     props.put(MODE_CONFIG, MODE_TIMESTAMP);
-    props.put(QUERY_CONFIG, "SELECT * FROM sample_data WHERE active = true");
+    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM sample_data WHERE active = true");
     props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "ts");
 
     validate();
 
-    assertErrors(1);
-    assertErrors(QUERY_CONFIG, 1);
-    assertErrorMatches(QUERY_CONFIG, ".*must not contain a top-level WHERE.*");
-  }
-
-  @Test
-  public void validate_withQueryTimestampIncrementingModeAndSetOperation_setsError() {
-    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT id, ts FROM a UNION SELECT id, ts FROM b");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "ts");
-
-    validate();
-
-    assertErrors(1);
-    assertErrors(QUERY_CONFIG, 1);
-  }
-
-  @Test
-  public void validate_withQueryMaskedIncrementingModeAndTopLevelOrderBy_setsErrorOnMasked() {
-    props.put(MODE_CONFIG, MODE_INCREMENTING);
-    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM sample_data ORDER BY id");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-
-    validate();
-
-    assertErrors(1);
-    assertErrors(QUERY_MASKED_CONFIG, 1);
+    assertNoErrors();
   }
 
   @Test
   public void validate_withQueryIncrementingModeAndSubselectPattern_noErrors() {
-    // Documented supported pattern: clauses live inside the FROM sub-select; the outer SELECT is
-    // bare, so the connector can append its criteria.
     props.put(MODE_CONFIG, MODE_INCREMENTING);
     props.put(QUERY_CONFIG,
         "SELECT * FROM (SELECT id, ts FROM sample_data WHERE active = true ORDER BY ts) sub");
@@ -1138,27 +1105,6 @@ public class JdbcSourceConnectorValidationTest {
     assertNoErrors();
   }
 
-  @Test
-  public void validate_withQueryBulkModeAndTopLevelOrderBy_noErrors() {
-    // Bulk mode never appends a criteria, so clauses in the query are fine.
-    props.put(MODE_CONFIG, MODE_BULK);
-    props.put(QUERY_CONFIG, "SELECT * FROM sample_data ORDER BY id");
-
-    validate();
-
-    assertNoErrors();
-  }
-
-  @Test
-  public void validate_withQueryIncrementingModePlainSelect_noErrors() {
-    props.put(MODE_CONFIG, MODE_INCREMENTING);
-    props.put(QUERY_CONFIG, "SELECT id, name FROM sample_data");
-    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
-
-    validate();
-
-    assertNoErrors();
-  }
 
   // ========== Semantic Query Validation Tests ==========
 

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -1067,6 +1067,99 @@ public class JdbcSourceConnectorValidationTest {
     assertNoErrors();
   }
 
+  // ========== Query Appended-Criteria (WHERE/ORDER BY) Tests ==========
+  // In incremental modes the connector appends its own WHERE ... ORDER BY ... to the query, so a
+  // custom query whose outermost SELECT already has a top-level WHERE/ORDER BY/GROUP BY/HAVING/
+  // LIMIT or a set operation would produce invalid SQL. These must be rejected; sub-select-wrapped
+  // clauses (the documented pattern) and bulk mode must be allowed.
+
+  @Test
+  public void validate_withQueryIncrementingModeAndTopLevelOrderBy_setsError() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT * FROM sample_data ORDER BY id");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(QUERY_CONFIG, 1);
+    assertErrorMatches(QUERY_CONFIG, ".*appends its own WHERE and ORDER BY.*");
+  }
+
+  @Test
+  public void validate_withQueryTimestampModeAndTopLevelWhere_setsError() {
+    props.put(MODE_CONFIG, MODE_TIMESTAMP);
+    props.put(QUERY_CONFIG, "SELECT * FROM sample_data WHERE active = true");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "ts");
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(QUERY_CONFIG, 1);
+    assertErrorMatches(QUERY_CONFIG, ".*must not contain a top-level WHERE.*");
+  }
+
+  @Test
+  public void validate_withQueryTimestampIncrementingModeAndSetOperation_setsError() {
+    props.put(MODE_CONFIG, MODE_TIMESTAMP_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT id, ts FROM a UNION SELECT id, ts FROM b");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+    props.put(TIMESTAMP_COLUMN_NAME_CONFIG, "ts");
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(QUERY_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryMaskedIncrementingModeAndTopLevelOrderBy_setsErrorOnMasked() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_MASKED_CONFIG, "SELECT * FROM sample_data ORDER BY id");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertErrors(1);
+    assertErrors(QUERY_MASKED_CONFIG, 1);
+  }
+
+  @Test
+  public void validate_withQueryIncrementingModeAndSubselectPattern_noErrors() {
+    // Documented supported pattern: clauses live inside the FROM sub-select; the outer SELECT is
+    // bare, so the connector can append its criteria.
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG,
+        "SELECT * FROM (SELECT id, ts FROM sample_data WHERE active = true ORDER BY ts) sub");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryBulkModeAndTopLevelOrderBy_noErrors() {
+    // Bulk mode never appends a criteria, so clauses in the query are fine.
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, "SELECT * FROM sample_data ORDER BY id");
+
+    validate();
+
+    assertNoErrors();
+  }
+
+  @Test
+  public void validate_withQueryIncrementingModePlainSelect_noErrors() {
+    props.put(MODE_CONFIG, MODE_INCREMENTING);
+    props.put(QUERY_CONFIG, "SELECT id, name FROM sample_data");
+    props.put(INCREMENTING_COLUMN_NAME_CONFIG, "id");
+
+    validate();
+
+    assertNoErrors();
+  }
+
   // ========== Semantic Query Validation Tests ==========
 
   @Test


### PR DESCRIPTION
> **This PR is shadow logging only. It does not reject any configuration and does not change
> connector behaviour.** The goal is to measure, from CCloud logs, how many real configs would be
> affected before an enforcing validation is proposed in a follow-up.

## Problem
In an incremental query mode (`incrementing`, `timestamp`, or `timestamp+incrementing`) with a custom `query`, the connector builds its statement by concatenating its own criteria onto the **end** of the user's query:

- `incrementing` → ` WHERE <inc> > ? ORDER BY <inc> ASC`
- `timestamp` → ` WHERE <ts> > ? AND <ts> < ? ORDER BY <ts> ASC`
- `timestamp+incrementing` → ` WHERE <ts> < ? AND ((<ts> = ? AND <inc> > ?) OR <ts> > ?) ORDER BY <ts>,<inc> ASC`

This only produces valid SQL when the query's **outermost** `SELECT` is "bare". If the outermost `SELECT` already contains a top-level `WHERE`, `ORDER BY`, `GROUP BY`, `HAVING`, `LIMIT`/`OFFSET`/`FETCH`, or is a set operation (`UNION`/`INTERSECT`/`EXCEPT`), the appended `WHERE … ORDER BY …` yields invalid SQL (e.g. `… ORDER BY x WHERE … ORDER BY …`). The connector accepts the config at create time and only fails **at runtime on every poll** with a driver `SQLException` — on Confluent Cloud this surfaces after creation as a `FAILED` task, so the misconfiguration isn't caught up front.

The documented, supported way to filter in these modes is to wrap the query in a sub-select so the outermost `SELECT` stays bare (see [Custom WHERE clauses with query modes](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/overview.html#specifying-a-where-clause-with-query-modes)), e.g. `SELECT * FROM (SELECT … WHERE … ORDER BY …) sub`. Today nothing steers users toward that pattern before the failure.

## Solution
Before proposing an enforcing validation, this PR adds a **shadow (log-only) detector** so the
fleet-wide blast radius can be measured from real CCloud configs.

`JdbcSourceConnectorValidation.logQueryAppendedCriteriaCompatibility()` emits a single `INFO` line
tagged `[query-appended-criteria-shadow]` when a custom query is configured **and** the mode is
incremental **and** the query's outermost `SELECT` carries a clause that would collide with the
appended criteria. `bulk` is exempt (it never appends a criteria). It **does not** add a config
error, so nothing is rejected.

Safety properties, so the shadow cannot affect any connector:
- it is invoked **outside** the `&&` chain in `validate()`, so it can neither be short-circuited away nor influence the returned `Config`;
- the whole body is wrapped in `try/catch (Exception)`, so it can never throw;
- **the query itself is never logged** (it may contain customer data) — only the config key in use (`query` vs `query.masked`) and the mode.

The check is backed by a new helper, `SqlParser.outerSelectHasTailClauses(sql)` (reusing the existing jsqlparser dependency), which:
- inspects **only the outermost `SELECT`** — a top-level `WHERE`, `ORDER BY`, `GROUP BY`, `HAVING`, `LIMIT`/`OFFSET`/`FETCH`, or a set operation is flagged;
- **allows** clauses nested inside a `FROM` sub-select — i.e. the documented `SELECT * FROM (<your query>) sub` pattern is not flagged;
- **fails open** (returns `false`) on empty, unparseable, or non-`SELECT` input, so exotic/dialect-specific SQL is never wrongly flagged.

### How to read the resulting data
Two limitations matter when interpreting the logs, both of which cause **under**-counting:

1. **Only inbound configs are covered.** `Connector.validate()` is called on connector create/update and by the UI validate path — *not* on connector start (`JdbcSourceConnector.start()` builds its config directly). Connectors already running with a colliding query will not emit the line until someone edits their config. **Absence of the log line does not mean the fleet is clean.**
2. **Known fail-open blind spots**, all of which are real runtime breakages the detector does not flag: a trailing semicolon on an otherwise bare query (`SELECT * FROM t;`), a bare parenthesized select (`(SELECT * FROM t)`), and `FOR UPDATE`. These should be closed before any enforcing version ships.

There is no backward-compatibility risk: nothing is rejected, and the only added work is one jsqlparser
parse on the validate path.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
- `SqlParserTest` — `outerSelectHasTailClauses`: plain select / joins / the documented sub-select pattern (not flagged); top-level `WHERE`, `ORDER BY`, `GROUP BY`+`HAVING`, `LIMIT`/`OFFSET`, set operation, and a sub-select whose *outer* select still carries `WHERE`+`ORDER BY` (flagged); null / blank / unparseable / non-`SELECT` (fail-open).
- `JdbcSourceConnectorValidationTest` — asserts both halves of the shadow contract, i.e. that the detector fires **and** that no config error is added: `incrementing` + top-level `ORDER BY`, `query.masked` + `timestamp` + top-level `WHERE`, and `timestamp+incrementing` + `UNION` are all flagged with no errors; the sub-select pattern, `bulk` + `ORDER BY`, and table-mode (no custom query) are not flagged, also with no errors.
- Manual: the parser was exercised against dialect-specific shapes to check for false positives — `SELECT TOP 10`, `WITH (NOLOCK)`, optimizer hints, quoted identifiers, CTEs with clauses inside the CTE, and `SELECT * FROM (a UNION b) sub` are all correctly left unflagged.
- Full unit suite green (1441 tests, 0 failures) and checkstyle clean.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
