### PR TITLE
enrich redacted JDBC sink SQL exceptions with non-sensitive diagnostics

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -89,10 +89,10 @@ public class JdbcDbWriter {
       log.trace("Committing transaction");
       connection.commit();
     } catch (SQLException e) {
-      SENSITIVE.trace("Raw sink write failure (redacted at ERROR)", e);
-      SQLException redactedException = LogUtil.redactSensitiveData(e);
-      rollback(connection, redactedException);
-      throw redactedException;
+      SQLException writeException =
+          redactSensitiveDataIfEnabled("Raw sink write failure (redacted at ERROR)", e);
+      rollback(connection, writeException);
+      throw writeException;
     } catch (TableAlterOrCreateException e) {
       rollback(connection, e);
       throw e;
@@ -106,11 +106,19 @@ public class JdbcDbWriter {
       connection.rollback();
       log.info("Successfully rolled back transaction");
     } catch (SQLException e) {
-      SENSITIVE.trace("Raw rollback failure (redacted at ERROR)", e);
-      SQLException redactedException = LogUtil.redactSensitiveData(e);
-      log.error("Failed to rollback transaction", redactedException);
-      writeException.addSuppressed(redactedException);
+      SQLException rollbackException =
+          redactSensitiveDataIfEnabled("Raw rollback failure (redacted at ERROR)", e);
+      log.error("Failed to rollback transaction", rollbackException);
+      writeException.addSuppressed(rollbackException);
     }
+  }
+
+  private SQLException redactSensitiveDataIfEnabled(String traceMessage, SQLException exception) {
+    if (!config.trimSensitiveLogsEnabled) {
+      return exception;
+    }
+    SENSITIVE.trace(traceMessage, exception);
+    return LogUtil.redactSensitiveData(exception);
   }
 
   void closeQuietly() {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -94,18 +94,18 @@ public class JdbcSinkTask extends SinkTask {
         throw tace;
       }
     } catch (SQLException sqle) {
-      SQLException redactedException = LogUtil.redactSensitiveData(sqle);
+      SQLException loggedException = redactSensitiveDataIfEnabled(sqle);
       log.warn(
           "Write of {} records failed, remainingRetries={}",
           records.size(),
           remainingRetries,
-          redactedException
+          loggedException
       );
       int totalExceptions = 0;
       for (Throwable e :sqle) {
         totalExceptions++;
       }
-      SQLException sqlAllMessagesException = getAllMessagesException(sqle);
+      SQLException sqlAllMessagesException = getAllMessagesException(loggedException);
       if (remainingRetries > 0) {
         writer.closeQuietly();
         initWriter();
@@ -123,7 +123,7 @@ public class JdbcSinkTask extends SinkTask {
                   + "For complete details on each exception, please enable DEBUG logging.",
               totalExceptions);
           int exceptionCount = 1;
-          for (Throwable e : redactedException) {
+          for (Throwable e : loggedException) {
             log.debug("Exception {}:", exceptionCount++, e);
           }
           throw new ConnectException(sqlAllMessagesException);
@@ -145,7 +145,8 @@ public class JdbcSinkTask extends SinkTask {
         reporter.report(record, tace);
         writer.closeQuietly();
       } catch (SQLException sqle) {
-        SQLException sqlAllMessagesException = getAllMessagesException(sqle);
+        SQLException sqlAllMessagesException =
+            getAllMessagesException(redactSensitiveDataIfEnabled(sqle));
         log.debug(sqlAllMessagesException.toString());
         reporter.report(record, sqlAllMessagesException);
         writer.closeQuietly();
@@ -155,13 +156,18 @@ public class JdbcSinkTask extends SinkTask {
 
   private SQLException getAllMessagesException(SQLException sqle) {
     String sqleAllMessages = "Exception chain:" + System.lineSeparator();
-    SQLException redactedException = LogUtil.redactSensitiveData(sqle);
-    for (Throwable e : redactedException) {
+    for (Throwable e : sqle) {
       sqleAllMessages += e + System.lineSeparator();
     }
     SQLException sqlAllMessagesException = new SQLException(sqleAllMessages);
-    sqlAllMessagesException.setNextException(redactedException);
+    sqlAllMessagesException.setNextException(sqle);
     return sqlAllMessagesException;
+  }
+
+  private SQLException redactSensitiveDataIfEnabled(SQLException exception) {
+    return config.trimSensitiveLogsEnabled
+        ? LogUtil.redactSensitiveData(exception)
+        : exception;
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
@@ -72,14 +72,24 @@ public class LogUtil {
     if (!(t instanceof SQLException)) {
       return t;
     }
+    // Already produced by this helper: detected by identity (never by trusting message text, which
+    // could otherwise let a raw message that merely begins with the redaction token bypass
+    // redaction). Re-redacting an already-redacted exception is a no-op.
+    if (t instanceof RedactedSqlException || t instanceof RedactedBatchUpdateException) {
+      return t;
+    }
 
     if (!(t instanceof BatchUpdateException)) {
       SQLException oldSqlException = (SQLException) t;
+      // Keep the original SQLState on the reconstructed object for getSQLState() fidelity; the
+      // rendered message uses the validated form (see buildRedactedMessage / safeSqlState).
       SQLException newSqlException =
-          new SQLException(
+          new RedactedSqlException(
               buildRedactedMessage(oldSqlException, null),
               oldSqlException.getSQLState(),
               oldSqlException.getErrorCode());
+      // Bounded-chain assumption: this recursion mirrors the pre-existing implementation and does
+      // not defend against self-referential or pathologically deep next-exception chains.
       newSqlException.setNextException(
           (SQLException) redactSensitiveData(oldSqlException.getNextException()));
       newSqlException.setStackTrace(oldSqlException.getStackTrace());
@@ -89,7 +99,7 @@ public class LogUtil {
     BatchUpdateException oldBatchUpdateException = (BatchUpdateException) t;
     int[] updateCounts = oldBatchUpdateException.getUpdateCounts();
     BatchUpdateException newBatchUpdateException =
-        new BatchUpdateException(
+        new RedactedBatchUpdateException(
             buildRedactedMessage(oldBatchUpdateException, updateCounts),
             oldBatchUpdateException.getSQLState(),
             oldBatchUpdateException.getErrorCode(),
@@ -101,35 +111,73 @@ public class LogUtil {
   }
 
   /**
-   * Builds a privacy-safe redacted message that keeps ONLY non-sensitive diagnostic metadata:
-   * the original exception class, SQLState, errorCode, and (for a batch) the batch size and the
-   * index of the first failed statement. Never includes the original driver message text.
+   * Builds a privacy-safe redacted message that keeps ONLY non-sensitive diagnostic metadata: the
+   * original exception class, a validated SQLState, the errorCode, and (for a batch) the observed
+   * update-count length and the index of the first {@code EXECUTE_FAILED} entry. It never includes
+   * the original driver message text or any row value.
    *
-   * <p>Idempotent: if the message is already redacted (starts with {@code <redacted>}) it is
-   * returned unchanged, so re-redacting an already-redacted exception preserves the original
-   * class captured on the first pass.
+   * <p>This produces the message FORMAT that {@code redactSensitiveData} attaches to a freshly
+   * reconstructed {@link RedactedSqlException}/{@link RedactedBatchUpdateException}.
+   * Idempotency of the transform is handled by the identity check in
+   * {@code redactSensitiveData}, not here, so this method never inspects or trusts an incoming
+   * message.
    */
   private static String buildRedactedMessage(SQLException e, int[] updateCounts) {
-    String existing = e.getMessage();
-    if (existing != null && existing.startsWith(REDACTED_VALUE)) {
-      return existing;
-    }
     StringBuilder sb = new StringBuilder(REDACTED_VALUE)
         .append(" [class=").append(e.getClass().getName())
-        .append("; SQLState=").append(e.getSQLState())
+        .append("; SQLState=").append(safeSqlState(e.getSQLState()))
         .append("; errorCode=").append(e.getErrorCode());
     if (updateCounts != null) {
-      int firstFailedIndex = -1;
+      int firstExecuteFailedIndex = -1;
       for (int i = 0; i < updateCounts.length; i++) {
         if (updateCounts[i] == Statement.EXECUTE_FAILED) {
-          firstFailedIndex = i;
+          firstExecuteFailedIndex = i;
           break;
         }
       }
-      sb.append("; batchSize=").append(updateCounts.length)
-        .append("; firstFailedIndex=").append(firstFailedIndex);
+      // updateCountLength is the number of per-statement results the driver reported, which for a
+      // stop-on-failure driver may be fewer than the submitted batch size; firstExecuteFailedIndex
+      // is -1 when the driver reported no EXECUTE_FAILED marker.
+      sb.append("; updateCountLength=").append(updateCounts.length)
+        .append("; firstExecuteFailedIndex=").append(firstExecuteFailedIndex);
     }
     return sb.append("]").toString();
+  }
+
+  /**
+   * SQLState is expected to be a five-character SQLSTATE per the SQL/JDBC standard, but the API
+   * does not enforce it and a non-conformant driver or subclass could return arbitrary text.
+   * Render only a null or a conformant value; replace anything else with a fixed token so no
+   * unexpected text can reach logs, traces, or DLQ headers through the redacted message.
+   */
+  private static String safeSqlState(String sqlState) {
+    if (sqlState == null) {
+      return "null";
+    }
+    return sqlState.matches("[A-Za-z0-9]{5}") ? sqlState : "<invalid>";
+  }
+
+  // Marker subtypes so redactSensitiveData can recognize its own output by identity rather than by
+  // trusting message text. They carry no extra state; the redacted message is built by the caller.
+  private static final class RedactedSqlException extends SQLException {
+    private static final long serialVersionUID = 1L;
+
+    RedactedSqlException(String message, String sqlState, int errorCode) {
+      super(message, sqlState, errorCode);
+    }
+  }
+
+  private static final class RedactedBatchUpdateException extends BatchUpdateException {
+    private static final long serialVersionUID = 1L;
+
+    RedactedBatchUpdateException(
+        String message,
+        String sqlState,
+        int errorCode,
+        int[] updateCounts
+    ) {
+      super(message, sqlState, errorCode, updateCounts);
+    }
   }
 
   // This implementation assumes it to be Postgres, see toString() of ServerErrorMessage.java

--- a/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/LogUtil.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.util;
 
 import java.sql.BatchUpdateException;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * A stop-gap utility class to find a tradeoff between 2 things: To have reasonably good exception/
@@ -73,28 +74,62 @@ public class LogUtil {
     }
 
     if (!(t instanceof BatchUpdateException)) {
-      // t is a SQLException, but not BatchUpdateException.
       SQLException oldSqlException = (SQLException) t;
       SQLException newSqlException =
           new SQLException(
-              REDACTED_VALUE, oldSqlException.getSQLState(), oldSqlException.getErrorCode());
-      newSqlException.setNextException(redactSensitiveData(oldSqlException.getNextException()));
+              buildRedactedMessage(oldSqlException, null),
+              oldSqlException.getSQLState(),
+              oldSqlException.getErrorCode());
+      newSqlException.setNextException(
+          (SQLException) redactSensitiveData(oldSqlException.getNextException()));
       newSqlException.setStackTrace(oldSqlException.getStackTrace());
       return newSqlException;
     }
 
-    // At this point t is BatchUpdateException; redact its message too.
     BatchUpdateException oldBatchUpdateException = (BatchUpdateException) t;
+    int[] updateCounts = oldBatchUpdateException.getUpdateCounts();
     BatchUpdateException newBatchUpdateException =
         new BatchUpdateException(
-            REDACTED_VALUE,
+            buildRedactedMessage(oldBatchUpdateException, updateCounts),
             oldBatchUpdateException.getSQLState(),
             oldBatchUpdateException.getErrorCode(),
-            oldBatchUpdateException.getUpdateCounts());
+            updateCounts);
     newBatchUpdateException.setNextException(
-        redactSensitiveData(oldBatchUpdateException.getNextException()));
+        (SQLException) redactSensitiveData(oldBatchUpdateException.getNextException()));
     newBatchUpdateException.setStackTrace(oldBatchUpdateException.getStackTrace());
     return newBatchUpdateException;
+  }
+
+  /**
+   * Builds a privacy-safe redacted message that keeps ONLY non-sensitive diagnostic metadata:
+   * the original exception class, SQLState, errorCode, and (for a batch) the batch size and the
+   * index of the first failed statement. Never includes the original driver message text.
+   *
+   * <p>Idempotent: if the message is already redacted (starts with {@code <redacted>}) it is
+   * returned unchanged, so re-redacting an already-redacted exception preserves the original
+   * class captured on the first pass.
+   */
+  private static String buildRedactedMessage(SQLException e, int[] updateCounts) {
+    String existing = e.getMessage();
+    if (existing != null && existing.startsWith(REDACTED_VALUE)) {
+      return existing;
+    }
+    StringBuilder sb = new StringBuilder(REDACTED_VALUE)
+        .append(" [class=").append(e.getClass().getName())
+        .append("; SQLState=").append(e.getSQLState())
+        .append("; errorCode=").append(e.getErrorCode());
+    if (updateCounts != null) {
+      int firstFailedIndex = -1;
+      for (int i = 0; i < updateCounts.length; i++) {
+        if (updateCounts[i] == Statement.EXECUTE_FAILED) {
+          firstFailedIndex = i;
+          break;
+        }
+      }
+      sb.append("; batchSize=").append(updateCounts.length)
+        .append("; firstFailedIndex=").append(firstFailedIndex);
+    }
+    return sb.append("]").toString();
   }
 
   // This implementation assumes it to be Postgres, see toString() of ServerErrorMessage.java

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -155,7 +155,7 @@ public class JdbcDbWriterTest {
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "id");
-    props.put("trim.sensitive.log", "false");
+    props.put(JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED, "true");
     JdbcDbWriter testWriter = newWriterWithMockConnection(props, mockConnection);
     PreparedStatement mockStatement = mock(PreparedStatement.class);
     when(dialect.parseTableIdentifier(any())).thenReturn(mock(TableId.class));
@@ -221,7 +221,8 @@ public class JdbcDbWriterTest {
 
     SQLException thrown = verifyConnectionRollback(
         false,
-        new SQLException(WRITE_CANARY, "42000", 10)
+        new SQLException(WRITE_CANARY, "42000", 10),
+        true
     );
 
     assertTrue(thrown.getMessage().startsWith(REDACTED));
@@ -233,6 +234,26 @@ public class JdbcDbWriterTest {
     String sensitiveLogs = capturedSensitiveLogs();
     assertTrue(sensitiveLogs.contains(WRITE_CANARY));
     assertTrue(sensitiveLogs.contains(ROLLBACK_CANARY));
+  }
+
+  @Test
+  public void writeKeepsRawFailuresWhenSensitiveLogTrimmingDisabled() throws SQLException {
+    captureWriterLogs();
+    captureSensitiveLogs();
+    SQLException writeFailure = new SQLException(WRITE_CANARY, "42000", 10);
+
+    SQLException thrown = verifyConnectionRollback(false, writeFailure, false);
+
+    assertSame(writeFailure, thrown);
+    assertEquals(WRITE_CANARY, thrown.getMessage());
+    assertEquals(1, thrown.getSuppressed().length);
+    assertEquals(ROLLBACK_CANARY, thrown.getSuppressed()[0].getMessage());
+
+    String writerLogs = capturedWriterLogs();
+    assertTrue(writerLogs.contains(WRITE_CANARY));
+    assertTrue(writerLogs.contains(ROLLBACK_CANARY));
+    assertFalse(writerLogs.contains(REDACTED));
+    assertTrue(capturedSensitiveLogs().isEmpty());
   }
 
   @Test
@@ -265,6 +286,14 @@ public class JdbcDbWriterTest {
       boolean succeedOnRollBack,
       SQLException writeFailure
   ) throws SQLException {
+    return verifyConnectionRollback(succeedOnRollBack, writeFailure, true);
+  }
+
+  private SQLException verifyConnectionRollback(
+      boolean succeedOnRollBack,
+      SQLException writeFailure,
+      boolean trimSensitiveLogsEnabled
+  ) throws SQLException {
     Connection mockConnection = mock(Connection.class);
 
     doThrow(writeFailure).when(mockConnection).commit();
@@ -281,6 +310,10 @@ public class JdbcDbWriterTest {
     props.put("insert.mode", "upsert");
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "id"); // assigned name for the primitive key
+    props.put(
+        JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED,
+        String.valueOf(trimSensitiveLogsEnabled)
+    );
 
     JdbcDbWriter writer = newWriterWithMockConnection(props, mockConnection);
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -191,7 +191,7 @@ public class JdbcDbWriterTest {
     verify(mockConnection, times(1)).rollback();
     assertNotSame(writeFailure, thrown);
     assertTrue(thrown instanceof BatchUpdateException);
-    assertEquals(REDACTED, thrown.getMessage());
+    assertTrue(thrown.getMessage().startsWith(REDACTED));
     assertEquals("23505", thrown.getSQLState());
     assertEquals(7, thrown.getErrorCode());
     assertArrayEquals(
@@ -199,12 +199,12 @@ public class JdbcDbWriterTest {
         ((BatchUpdateException) thrown).getUpdateCounts()
     );
     assertArrayEquals(writeFailure.getStackTrace(), thrown.getStackTrace());
-    assertEquals(REDACTED, thrown.getNextException().getMessage());
+    assertTrue(thrown.getNextException().getMessage().startsWith(REDACTED));
     assertEquals("23505", thrown.getNextException().getSQLState());
     assertEquals(7, thrown.getNextException().getErrorCode());
     assertEquals(1, thrown.getSuppressed().length);
     SQLException suppressed = (SQLException) thrown.getSuppressed()[0];
-    assertEquals(REDACTED, suppressed.getMessage());
+    assertTrue(suppressed.getMessage().startsWith(REDACTED));
     assertEquals("08006", suppressed.getSQLState());
     assertEquals(17002, suppressed.getErrorCode());
 
@@ -224,7 +224,7 @@ public class JdbcDbWriterTest {
         new SQLException(WRITE_CANARY, "42000", 10)
     );
 
-    assertEquals(REDACTED, thrown.getMessage());
+    assertTrue(thrown.getMessage().startsWith(REDACTED));
     String writerLogs = capturedWriterLogs();
     assertTrue(writerLogs.contains(REDACTED));
     assertFalse(writerLogs.contains(WRITE_CANARY));
@@ -243,7 +243,7 @@ public class JdbcDbWriterTest {
     assertEquals(suppressed.length, 1);
     assertTrue(suppressed[0] instanceof SQLException);
     SQLException rollbackException = (SQLException) suppressed[0];
-    assertEquals(REDACTED, rollbackException.getMessage());
+    assertTrue(rollbackException.getMessage().startsWith(REDACTED));
     assertEquals("08006", rollbackException.getSQLState());
     assertEquals(17002, rollbackException.getErrorCode());
     assertFalse(rollbackException.getMessage().contains(ROLLBACK_CANARY));

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkConfigTest.java
@@ -27,6 +27,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class JdbcSinkConfigTest {
 
@@ -61,6 +63,19 @@ public class JdbcSinkConfigTest {
   public void shouldCreateConfigWithMinimalConfigs() {
     createConfig();
     assertTableTypes(TableType.TABLE);
+  }
+
+  @Test
+  public void shouldDisableSensitiveLogTrimmingByDefault() {
+    createConfig();
+    assertFalse(config.trimSensitiveLogsEnabled);
+  }
+
+  @Test
+  public void shouldEnableSensitiveLogTrimming() {
+    props.put(JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED, "true");
+    createConfig();
+    assertTrue(config.trimSensitiveLogsEnabled);
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -274,6 +275,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     replayAll();
 
     Map<String, String> props = setupBasicProps(maxRetries, retryBackoffMs);
+    props.put(JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED, "true");
     task.start(props);
 
     RetriableException firstRetry =
@@ -325,6 +327,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     replayAll();
 
     Map<String, String> props = setupBasicProps(0, 0);
+    props.put(JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED, "true");
     task.start(props);
     captureTaskLogs();
     task.put(records);
@@ -372,6 +375,46 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     Map<String, String> props = setupBasicProps(0, 0);
     task.start(props);
     task.put(records);
+    verifyAll();
+  }
+
+  @Test
+  public void putKeepsRawSqlExceptionWhenSensitiveLogTrimmingDisabled()
+      throws SQLException {
+    List<SinkRecord> records = createRecordsList(1);
+    SQLException exception = new SQLException(
+        "Duplicate entry '" + MYSQL_CANARY + "' for key 'email'",
+        "23000",
+        1062
+    );
+
+    mockWriter.write(records);
+    expectLastCall().andThrow(exception);
+
+    JdbcSinkTask task = new JdbcSinkTask() {
+      @Override
+      void initWriter() {
+        this.writer = mockWriter;
+      }
+    };
+    task.initialize(ctx);
+    expect(ctx.errantRecordReporter()).andReturn(null);
+    replayAll();
+
+    Map<String, String> props = setupBasicProps(0, 0);
+    task.start(props);
+    captureTaskLogs();
+    ConnectException thrown =
+        assertThrows(ConnectException.class, () -> task.put(records));
+
+    assertTrue(thrown.getCause() instanceof SQLException);
+    SQLException allMessagesException = (SQLException) thrown.getCause();
+    assertTrue(allMessagesException.getMessage().contains(MYSQL_CANARY));
+    assertFalse(allMessagesException.getMessage().contains(REDACTED));
+    assertSame(exception, allMessagesException.getNextException());
+    String logs = capturedTaskLogs();
+    assertTrue(logs.contains(MYSQL_CANARY));
+    assertFalse(logs.contains(REDACTED));
     verifyAll();
   }
 
@@ -510,6 +553,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     replayAll();
 
     Map<String, String> props = setupBasicProps(0, 0);
+    props.put(JdbcSinkConfig.TRIM_SENSITIVE_LOG_ENABLED, "true");
     task.start(props);
     captureTaskLogs();
     ConnectException thrown =

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -561,7 +561,7 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
     assertEquals(sqlState, redactedException.getSQLState());
     assertEquals(errorCode, redactedException.getErrorCode());
     for (Throwable current : redactedException) {
-      assertEquals(REDACTED, current.getMessage());
+      assertTrue(current.getMessage().startsWith(REDACTED));
       assertFalse(current.getMessage().contains(sensitiveValue));
     }
     return redactedException;

--- a/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
@@ -20,8 +20,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.postgresql.util.PSQLException;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.sql.BatchUpdateException;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import static org.junit.Assert.assertEquals;
 
@@ -157,34 +160,133 @@ public class LogUtilTest {
     SQLException e2 = new SQLException("sensitive-message-e2", "42001", 20);
     e1.setNextException(e2);
 
-    SQLException expected = new SQLException(REDACTED, "42000", 10);
-    SQLException expectedChild = new SQLException(REDACTED, "42001", 20);
-    expected.setNextException(expectedChild);
-
     SQLException redacted = LogUtil.redactSensitiveData(e1);
+    assertRedactedMetadata(redacted, SQLException.class, "42000", 10);
 
-    assertEqualsSQLException(expected, redacted);
+    SQLException redactedChild = redacted.getNextException();
+    Assert.assertNotNull(redactedChild);
+    assertRedactedMetadata(redactedChild, SQLException.class, "42001", 20);
+    Assert.assertNull(redactedChild.getNextException());
+    Assert.assertArrayEquals(e1.getStackTrace(), redacted.getStackTrace());
+    Assert.assertArrayEquals(e2.getStackTrace(), redactedChild.getStackTrace());
   }
 
   @Test
   public void testRedactSensitiveDataWithBatchUpdateException() {
+    int[] updateCounts = {1, Statement.EXECUTE_FAILED, 1};
     BatchUpdateException e1 =
-        new BatchUpdateException("sensitive message-e1", "42002", 30, new int[0]);
+        new BatchUpdateException("sensitive message-e1", "42002", 30, updateCounts);
 
     SQLException e2 = new SQLException("sensitive message-e2", "42003", 40);
     e1.setNextException(e2);
 
-    BatchUpdateException expected =
-        new BatchUpdateException(REDACTED, "42002", 30, new int[0]);
-    SQLException expectedChild = new SQLException(REDACTED, "42003", 40);
-    expected.setNextException(expectedChild);
-
     SQLException actual = LogUtil.redactSensitiveData(e1);
     Assert.assertTrue(actual instanceof BatchUpdateException);
-    Assert.assertArrayEquals(
-        expected.getUpdateCounts(), ((BatchUpdateException) actual).getUpdateCounts());
+    assertRedactedMetadata(actual, BatchUpdateException.class, "42002", 30);
+    Assert.assertTrue(actual.getMessage().contains("batchSize=3"));
+    Assert.assertTrue(actual.getMessage().contains("firstFailedIndex=1"));
+    Assert.assertArrayEquals(updateCounts, ((BatchUpdateException) actual).getUpdateCounts());
 
-    assertEqualsSQLException(expected, actual);
+    SQLException redactedChild = actual.getNextException();
+    Assert.assertNotNull(redactedChild);
+    assertRedactedMetadata(redactedChild, SQLException.class, "42003", 40);
+    Assert.assertNull(redactedChild.getNextException());
+  }
+
+  @Test
+  public void testRedactSensitiveDataDoesNotLeakOriginalMessages() {
+    String canary = "LEAK_CANARY_PII_9000";
+    String rowValue = "customer@example.com";
+    String valuesClause = "VALUES ('" + rowValue + "', '123-45-6789')";
+    String plainMessage = "Driver rejected " + canary + " " + valuesClause;
+    SQLException plain = new SQLException(plainMessage, "23505", 7);
+
+    SQLException redactedPlain = LogUtil.redactSensitiveData(plain);
+    assertRedactedChainDoesNotContain(
+        redactedPlain, plainMessage, canary, valuesClause, rowValue, "123-45-6789");
+
+    String batchMessage = "Batch failed " + canary + " " + valuesClause;
+    String childMessage = "Child failed " + canary + " " + valuesClause;
+    BatchUpdateException batch = new BatchUpdateException(
+        batchMessage,
+        "23505",
+        8,
+        new int[] {1, Statement.EXECUTE_FAILED}
+    );
+    batch.setNextException(new SQLException(childMessage, "22001", 9));
+
+    SQLException redactedBatch = LogUtil.redactSensitiveData(batch);
+    assertRedactedChainDoesNotContain(
+        redactedBatch,
+        batchMessage,
+        childMessage,
+        canary,
+        valuesClause,
+        rowValue,
+        "123-45-6789"
+    );
+  }
+
+  @Test
+  public void testRedactSensitiveDataIncludesDiagnosticMetadata() {
+    SQLException original =
+        new DiagnosticSQLException("sensitive driver message", "22001", 1234);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    assertRedactedMetadata(redacted, DiagnosticSQLException.class, "22001", 1234);
+  }
+
+  @Test
+  public void testRedactSensitiveDataIncludesBatchSummary() {
+    int[] updateCounts = {1, Statement.EXECUTE_FAILED, 1};
+    BatchUpdateException original =
+        new BatchUpdateException("sensitive batch message", "23505", 17, updateCounts);
+
+    BatchUpdateException redacted =
+        (BatchUpdateException) LogUtil.redactSensitiveData(original);
+
+    Assert.assertTrue(redacted.getMessage().contains("batchSize=3"));
+    Assert.assertTrue(redacted.getMessage().contains("firstFailedIndex=1"));
+    Assert.assertArrayEquals(updateCounts, redacted.getUpdateCounts());
+  }
+
+  @Test
+  public void testRedactSensitiveDataIsIdempotent() {
+    SQLException original =
+        new DiagnosticSQLException("sensitive driver message", "22001", 1234);
+
+    SQLException redactedOnce = LogUtil.redactSensitiveData(original);
+    SQLException redactedTwice = LogUtil.redactSensitiveData(redactedOnce);
+
+    assertEquals(redactedOnce.getMessage(), redactedTwice.getMessage());
+    Assert.assertTrue(
+        redactedTwice.getMessage().contains("class=" + DiagnosticSQLException.class.getName()));
+    Assert.assertFalse(
+        redactedTwice.getMessage().substring(REDACTED.length()).contains(REDACTED));
+  }
+
+  @Test
+  public void testRedactSensitiveDataPreservesExceptionChain() {
+    SQLException first = new SQLException("first sensitive message", "42000", 10);
+    BatchUpdateException second = new BatchUpdateException(
+        "second sensitive message",
+        "42001",
+        20,
+        new int[] {Statement.EXECUTE_FAILED}
+    );
+    SQLException third = new SQLException("third sensitive message", "42002", 30);
+    first.setNextException(second);
+    second.setNextException(third);
+
+    SQLException redacted = LogUtil.redactSensitiveData(first);
+
+    Assert.assertEquals(3, exceptionChainDepth(redacted));
+    assertRedactedMetadata(redacted, SQLException.class, "42000", 10);
+    assertRedactedMetadata(
+        redacted.getNextException(), BatchUpdateException.class, "42001", 20);
+    assertRedactedMetadata(
+        redacted.getNextException().getNextException(), SQLException.class, "42002", 30);
   }
 
   @Test
@@ -340,6 +442,55 @@ public class LogUtilTest {
     Assert.assertFalse("VALUES clause leaked: " + msg, msg.contains("VALUES"));
   }
 
+  private static void assertRedactedMetadata(
+      SQLException redacted,
+      Class<? extends SQLException> originalClass,
+      String sqlState,
+      int errorCode
+  ) {
+    String message = redacted.getMessage();
+    Assert.assertTrue(message, message.startsWith(REDACTED));
+    Assert.assertTrue(message, message.contains("class=" + originalClass.getName()));
+    Assert.assertTrue(message, message.contains("SQLState=" + sqlState));
+    Assert.assertTrue(message, message.contains("errorCode=" + errorCode));
+    Assert.assertEquals(sqlState, redacted.getSQLState());
+    Assert.assertEquals(errorCode, redacted.getErrorCode());
+  }
+
+  private static void assertRedactedChainDoesNotContain(
+      SQLException redacted,
+      String... sensitiveValues
+  ) {
+    StringWriter stackTrace = new StringWriter();
+    PrintWriter stackTraceWriter = new PrintWriter(stackTrace);
+    for (SQLException current = redacted; current != null; current = current.getNextException()) {
+      String message = current.getMessage();
+      Assert.assertTrue(message, message.startsWith(REDACTED));
+      for (String sensitiveValue : sensitiveValues) {
+        Assert.assertFalse(
+            "Sensitive data leaked from redacted message: " + message,
+            message.contains(sensitiveValue)
+        );
+      }
+      current.printStackTrace(stackTraceWriter);
+    }
+    stackTraceWriter.flush();
+    for (String sensitiveValue : sensitiveValues) {
+      Assert.assertFalse(
+          "Sensitive data leaked from redacted stack trace: " + stackTrace,
+          stackTrace.toString().contains(sensitiveValue)
+      );
+    }
+  }
+
+  private static int exceptionChainDepth(SQLException exception) {
+    int depth = 0;
+    for (SQLException current = exception; current != null; current = current.getNextException()) {
+      depth++;
+    }
+    return depth;
+  }
+
   private static void assertEqualsSQLException(SQLException expected, SQLException actual) {
     if (expected == actual) {
       return;
@@ -356,5 +507,13 @@ public class LogUtilTest {
     Assert.assertEquals(msg1, msg2);
 
     assertEqualsSQLException(expected.getNextException(), actual.getNextException());
+  }
+
+  private static class DiagnosticSQLException extends SQLException {
+    private static final long serialVersionUID = 1L;
+
+    DiagnosticSQLException(String reason, String sqlState, int vendorCode) {
+      super(reason, sqlState, vendorCode);
+    }
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/LogUtilTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 public class LogUtilTest {
   private static final String REDACTED = "<redacted>";
+  private static final String LEAK = "LEAK_CANARY_PII_9000";
 
   @Test
   public void testNonSqlThrowable() {
@@ -183,8 +184,8 @@ public class LogUtilTest {
     SQLException actual = LogUtil.redactSensitiveData(e1);
     Assert.assertTrue(actual instanceof BatchUpdateException);
     assertRedactedMetadata(actual, BatchUpdateException.class, "42002", 30);
-    Assert.assertTrue(actual.getMessage().contains("batchSize=3"));
-    Assert.assertTrue(actual.getMessage().contains("firstFailedIndex=1"));
+    Assert.assertTrue(actual.getMessage().contains("updateCountLength=3"));
+    Assert.assertTrue(actual.getMessage().contains("firstExecuteFailedIndex=1"));
     Assert.assertArrayEquals(updateCounts, ((BatchUpdateException) actual).getUpdateCounts());
 
     SQLException redactedChild = actual.getNextException();
@@ -195,18 +196,17 @@ public class LogUtilTest {
 
   @Test
   public void testRedactSensitiveDataDoesNotLeakOriginalMessages() {
-    String canary = "LEAK_CANARY_PII_9000";
     String rowValue = "customer@example.com";
     String valuesClause = "VALUES ('" + rowValue + "', '123-45-6789')";
-    String plainMessage = "Driver rejected " + canary + " " + valuesClause;
+    String plainMessage = "Driver rejected " + LEAK + " " + valuesClause;
     SQLException plain = new SQLException(plainMessage, "23505", 7);
 
     SQLException redactedPlain = LogUtil.redactSensitiveData(plain);
     assertRedactedChainDoesNotContain(
-        redactedPlain, plainMessage, canary, valuesClause, rowValue, "123-45-6789");
+        redactedPlain, plainMessage, LEAK, valuesClause, rowValue, "123-45-6789");
 
-    String batchMessage = "Batch failed " + canary + " " + valuesClause;
-    String childMessage = "Child failed " + canary + " " + valuesClause;
+    String batchMessage = "Batch failed " + LEAK + " " + valuesClause;
+    String childMessage = "Child failed " + LEAK + " " + valuesClause;
     BatchUpdateException batch = new BatchUpdateException(
         batchMessage,
         "23505",
@@ -220,11 +220,157 @@ public class LogUtilTest {
         redactedBatch,
         batchMessage,
         childMessage,
-        canary,
+        LEAK,
         valuesClause,
         rowValue,
         "123-45-6789"
     );
+  }
+
+  @Test
+  public void testRedactSensitiveDataDoesNotTrustRawRedactedPrefix() {
+    SQLException original =
+        new SQLException(REDACTED + " customer=" + LEAK, "23505", 0);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    String message = redacted.getMessage();
+    Assert.assertFalse(message, message.contains(LEAK));
+    Assert.assertTrue(message, message.startsWith(REDACTED + " ["));
+    Assert.assertTrue(message, message.contains("SQLState=23505"));
+  }
+
+  @Test
+  public void testRedactSensitiveDataDoesNotTrustRawRedactedPrefixInChain() {
+    SQLException original = new SQLException("top", "42000", 1);
+    original.setNextException(
+        new SQLException(REDACTED + " " + LEAK, "23505", 2));
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    SQLException redactedChild = redacted.getNextException();
+    Assert.assertNotNull(redactedChild);
+    Assert.assertFalse(
+        redactedChild.getMessage(), redactedChild.getMessage().contains(LEAK));
+
+    StringWriter stackTrace = new StringWriter();
+    PrintWriter stackTraceWriter = new PrintWriter(stackTrace);
+    redacted.printStackTrace(stackTraceWriter);
+    stackTraceWriter.flush();
+    Assert.assertFalse(stackTrace.toString(), stackTrace.toString().contains(LEAK));
+  }
+
+  @Test
+  public void testRedactSensitiveDataRejectsMalformedSqlStateInMessage() {
+    SQLException original = new SQLException("raw " + LEAK, LEAK, 0);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    String message = redacted.getMessage();
+    Assert.assertTrue(message, message.contains("SQLState=<invalid>"));
+    Assert.assertFalse(message, message.contains(LEAK));
+  }
+
+  @Test
+  public void testRedactSensitiveDataWithNullMessage() {
+    SQLException original = new SQLException((String) null, "23505", 0);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    Assert.assertTrue(
+        redacted.getMessage(), redacted.getMessage().startsWith(REDACTED + " ["));
+  }
+
+  @Test
+  public void testRedactSensitiveDataWithNullSqlState() {
+    SQLException original = new SQLException("raw", null, 0);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    Assert.assertTrue(
+        redacted.getMessage(), redacted.getMessage().contains("SQLState=null"));
+  }
+
+  @Test
+  public void testRedactSensitiveDataWithEmptyUpdateCounts() {
+    BatchUpdateException original =
+        new BatchUpdateException("raw", "23505", 0, new int[0]);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    Assert.assertTrue(
+        redacted.getMessage(),
+        redacted.getMessage()
+            .contains("updateCountLength=0; firstExecuteFailedIndex=-1")
+    );
+  }
+
+  @Test
+  public void testRedactSensitiveDataWithStopOnFailureUpdateCounts() {
+    BatchUpdateException original =
+        new BatchUpdateException("raw", "23505", 0, new int[] {1, 1});
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    Assert.assertTrue(
+        redacted.getMessage(),
+        redacted.getMessage()
+            .contains("updateCountLength=2; firstExecuteFailedIndex=-1")
+    );
+  }
+
+  @Test
+  public void testRedactSensitiveDataNonBatchMessageGrammar() {
+    SQLException original = new SQLException("raw", "23505", 7);
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    Assert.assertEquals(
+        "<redacted> [class=java.sql.SQLException; SQLState=23505; errorCode=7]",
+        redacted.getMessage()
+    );
+  }
+
+  @Test
+  public void testRedactSensitiveDataBatchMessageGrammar() {
+    BatchUpdateException original =
+        new BatchUpdateException(
+            "raw",
+            "23505",
+            7,
+            new int[] {1, Statement.EXECUTE_FAILED, 1}
+        );
+
+    SQLException redacted = LogUtil.redactSensitiveData(original);
+
+    Assert.assertEquals(
+        "<redacted> [class=java.sql.BatchUpdateException; SQLState=23505; errorCode=7; "
+            + "updateCountLength=3; firstExecuteFailedIndex=1]",
+        redacted.getMessage()
+    );
+  }
+
+  @Test
+  public void testRedactSensitiveDataIdentityIdempotencyForChain() {
+    SQLException original = new SQLException("root raw", "42000", 1);
+    original.setNextException(
+        new BatchUpdateException(
+            "child raw",
+            "23505",
+            2,
+            new int[] {Statement.EXECUTE_FAILED}
+        )
+    );
+
+    SQLException redactedOnce = LogUtil.redactSensitiveData(original);
+    SQLException redactedChildOnce = redactedOnce.getNextException();
+    SQLException redactedTwice = LogUtil.redactSensitiveData(redactedOnce);
+    SQLException redactedChildTwice = LogUtil.redactSensitiveData(redactedChildOnce);
+
+    Assert.assertSame(redactedOnce, redactedTwice);
+    Assert.assertSame(redactedChildOnce, redactedChildTwice);
+    assertEquals(redactedOnce.getMessage(), redactedTwice.getMessage());
+    assertEquals(redactedChildOnce.getMessage(), redactedTwice.getNextException().getMessage());
   }
 
   @Test
@@ -246,8 +392,8 @@ public class LogUtilTest {
     BatchUpdateException redacted =
         (BatchUpdateException) LogUtil.redactSensitiveData(original);
 
-    Assert.assertTrue(redacted.getMessage().contains("batchSize=3"));
-    Assert.assertTrue(redacted.getMessage().contains("firstFailedIndex=1"));
+    Assert.assertTrue(redacted.getMessage().contains("updateCountLength=3"));
+    Assert.assertTrue(redacted.getMessage().contains("firstExecuteFailedIndex=1"));
     Assert.assertArrayEquals(updateCounts, redacted.getUpdateCounts());
   }
 


### PR DESCRIPTION
# TL;DR
```java
StringBuilder sb = new StringBuilder(REDACTED_VALUE)
        .append(" [class=").append(e.getClass().getName())
        .append("; SQLState=").append(safeSqlState(e.getSQLState()))
        .append("; errorCode=").append(e.getErrorCode());
```
# What

`LogUtil.redactSensitiveData` now appends appends non-sensitive diagnostic metadata to the `<redacted>` exception.:

`<redacted> [class=<origClass>; SQLState=<state>; errorCode=<code>]`

For a `BatchUpdateException`, the message also includes `updateCountLength` and `firstExecuteFailedIndex`.

The method uses private exception subclasses to mark exceptions that it has already redacted.
If the writer and task both pass the same exception through the redactor, the second call recognizes the marked exception and returns it unchanged.

Before including SQLState in the message, the method verifies that it is either null or a five-character alphanumeric code.
Any other value is rendered as `<invalid>`, which prevents arbitrary driver-provided text from entering the redacted output.

The output never includes the original driver message text or any row values.

It is gated behind the existing `trim.sensitive.log` connector config.

The config remains a boolean with its existing default of `false`.

| `trim.sensitive.log` | Behavior |
| --- | --- |
| `false` or omitted | Preserve the original `SQLException`, including its raw driver message, in normal sink failure logging and propagated exception chains. |
| `true` | Replace driver messages with `<redacted>` plus non-sensitive diagnostics such as `class=`, validated `SQLState=`, `errorCode=`, and batch execution metadata. |

## Before
<img width="1020" height="373" alt="image" src="https://github.com/user-attachments/assets/361a9c01-2c62-4809-9601-0a4c2b4aed96" />


## After
<img width="1395" height="374" alt="image" src="https://github.com/user-attachments/assets/67e516c9-cc89-4416-849f-a41bdac4b756" />


# Why it is safe

- The redacted output never includes the original driver message text or any row values; only the exception class name, a validated SQLState, the errorCode, and batch counts, none of which carry customer data.
- Identity-based idempotency (marker subtypes) closes the raw-`<redacted>`-prefix bypass; SQLState is rendered only when null or a 5-char code, else `<invalid>`.
- The enriched output was validated end-to-end on Confluent Cloud devel (fresh PCC, MySQL + Postgres): redaction holds on pod/OpenSearch/DLQ headers with the enriched tokens present, and the `Sensitive` TRACE hatch still works.