### PR TITLE
Preserve RecordQueue MDC context compatibility

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/RecordQueue.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/RecordQueue.java
@@ -9,6 +9,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -29,8 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
-
-import org.slf4j.MDC;
 
 /**
  * A concurrent and blocking queue for source records, with the ability to asynchronously execute
@@ -328,10 +327,12 @@ public class RecordQueue<RecordT extends SourceRecord> implements RecordDestinat
         operationName,
         logContext,
         cancellableDestination,
-        generatorProcessor,
-        callerMdc
+        generatorProcessor
     );
-    return CompletableFuture.supplyAsync(supplier, executor);
+    return CompletableFuture.supplyAsync(
+        withMdcContext(supplier, callerMdc),
+        executor
+    );
   }
 
   @Override
@@ -471,13 +472,9 @@ public class RecordQueue<RecordT extends SourceRecord> implements RecordDestinat
       String operationName,
       String logContext,
       RecordDestination<RecordT> destination,
-      Function<RecordDestination<RecordT>, T> generatorProcessor,
-      Map<String, String> callerMdc
+      Function<RecordDestination<RecordT>, T> generatorProcessor
   ) {
     return () -> {
-      if (callerMdc != null) {
-        MDC.setContextMap(callerMdc);
-      }
       try (ConnectLogContext context = new ConnectLogContext(logContext)) {
         try {
           log.debug("{}Starting {}", context.prefix(), operationName);
@@ -489,8 +486,29 @@ public class RecordQueue<RecordT extends SourceRecord> implements RecordDestinat
         } finally {
           log.debug("{}Stopped {}", context.prefix(), operationName);
         }
+      }
+    };
+  }
+
+  private <T> Supplier<T> withMdcContext(
+      Supplier<T> supplier,
+      Map<String, String> callerMdc
+  ) {
+    return () -> {
+      Map<String, String> previousMdc = MDC.getCopyOfContextMap();
+      try {
+        if (callerMdc != null) {
+          MDC.setContextMap(callerMdc);
+        } else {
+          MDC.clear();
+        }
+        return supplier.get();
       } finally {
-        MDC.clear();
+        if (previousMdc != null) {
+          MDC.setContextMap(previousMdc);
+        } else {
+          MDC.clear();
+        }
       }
     };
   }

--- a/src/test/java/io/confluent/connect/jdbc/util/RecordQueueMdcTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/RecordQueueMdcTest.java
@@ -11,25 +11,38 @@ import org.junit.Test;
 import org.slf4j.MDC;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class RecordQueueMdcTest {
 
   private static final String CONNECTOR_MDC_CONTEXT = "connector.context";
+  private static final String TRACE_MDC_CONTEXT = "trace.id";
+  private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
 
   private RecordQueue<SourceRecord> queue;
 
   @Before
   public void setUp() {
-    queue = RecordQueue.<SourceRecord>builder()
-        .maxBatchSize(10)
+    queue = queueBuilder()
         .maxExecutorThreads(1)
         .build();
   }
@@ -37,9 +50,24 @@ public class RecordQueueMdcTest {
   @After
   public void tearDown() throws InterruptedException {
     MDC.clear();
+    stopQueue();
+  }
+
+  private RecordQueue.Builder<SourceRecord> queueBuilder() {
+    return RecordQueue.<SourceRecord>builder()
+        .maxBatchSize(10);
+  }
+
+  private void replaceQueue(RecordQueue<SourceRecord> replacement) throws InterruptedException {
+    stopQueue();
+    queue = replacement;
+  }
+
+  private void stopQueue() throws InterruptedException {
     if (queue != null) {
       queue.stop();
-      queue.awaitTermination(Duration.ofSeconds(5));
+      queue.awaitTermination(TERMINATION_TIMEOUT);
+      queue = null;
     }
   }
 
@@ -124,5 +152,164 @@ public class RecordQueueMdcTest {
 
     // Without MDC, ConnectLogContext falls back to prefix mode — no MDC set
     assertNull(capturedMdc.get());
+  }
+
+  @Test
+  public void shouldInvokeProtectedCreateLoggingSupplierOverride() throws Exception {
+    TrackingRecordQueue trackingQueue = new TrackingRecordQueue(
+        queueBuilder().maxExecutorThreads(1)
+    );
+    replaceQueue(trackingQueue);
+
+    assertTrue(queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> true
+    ).get(10, TimeUnit.SECONDS));
+
+    assertTrue(trackingQueue.loggingSupplierCreated());
+  }
+
+  @Test
+  public void shouldRestoreCallerMdcWithDirectExecutor() throws Exception {
+    replaceQueue(
+        queueBuilder()
+            .executorFactory(DirectExecutorService::new)
+            .build()
+    );
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+    MDC.put(TRACE_MDC_CONTEXT, "caller-trace");
+    Map<String, String> callerMdc = MDC.getCopyOfContextMap();
+
+    assertTrue(queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> true
+    ).get(10, TimeUnit.SECONDS));
+
+    assertEquals(callerMdc, MDC.getCopyOfContextMap());
+  }
+
+  @Test
+  public void shouldRestorePreExistingExecutorMdc() throws Exception {
+    ExecutorService executor = useExecutorWithMdc(TRACE_MDC_CONTEXT, "worker-trace");
+    AtomicReference<String> capturedMdc = new AtomicReference<>();
+
+    assertTrue(queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> {
+          capturedMdc.set(MDC.get(TRACE_MDC_CONTEXT));
+          return true;
+        }
+    ).get(10, TimeUnit.SECONDS));
+
+    assertNull(capturedMdc.get());
+    assertEquals(
+        "worker-trace",
+        executor.submit(() -> MDC.get(TRACE_MDC_CONTEXT)).get(10, TimeUnit.SECONDS)
+    );
+  }
+
+  @Test
+  public void shouldRestorePreExistingExecutorMdcAfterFailure() throws Exception {
+    ExecutorService executor = useExecutorWithMdc(TRACE_MDC_CONTEXT, "worker-trace");
+    MDC.put(CONNECTOR_MDC_CONTEXT, "[my-connector|task-0] ");
+
+    CompletableFuture<Boolean> future = queue.submit(
+        "Test Operation",
+        "testProcessor",
+        destination -> {
+          throw new IllegalStateException("test failure");
+        }
+    );
+
+    assertThrows(
+        ExecutionException.class,
+        () -> future.get(10, TimeUnit.SECONDS)
+    );
+    assertEquals(
+        "worker-trace",
+        executor.submit(() -> MDC.get(TRACE_MDC_CONTEXT)).get(10, TimeUnit.SECONDS)
+    );
+  }
+
+  private ExecutorService useExecutorWithMdc(String key, String value) throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.submit(() -> MDC.put(key, value)).get(10, TimeUnit.SECONDS);
+    replaceQueue(
+        queueBuilder()
+            .executorFactory(() -> executor)
+            .build()
+    );
+    return executor;
+  }
+
+  private static class TrackingRecordQueue extends RecordQueue<SourceRecord> {
+
+    private final AtomicBoolean loggingSupplierCreated = new AtomicBoolean();
+
+    private TrackingRecordQueue(RecordQueue.Builder<SourceRecord> builder) {
+      super(builder);
+    }
+
+    @Override
+    protected <T> Supplier<T> createLoggingSupplier(
+        String operationName,
+        String logContext,
+        RecordDestination<SourceRecord> destination,
+        Function<RecordDestination<SourceRecord>, T> generatorProcessor
+    ) {
+      loggingSupplierCreated.set(true);
+      return super.createLoggingSupplier(
+          operationName,
+          logContext,
+          destination,
+          generatorProcessor
+      );
+    }
+
+    private boolean loggingSupplierCreated() {
+      return loggingSupplierCreated.get();
+    }
+  }
+
+  private static class DirectExecutorService extends AbstractExecutorService {
+
+    private final AtomicBoolean shutdown = new AtomicBoolean();
+
+    @Override
+    public void shutdown() {
+      shutdown.set(true);
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown.set(true);
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return shutdown.get();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return shutdown.get();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return isTerminated();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      if (isShutdown()) {
+        throw new RejectedExecutionException();
+      }
+      command.run();
+    }
   }
 }


### PR DESCRIPTION
Updates PR #1613 to address review findings:

- preserve the existing protected `createLoggingSupplier(...)` extension point
- propagate caller MDC without clearing pre-existing executor-thread context
- restore MDC on success and failure
- add regression coverage for subclass overrides, direct executors, and shared executors