### PR TITLE
fix: append suffix during query validation

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
+++ b/src/main/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidation.java
@@ -412,6 +412,13 @@ public class JdbcSourceConnectorValidation extends AbstractJdbcConnectorValidati
     }
 
     String query = queryVal.get();
+    String suffix = config.getString(JdbcSourceConnectorConfig.QUERY_SUFFIX_CONFIG).trim();
+
+    if (!suffix.isEmpty()) {
+      // Append suffix so potential opening parentheses will be closed
+      query = query + " " + suffix;
+    }
+
     String configKey = config.isQueryMasked()
         ? JdbcSourceConnectorConfig.QUERY_MASKED_CONFIG
         : JdbcSourceConnectorConfig.QUERY_CONFIG;

--- a/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/validation/JdbcSourceConnectorValidationTest.java
@@ -1233,6 +1233,30 @@ public class JdbcSourceConnectorValidationTest {
   }
 
   @Test
+  public void validate_withQueryAndQuerySuffixCompletingParenthesis_noErrors()
+    throws Exception {
+    String query = "SELECT * FROM (SELECT id FROM sample_data";
+    String suffix = ") sub";
+    String expectedValidatedQuery = query + " " + suffix;
+
+    props.put(MODE_CONFIG, MODE_BULK);
+    props.put(QUERY_CONFIG, query);
+    props.put(QUERY_SUFFIX_CONFIG, suffix);
+
+    DatabaseDialect mockDialect = EasyMock.createNiceMock(DatabaseDialect.class);
+    Connection mockConnection = EasyMock.createNiceMock(Connection.class);
+    EasyMock.expect(mockDialect.getConnection()).andReturn(mockConnection);
+    mockDialect.validateQuery(mockConnection, expectedValidatedQuery);
+    EasyMock.expectLastCall();
+    EasyMock.replay(mockDialect, mockConnection);
+
+    validateWithMockDialect(mockDialect);
+
+    assertNoErrors();
+    EasyMock.verify(mockDialect, mockConnection);
+  }
+
+  @Test
   public void validate_withNoQuery_skipsSemanticValidation() throws Exception {
     props.put(MODE_CONFIG, MODE_BULK);
     props.put(TABLE_WHITELIST_CONFIG, "table1,table2");


### PR DESCRIPTION
## Problem
Connector configurations containing opening parentheses in the `query` and closing parentheses in the `query.suffix` fail to validate, even though the resulting query would be valid sql. Connectors before #1616 will load (no validation yet), Connectors with the same config will not load after #1616.
```yaml
query: "SELECT * FROM (SELECT id FROM sample_data" # invalid indeed
query.suffix: ") sub" # contains closing parenthesis, so valid
```

## Solution
Add suffix to the to be validated query in `validateQuerySemantics()` if `query.suffix` is set

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Added `validate_withQueryAndQuerySuffixCompletingParenthesis_noErrors` unit test

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
