### PR TITLE
Write PostgreSQL hstore columns from Connect maps, including off-search_path extensions

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -85,6 +85,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * The type name to write hstore columns with, resolved once per connection: {@code hstore} when
    * the extension is on the search_path, {@code "schema".hstore} when it is installed elsewhere,
    * and null when it is not installed at all. Visible for testing.
+   *
+   * <p>{@link #hstoreTypeResolved} is written last, inside the {@code synchronized} block in
+   * {@link #getConnection()}. Both are volatile, so a reader that sees it {@code true} is
+   * guaranteed to see the name written before it, and needs no lock of its own.
    */
   volatile String hstoreTypeName;
   volatile boolean hstoreTypeResolved;
@@ -210,9 +214,18 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (maxIdentifierLength <= 0) {
         maxIdentifierLength = computeMaxIdentifierLength(result);
       }
-      if (!hstoreTypeResolved && complexTypesEnabled()) {
-        hstoreTypeName = resolveHstoreTypeName(result);
-        hstoreTypeResolved = true;
+      // Only the sink writes hstore columns, so a source task never pays for the lookup.
+      if (!hstoreTypeResolved && complexTypesEnabled() && config instanceof JdbcSinkConfig) {
+        try {
+          hstoreTypeName = resolveHstoreTypeName(result);
+          // Written last: see the ordering note on hstoreTypeResolved.
+          hstoreTypeResolved = true;
+        } catch (SQLException e) {
+          // Leave it unresolved rather than report the extension as missing, which would name the
+          // wrong cause. A write then assumes the bare type name and lets PostgreSQL say why.
+          log.warn("Unable to determine where the hstore extension is installed; hstore columns "
+              + "will be written as the unqualified type", e);
+        }
       }
     }
     return result;
@@ -221,9 +234,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   /**
    * Locate the hstore extension: the bare name when {@code search_path} resolves it, otherwise the
    * schema it was installed into, so {@code CREATE EXTENSION hstore SCHEMA ext} is usable without
-   * changing the connection's search_path. Returns null when the extension is not installed.
+   * changing the connection's search_path. Returns null when the extension is not installed, and
+   * throws when the catalog cannot be read — the two are distinct and must not be conflated.
    */
-  static String resolveHstoreTypeName(Connection connection) {
+  static String resolveHstoreTypeName(Connection connection) throws SQLException {
     try (Statement stmt = connection.createStatement()) {
       try (ResultSet rs = stmt.executeQuery("SELECT to_regtype('hstore') IS NOT NULL")) {
         if (rs.next() && rs.getBoolean(1)) {
@@ -233,20 +247,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       try (ResultSet rs = stmt.executeQuery(
           "SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace"
               + " WHERE e.extname = 'hstore'")) {
-        if (rs.next()) {
-          return "\"" + rs.getString(1) + "\"." + HSTORE_TYPE_NAME;
-        }
+        return rs.next() ? "\"" + rs.getString(1) + "\"." + HSTORE_TYPE_NAME : null;
       }
-    } catch (SQLException e) {
-      log.warn("Unable to determine whether the hstore extension is installed", e);
     }
-    return null;
   }
 
   /**
-   * The type name for an hstore column, or a failure naming the field when the extension is not
-   * installed. Before any connection exists — unit tests, and validation before the first write —
-   * the bare name is assumed, since there is nothing yet to check it against.
+   * The type name for an hstore column, or a failure naming the field when the extension is known
+   * to be absent. Where it is merely unresolved — before any connection exists, or after a catalog
+   * read failed — the bare name is assumed, since there is nothing to contradict it.
    */
   private String hstoreTypeName(String fieldName) {
     if (hstoreTypeResolved && hstoreTypeName == null) {
@@ -1158,7 +1167,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   ) throws SQLException {
     switch (schema.type()) {
       case ARRAY:
-        if (bindArray(statement, index, schema, value)) {
+        if (bindArray(statement, index, schema, value, fieldName)) {
           return true;
         }
         break;
@@ -1176,16 +1185,21 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   /**
    * Bind a Connect ARRAY value to a native PostgreSQL array parameter. When complex types are
    * enabled, element types with a dedicated PostgreSQL array type (json, numeric and the
-   * temporals) are resolved by {@link #arrayElementBinding(Schema)} and bound via
+   * temporals) are resolved by {@link #arrayElementBinding(Schema, String)} and bound via
    * {@code createArrayOf}; any other (primitive) element type falls back to the pre-existing
    * {@link #maybeBindPrimitiveArray}. Returns false if the element type is not handled here.
    */
-  private boolean bindArray(PreparedStatement statement, int index, Schema schema, Object value)
-      throws SQLException {
+  private boolean bindArray(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value,
+      String fieldName
+  ) throws SQLException {
     Collection<?> values = arrayValueCollection(value);
     Schema elementSchema = schema.valueSchema();
     ArrayElementBinding binding =
-        complexTypesEnabled() ? arrayElementBinding(elementSchema) : null;
+        complexTypesEnabled() ? arrayElementBinding(elementSchema, fieldName) : null;
     if (binding == null) {
       return maybeBindPrimitiveArray(statement, index, elementSchema, values);
     }
@@ -1224,15 +1238,16 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * Resolve the native array binding for a Connect element schema, or null if the element has no
    * dedicated PostgreSQL array type (a primitive, handled by {@link #maybeBindPrimitiveArray}).
    * Only the hstore-shaped {@code MAP<STRING, STRING>} and the logical types below are mapped.
+   * The field name is carried only so a missing hstore extension can name the column it fails on.
    */
-  private ArrayElementBinding arrayElementBinding(Schema elementSchema) {
+  private ArrayElementBinding arrayElementBinding(Schema elementSchema, String fieldName) {
     if (elementSchema == null) {
       return null;
     }
     if (isStringToStringMap(elementSchema)) {
       // Each element serialized to hstore text -> hstore[].
       return new ArrayElementBinding(
-          hstoreTypeName(null), PostgreSqlDatabaseDialect::hstoreArrayFor);
+          hstoreTypeName(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
     }
     String elementName = elementSchema.name();
     if (elementName != null) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -28,6 +28,7 @@ import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.DateTimeUtils;
 import io.confluent.connect.jdbc.util.ExpressionBuilder;
 import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
+import io.confluent.connect.jdbc.util.HstoreConverter;
 import io.confluent.connect.jdbc.util.IdentifierRules;
 import io.confluent.connect.jdbc.util.JdbcCredentials;
 import io.confluent.connect.jdbc.util.JsonConverter;
@@ -53,6 +54,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,6 +80,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   // Visible for testing
   volatile int maxIdentifierLength = 0;
+
+  /**
+   * The type name to write hstore columns with, resolved once per connection: {@code hstore} when
+   * the extension is on the search_path, {@code "schema".hstore} when it is installed elsewhere,
+   * and null when it is not installed at all. Visible for testing.
+   */
+  volatile String hstoreTypeName;
+  volatile boolean hstoreTypeResolved;
 
   /**
    * The provider for {@link PostgreSqlDatabaseDialect}.
@@ -124,6 +134,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           + "not on this connection's search_path. Add the schema owning the extension to the "
           + "search_path, for example with ?currentSchema=ext,public on connection.url, or set "
           + "hstore.handling.mode=none to skip hstore columns.";
+
+  private static final String HSTORE_EXTENSION_MISSING =
+      "Cannot write %s to an hstore column: the hstore extension is not installed on this "
+          + "database. Install it with CREATE EXTENSION hstore, in any schema.";
 
   /**
    * Define the PG datatypes that require casting upon insert/update statements.
@@ -196,8 +210,50 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (maxIdentifierLength <= 0) {
         maxIdentifierLength = computeMaxIdentifierLength(result);
       }
+      if (!hstoreTypeResolved && complexTypesEnabled()) {
+        hstoreTypeName = resolveHstoreTypeName(result);
+        hstoreTypeResolved = true;
+      }
     }
     return result;
+  }
+
+  /**
+   * Locate the hstore extension: the bare name when {@code search_path} resolves it, otherwise the
+   * schema it was installed into, so {@code CREATE EXTENSION hstore SCHEMA ext} is usable without
+   * changing the connection's search_path. Returns null when the extension is not installed.
+   */
+  static String resolveHstoreTypeName(Connection connection) {
+    try (Statement stmt = connection.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery("SELECT to_regtype('hstore') IS NOT NULL")) {
+        if (rs.next() && rs.getBoolean(1)) {
+          return HSTORE_TYPE_NAME;
+        }
+      }
+      try (ResultSet rs = stmt.executeQuery(
+          "SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace"
+              + " WHERE e.extname = 'hstore'")) {
+        if (rs.next()) {
+          return "\"" + rs.getString(1) + "\"." + HSTORE_TYPE_NAME;
+        }
+      }
+    } catch (SQLException e) {
+      log.warn("Unable to determine whether the hstore extension is installed", e);
+    }
+    return null;
+  }
+
+  /**
+   * The type name for an hstore column, or a failure naming the field when the extension is not
+   * installed. Before any connection exists — unit tests, and validation before the first write —
+   * the bare name is assumed, since there is nothing yet to check it against.
+   */
+  private String hstoreTypeName(String fieldName) {
+    if (hstoreTypeResolved && hstoreTypeName == null) {
+      throw new ConnectException(String.format(HSTORE_EXTENSION_MISSING,
+          fieldName == null ? "a map value" : "field " + fieldName));
+    }
+    return hstoreTypeName == null ? HSTORE_TYPE_NAME : hstoreTypeName;
   }
 
   static int computeMaxIdentifierLength(Connection connection) {
@@ -721,7 +777,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Whether the schema is a {@code MAP<STRING, STRING>}, the only Connect container mapped to a
-   * native {@code jsonb} column. That is the shape a PostgreSQL {@code hstore} column takes on the
+   * native {@code hstore} column. That is the shape a PostgreSQL {@code hstore} column takes on the
    * topic; STRUCT values and other map shapes are not supported.
    */
   private static boolean isStringToStringMap(Schema schema) {
@@ -730,26 +786,20 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         && schema.valueSchema().type() == Schema.Type.STRING;
   }
 
-  private boolean isJsonBindCandidate(Schema schema) {
-    return isStringToStringMap(schema) && complexTypesEnabled();
-  }
-
-  private boolean maybeBindJson(
+  /**
+   * Bind a Connect map as hstore text; the {@code ::hstore} cast from {@link #valueTypeCast} parses
+   * it server-side. Returns false when the schema is not the supported map shape.
+   */
+  private boolean maybeBindHstore(
       PreparedStatement statement,
       int index,
       Schema schema,
       Object value
   ) throws SQLException {
-    if (!isJsonBindCandidate(schema)) {
+    if (!isStringToStringMap(schema) || !complexTypesEnabled()) {
       return false;
     }
-    String json = JsonConverter.connectMapToJson(value);
-    if (json == null) {
-      statement.setNull(index, Types.OTHER);
-    } else {
-      // Bind as text; the ::jsonb cast (see valueTypeCast) parses it into jsonb server-side.
-      statement.setString(index, json);
-    }
+    statement.setString(index, HstoreConverter.connectMapToHstore(value));
     return true;
   }
 
@@ -937,7 +987,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return getSqlType(childField) + "[]";
       case MAP:
         if (isStringToStringMap(field.schema()) && complexTypesEnabled()) {
-          return JSONB_TYPE_NAME.toUpperCase();
+          return hstoreTypeName(field.name());
         }
         return super.getSqlType(field);
       default:
@@ -1113,7 +1163,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         }
         break;
       case MAP:
-        if (maybeBindJson(statement, index, schema, value)) {
+        if (maybeBindHstore(statement, index, schema, value)) {
           return true;
         }
         break;
@@ -1180,8 +1230,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       return null;
     }
     if (isStringToStringMap(elementSchema)) {
-      // hstore map mode -> each element serialized to JSON text -> jsonb[].
-      return new ArrayElementBinding(JSONB_TYPE_NAME, PostgreSqlDatabaseDialect::jsonArrayFor);
+      // Each element serialized to hstore text -> hstore[].
+      return new ArrayElementBinding(
+          hstoreTypeName(null), PostgreSqlDatabaseDialect::hstoreArrayFor);
     }
     String elementName = elementSchema.name();
     if (elementName != null) {
@@ -1255,12 +1306,12 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Serialize each map element to JSON text for binding into a native {@code jsonb[]} column, as an
-   * hstore column in map mode produces. Null elements are preserved.
+   * Serialize each map element to hstore text for binding into a native {@code hstore[]} column.
+   * Null elements are preserved.
    */
-  private static Object[] jsonArrayFor(Collection<?> valueCollection) {
+  private static Object[] hstoreArrayFor(Collection<?> valueCollection) {
     return valueCollection.stream()
-        .map(o -> o == null ? null : JsonConverter.connectMapToJson(o))
+        .map(o -> o == null ? null : HstoreConverter.connectMapToHstore(o))
         .toArray();
   }
 
@@ -1366,13 +1417,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   protected String valueTypeCast(TableDefinition tableDefn, ColumnId columnId) {
     if (tableDefn != null) {
       ColumnDefinition defn = tableDefn.definitionForColumn(columnId.name());
-      if (defn != null) {
+      if (defn != null && defn.typeName() != null) {
         String typeName = defn.typeName(); // database-specific
-        if (typeName != null) {
-          typeName = typeName.toLowerCase();
-          if (CAST_TYPES.contains(typeName)) {
-            return "::" + typeName;
-          }
+        String localName = localTypeName(typeName).toLowerCase();
+        if (HSTORE_TYPE_NAME.equals(localName)) {
+          // The reported name, so an extension off the search_path stays schema-qualified.
+          return "::" + typeName;
+        }
+        if (CAST_TYPES.contains(localName)) {
+          return "::" + localName;
         }
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -22,6 +22,7 @@ import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig.InsertMode;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig.PrimaryKeyMode;
 import io.confluent.connect.jdbc.sink.PreparedStatementBinder;
+import io.confluent.connect.jdbc.sink.TableAlterOrCreateException;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -92,10 +93,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    */
   volatile String hstoreTypeName;
   volatile boolean hstoreTypeResolved;
-
-  /** Set when the catalog is unreadable, so the lookup runs once. Not an absence
-   * and on every connection */
-  private volatile boolean hstoreTypeLookupFailed;
 
   /**
    * The provider for {@link PostgreSqlDatabaseDialect}.
@@ -225,12 +222,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Resolve the type name at most once. A refusal leaves it unresolved so the bare name is assumed,
-   * but is not retried: getConnection runs per batch, so a persistent failure would cost a query
-   * and a WARN on each. Visible for testing.
+   * Resolve the type name once per connection. A failed read leaves it unresolved, not absent, so
+   * the next connection retries and a transient failure heals. Visible for testing.
    */
   void maybeResolveHstoreType(Connection connection) {
-    if (hstoreTypeResolved || hstoreTypeLookupFailed) {
+    if (hstoreTypeResolved) {
       return;
     }
     try {
@@ -238,16 +234,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       hstoreTypeResolved = true;
     } catch (SQLException e) {
       // Unresolved, not absent: a write assumes the bare name and lets PostgreSQL say why.
-      hstoreTypeLookupFailed = true;
-      log.warn("Could not locate the hstore extension; assuming the bare type name and not "
-          + "retrying. Writes fail if it is installed off the search_path.");
+      log.warn("Could not locate the hstore extension; assuming the bare type name. Writes fail "
+          + "if it is installed off the search_path.", e);
     }
   }
 
   /**
-   * Locate the extension: bare name when search_path resolves it, else its schema, so CREATE
-   * EXTENSION hstore SCHEMA ext works unchanged. Null when not installed; throws when the catalog
-   * cannot be read — distinct cases that must not be conflated.
+   * Locate the extension: bare name when search_path resolves it, else its schema. Null when not
+   * installed; throws when the catalog cannot be read — cases that must not be conflated.
    */
   static String resolveHstoreTypeName(Connection connection) throws SQLException {
     try (Statement stmt = connection.createStatement()) {
@@ -269,10 +263,27 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     return "\"" + identifier.replace("\"", "\"\"") + "\"";
   }
 
-  /** Type name, or a failure naming the field when absent. Unresolved assumes the bare name. */
+  /** Requote a reported type name, doubling any embedded quote the driver left as-is. */
+  private static String requoteTypeName(String typeName) {
+    int lastDot = typeName.lastIndexOf('.');
+    if (lastDot < 0) {
+      return typeName;
+    }
+    return quoteIdentifier(unquoteOuter(typeName.substring(0, lastDot)))
+        + "." + quoteIdentifier(unquoteOuter(typeName.substring(lastDot + 1)));
+  }
+
+  /** Strip only the delimiting quotes; stripping every quote would drop an embedded one. */
+  private static String unquoteOuter(String part) {
+    return part.length() > 1 && part.startsWith("\"") && part.endsWith("\"")
+        ? part.substring(1, part.length() - 1)
+        : part;
+  }
+
+  /** Type name, or a rollback-and-reportable failure when absent. Unresolved assumes bare. */
   private String requireHstoreTypeName(String fieldName) {
     if (hstoreTypeResolved && hstoreTypeName == null) {
-      throw new ConnectException(String.format(HSTORE_EXTENSION_MISSING,
+      throw new TableAlterOrCreateException(String.format(HSTORE_EXTENSION_MISSING,
           fieldName == null ? "a map value" : "field " + fieldName));
     }
     return hstoreTypeName == null ? HSTORE_TYPE_NAME : hstoreTypeName;
@@ -518,7 +529,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     } catch (DataException e) {
       if (columnDefn.isOptional()) {
         log.warn("Unparseable value for hstore column {}: class={}; emitting null",
-            columnDefn.id(), value.getClass().getName(), e);
+            columnDefn.id(), value.getClass().getName());
         return null;
       }
       throw new DataException("Unparseable value for hstore column " + columnDefn.id()
@@ -733,9 +744,17 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     if (value == null) {
       return null;
     }
-    Map<String, String> map = value instanceof Map
-        ? asStringMap(value)
-        : HstoreConverter.hstoreToConnectMap(value.toString());
+    Map<String, String> map;
+    try {
+      map = value instanceof Map
+          ? asStringMap(value)
+          : HstoreConverter.hstoreToConnectMap(value.toString());
+    } catch (DataException | ClassCastException e) {
+      // Element schemas are always optional, so degrade as the scalar path does.
+      log.warn("Unparseable hstore array element: class={}; emitting null",
+          value.getClass().getName());
+      return null;
+    }
     return hstoreHandlingMode() == HstoreHandlingMode.JSON
         ? JsonConverter.connectMapToJson(map)
         : map;
@@ -802,10 +821,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * {@inheritDoc} Overridden only to carry the table definition into the binder: the interface
-   * default drops it, leaving every column definition null at bind time. SQL Server, Oracle and
-   * Sybase override it for the same mechanical reason, though they read the definition to choose a
-   * better bind rather than to reject one.
+   * {@inheritDoc} Overridden only to carry the table definition into the binder, which the
+   * interface default drops — leaving every column definition null at bind time. SQL Server,
+   * Oracle and Sybase override it for the same mechanical reason.
    */
   @Override
   public StatementBinder statementBinder(
@@ -831,8 +849,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * {@inheritDoc} A map is written as hstore text, so the column must be an hstore. Checked here
-   * because this is the only bind entry point given the column definition; otherwise PostgreSQL
-   * reports a syntax error that never mentions hstore.
+   * as the only bind entry point given the column definition.
    */
   @Override
   public void bindField(
@@ -853,14 +870,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     super.bindField(statement, index, schema, value, colDef, fieldName);
   }
 
-  /** Fail unless an existing column can hold hstore text; an unknown column or type is skipped. */
+  /** Fail unless an existing column can hold hstore text; unknown column or type is skipped. */
   private void requireHstoreColumn(ColumnDefinition colDef, String fieldName, String expected) {
     String actual = colDef == null ? null : localTypeName(colDef.typeName());
     if (actual == null) {
       return;
     }
     if (!expected.equalsIgnoreCase(actual)) {
-      throw new ConnectException(
+      throw new TableAlterOrCreateException(
           String.format(HSTORE_COLUMN_REQUIRED, fieldName, actual, expected));
     }
   }
@@ -917,7 +934,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * The on-topic schema for an hstore value under {@code hstore.handling.mode}: a {@code Json}
    * STRING, or a {@code MAP<STRING, STRING>} whose values are optional since an hstore value may
    * be NULL. Shared so a scalar column (optionality from the column) and an array element (always
-   * optional) cannot drift apart. Only valid once {@link #hstoreMappingEnabled()} holds; the map
+   * optional) cannot drift apart. Only valid once {@link #hstoreMappingSelected()} holds; the map
    * branch is the fallback, so {@code none} would otherwise be read as {@code map}.
    */
   protected Schema hstoreSchema(boolean optional) {
@@ -1482,8 +1499,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         String typeName = defn.typeName(); // database-specific
         String localName = localTypeName(typeName).toLowerCase();
         if (HSTORE_TYPE_NAME.equals(localName)) {
-          // The reported name, so an extension off the search_path stays schema-qualified.
-          return "::" + typeName;
+          // Requoted, not interpolated: pgjdbc builds the qualified name without escaping.
+          return "::" + requoteTypeName(typeName);
         }
         if (CAST_TYPES.contains(localName)) {
           return "::" + localName;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -87,22 +87,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   volatile int maxIdentifierLength = 0;
 
   /**
-   * The type name to write hstore columns with, resolved once per connection: {@code hstore} when
-   * the extension is on the search_path, {@code "schema".hstore} when it is installed elsewhere,
-   * and null when it is not installed at all. Visible for testing.
-   *
-   * <p>{@link #hstoreTypeResolved} is written last, inside the {@code synchronized} block in
-   * {@link #getConnection()}. Both are volatile, so a reader that sees it {@code true} is
-   * guaranteed to see the name written before it, and needs no lock of its own.
+   * Type name for hstore columns: bare on the search_path, "schema".hstore elsewhere, null when not
+   * installed. Written before volatile hstoreTypeResolved, so a reader seeing that true sees this.
    */
   volatile String hstoreTypeName;
   volatile boolean hstoreTypeResolved;
 
-  /**
-   * Set when the catalog could not be read, so the lookup is attempted once rather than on every
-   * connection. Kept separate from {@link #hstoreTypeResolved}, which stays false: an unreadable
-   * catalog is not a confirmed absence, and must not be reported as one.
-   */
+  /** Set when the catalog is unreadable, so the lookup runs once. Not an absence
+   * and on every connection */
   private volatile boolean hstoreTypeLookupFailed;
 
   /**
@@ -233,11 +225,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Resolve the hstore type name at most once, whether the catalog answers or refuses. A refusal
-   * leaves it unresolved so the bare name is still assumed, but is not retried: {@link
-   * #getConnection()} runs per batch, so a persistent failure — a user without permission on
-   * {@code pg_extension}, say — would otherwise cost a round-trip and a WARN on every one of them.
-   * Visible for testing.
+   * Resolve the type name at most once. A refusal leaves it unresolved so the bare name is assumed,
+   * but is not retried: getConnection runs per batch, so a persistent failure would cost a query
+   * and a WARN on each. Visible for testing.
    */
   void maybeResolveHstoreType(Connection connection) {
     if (hstoreTypeResolved || hstoreTypeLookupFailed) {
@@ -245,22 +235,19 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
     try {
       hstoreTypeName = resolveHstoreTypeName(connection);
-      // Written last: see the ordering note on hstoreTypeResolved.
       hstoreTypeResolved = true;
     } catch (SQLException e) {
-      // Leave it unresolved rather than report the extension as missing, which would name the
-      // wrong cause. A write then assumes the bare type name and lets PostgreSQL say why.
+      // Unresolved, not absent: a write assumes the bare name and lets PostgreSQL say why.
       hstoreTypeLookupFailed = true;
-      log.warn("Unable to determine where the hstore extension is installed; hstore columns "
-          + "will be written as the unqualified type", e);
+      log.warn("Could not locate the hstore extension; assuming the bare type name and not "
+          + "retrying. Writes fail if it is installed off the search_path.");
     }
   }
 
   /**
-   * Locate the hstore extension: the bare name when {@code search_path} resolves it, otherwise the
-   * schema it was installed into, so {@code CREATE EXTENSION hstore SCHEMA ext} is usable without
-   * changing the connection's search_path. Returns null when the extension is not installed, and
-   * throws when the catalog cannot be read — the two are distinct and must not be conflated.
+   * Locate the extension: bare name when search_path resolves it, else its schema, so CREATE
+   * EXTENSION hstore SCHEMA ext works unchanged. Null when not installed; throws when the catalog
+   * cannot be read — distinct cases that must not be conflated.
    */
   static String resolveHstoreTypeName(Connection connection) throws SQLException {
     try (Statement stmt = connection.createStatement()) {
@@ -277,19 +264,12 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
-  /**
-   * Quote a PostgreSQL identifier, doubling any embedded quote. Schema names come from the
-   * catalog rather than from config, but they are user-chosen and may legally contain one.
-   */
+  /** Quote an identifier, doubling embedded quotes: a schema name may legally contain one. */
   private static String quoteIdentifier(String identifier) {
     return "\"" + identifier.replace("\"", "\"\"") + "\"";
   }
 
-  /**
-   * The type name for an hstore column, or a failure naming the field when the extension is known
-   * to be absent. Where it is merely unresolved — before any connection exists, or after a catalog
-   * read failed — the bare name is assumed, since there is nothing to contradict it.
-   */
+  /** Type name, or a failure naming the field when absent. Unresolved assumes the bare name. */
   private String requireHstoreTypeName(String fieldName) {
     if (hstoreTypeResolved && hstoreTypeName == null) {
       throw new ConnectException(String.format(HSTORE_EXTENSION_MISSING,
@@ -409,8 +389,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       case Types.OTHER: {
         // Some of these types will have fixed size, but we drop this from the schema conversion
         // since only fixed byte arrays can have a fixed size
-        // Under hstore.handling.mode=none this falls through and the column is skipped, as it was
-        // before the feature existed.
+        // hstore.handling.mode=none falls through: the column is skipped, as it was before.
         if (complexTypesEnabled() && hstoreMappingSelected() && isHstoreType(columnDefn)) {
           builder.field(fieldName, hstoreSchema(columnDefn.isOptional()));
           return fieldName;
@@ -519,24 +498,16 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     return JSON_TYPE_NAME.equalsIgnoreCase(typeName) || JSONB_TYPE_NAME.equalsIgnoreCase(typeName);
   }
 
-  /**
-   * Whether the column is an {@code hstore}, wherever the extension is installed. pgjdbc reports
-   * the type bare while its schema is on the connection's {@code search_path} and qualified
-   * otherwise, so the local name decides — the same normalisation Debezium applies before its own
-   * catalog lookup, and what lets an {@code ext.hstore} column be mapped rather than refused.
-   */
+  /** An hstore wherever installed: pgjdbc qualifies it off search_path, so local name decides. */
   protected boolean isHstoreType(ColumnDefinition columnDefn) {
     return HSTORE_TYPE_NAME.equalsIgnoreCase(localTypeName(columnDefn.typeName()));
   }
 
   /**
-   * The driver's value for an hstore column, as the map both handling modes require. pgjdbc decodes
-   * one only while it can resolve the extension's type OID; off the {@code search_path} it hands
-   * back the raw {@code "k"=>"v"} text instead, which is parsed here — the same normalisation
-   * Debezium performs with the driver's own parser.
-   *
-   * <p>Anything that is neither follows Debezium's {@code handleUnknownData}: a nullable column
-   * degrades to null, a NOT NULL column fails. The value is never logged, in case it is sensitive.
+   * The driver's value for an hstore column, as the map both modes require. pgjdbc decodes one only
+   * when it can resolve the type OID; off the {@code search_path} it returns raw {@code "k"=>"v"}
+   * text, parsed here as Debezium does. Anything else follows its {@code handleUnknownData}: a
+   * nullable column degrades to null, a NOT NULL column fails. The value is never logged.
    */
   private Object hstoreValue(ColumnDefinition columnDefn, Object value) {
     if (value == null || value instanceof Map) {
@@ -754,9 +725,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Decode one hstore array element. The element {@link ResultSet} gives a decoded Map where the
-   * driver could resolve the type and the raw text where it could not, so both are normalised here
-   * exactly as the scalar path does; json mode then serializes the result.
+   * Decode one hstore array element. The element {@link ResultSet} yields a Map or raw text, so
+   * both are normalised as the scalar path does; json mode then serializes the result.
    */
   private Object decodeHstoreElement(ResultSet elementRs) throws SQLException {
     Object value = elementRs.getObject(ELEMENT_VALUE_COLUMN);
@@ -832,11 +802,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * <p>Overridden only to carry the table definition into the binder. The interface default drops
-   * it, which leaves every column definition null at bind time; the SQL Server, Oracle and Sybase
-   * dialects override it for the same reason.
+   * {@inheritDoc} Overridden only to carry the table definition into the binder: the interface
+   * default drops it, leaving every column definition null at bind time. SQL Server, Oracle and
+   * Sybase override it for the same mechanical reason, though they read the definition to choose a
+   * better bind rather than to reject one.
    */
   @Override
   public StatementBinder statementBinder(
@@ -861,11 +830,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * <p>A map is written as hstore text, so the target column has to be an hstore. Checked here
-   * because this is the only bind entry point given the column definition; without it the statement
-   * carries the wrong cast and PostgreSQL reports a syntax error that never mentions hstore.
+   * {@inheritDoc} A map is written as hstore text, so the column must be an hstore. Checked here
+   * because this is the only bind entry point given the column definition; otherwise PostgreSQL
+   * reports a syntax error that never mentions hstore.
    */
   @Override
   public void bindField(
@@ -886,11 +853,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     super.bindField(statement, index, schema, value, colDef, fieldName);
   }
 
-  /**
-   * Fail unless an existing column can hold hstore text. An unknown column or type is left alone:
-   * either the table is about to be created with the type this dialect chose, or there is nothing
-   * to check against.
-   */
+  /** Fail unless an existing column can hold hstore text; an unknown column or type is skipped. */
   private void requireHstoreColumn(ColumnDefinition colDef, String fieldName, String expected) {
     String actual = colDef == null ? null : localTypeName(colDef.typeName());
     if (actual == null) {
@@ -902,10 +865,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
   }
 
-  /**
-   * Bind a Connect map as hstore text; the {@code ::hstore} cast from {@link #valueTypeCast} parses
-   * it server-side. Returns false when the schema is not the supported map shape.
-   */
+  /** Bind a map as hstore text for the ::hstore cast to parse; false if the shape differs. */
   private boolean maybeBindHstore(
       PreparedStatement statement,
       int index,
@@ -1333,7 +1293,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       return null;
     }
     if (isStringToStringMap(elementSchema)) {
-      // Each element serialized to hstore text -> hstore[].
       return new ArrayElementBinding(
           requireHstoreTypeName(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
     }
@@ -1409,8 +1368,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Serialize each map element to hstore text for binding into a native {@code hstore[]} column.
-   * Null elements are preserved.
+   * Serialize each map element to hstore text for a native hstore[] column, nulls preserved.
    */
   private static Object[] hstoreArrayFor(Collection<?> valueCollection) {
     return valueCollection.stream()

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -1563,6 +1563,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       ColumnDefinition defn = tableDefn.definitionForColumn(columnId.name());
       if (defn != null && defn.typeName() != null) {
         String typeName = defn.typeName(); // database-specific
+        if (!complexTypesEnabled()) {
+          // The hstore cast and the local-name match are both new, so off is the pre-feature form.
+          String rawName = typeName.toLowerCase();
+          return CAST_TYPES.contains(rawName) ? "::" + rawName : "";
+        }
         String localName = localTypeName(typeName).toLowerCase();
         if (HSTORE_TYPE_NAME.equals(localName)) {
           // Requoted, not interpolated: pgjdbc builds the qualified name without escaping.

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -119,6 +119,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   static final String TIMESTAMP_TYPE_NAME = "timestamp";
   static final String TIMESTAMPTZ_TYPE_NAME = "timestamptz";
 
+  /** pgjdbc reports an array type as its element name with this prefix: hstore[] is _hstore. */
+  static final String ARRAY_TYPE_PREFIX = "_";
+
   // Array.getResultSet() yields two columns per element: 1 is the index, 2 the value.
   private static final int ELEMENT_VALUE_COLUMN = 2;
 
@@ -134,9 +137,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    */
   private final Set<ColumnId> multiDimensionalWarnedColumns = ConcurrentHashMap.newKeySet();
 
+  /** Names the expected type twice: the remediation must be a type the operator can create. */
   private static final String HSTORE_COLUMN_REQUIRED =
-      "Cannot write field %s as hstore: column type is %s, not %s. Recreate the column with the "
-          + "hstore type, or set " + JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE + "=false.";
+      "Cannot write field %1$s as hstore: column type is %2$s, not %3$s. Recreate the column as "
+          + "%3$s, or set " + JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE + "=false.";
 
   private static final String HSTORE_EXTENSION_MISSING =
       "Cannot write %s to an hstore column: the hstore extension is not installed on this "
@@ -222,8 +226,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Resolve the type name once per connection. A failed read leaves it unresolved, not absent, so
-   * the next connection retries and a transient failure heals. Visible for testing.
+   * Resolve the type name once per dialect instance — once resolved it is not re-checked, so a
+   * reconnect keeps the first answer. A failed read leaves it unresolved rather than absent, so the
+   * next connection on this instance retries and a transient failure heals. Visible for testing.
    */
   void maybeResolveHstoreType(Connection connection) {
     if (hstoreTypeResolved) {
@@ -234,8 +239,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       hstoreTypeResolved = true;
     } catch (SQLException e) {
       // Unresolved, not absent: a write assumes the bare name and lets PostgreSQL say why.
-      log.warn("Could not locate the hstore extension; assuming the bare type name. Writes fail "
-          + "if it is installed off the search_path.", e);
+      log.warn("Could not read the catalog to find where the hstore extension is installed — this "
+          + "does not mean it is absent, which is reported separately when a write needs it. "
+          + "Assuming the bare type name; writes fail if it turns out to live off the search_path.",
+          e);
     }
   }
 
@@ -263,7 +270,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     return "\"" + identifier.replace("\"", "\"\"") + "\"";
   }
 
-  /** Requote a reported type name, doubling any embedded quote the driver left as-is. */
+  /**
+   * Requote a qualified type name the driver reported, doubling any embedded quote it left as-is.
+   * pgjdbc builds {@code "schema"."type"} by concatenation without escaping, so a schema named
+   * {@code e"x} arrives as {@code "e"x"."hstore"} — where the stray quote closes the identifier
+   * early and the generated DML will not parse. Unquoting each half and quoting it again fixes
+   * that: {@code "e"x"."hstore"} becomes {@code "e""x"."hstore"}.
+   *
+   * <p>An unqualified name has nothing to requote and is returned unchanged.
+   */
   private static String requoteTypeName(String typeName) {
     int lastDot = typeName.lastIndexOf('.');
     if (lastDot < 0) {
@@ -605,7 +620,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     if (typeName == null) {
       return null;
     }
-    String base = typeName.startsWith("_") ? typeName.substring(1) : typeName;
+    String base = typeName.startsWith(ARRAY_TYPE_PREFIX)
+        ? typeName.substring(ARRAY_TYPE_PREFIX.length())
+        : typeName;
     return base.toLowerCase();
   }
 
@@ -749,7 +766,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       map = value instanceof Map
           ? asStringMap(value)
           : HstoreConverter.hstoreToConnectMap(value.toString());
-    } catch (DataException | ClassCastException e) {
+    } catch (DataException e) {
       // Element schemas are always optional, so degrade as the scalar path does.
       log.warn("Unparseable hstore array element: class={}; emitting null",
           value.getClass().getName());
@@ -864,22 +881,36 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (isStringToStringMap(schema)) {
         requireHstoreColumn(colDef, fieldName, HSTORE_TYPE_NAME);
       } else if (schema.type() == Schema.Type.ARRAY && isStringToStringMap(schema.valueSchema())) {
-        requireHstoreColumn(colDef, fieldName, "_" + HSTORE_TYPE_NAME);
+        requireHstoreColumn(colDef, fieldName, ARRAY_TYPE_PREFIX + HSTORE_TYPE_NAME);
       }
     }
     super.bindField(statement, index, schema, value, colDef, fieldName);
   }
 
-  /** Fail unless an existing column can hold hstore text; unknown column or type is skipped. */
+  /**
+   * Fail unless an existing column can hold hstore text; unknown column or type is skipped. Bind
+   * time, so this fails the task as any unbindable value does rather than reading as a DDL failure:
+   * the mismatch holds for every record, so unrolling the batch would only find it again.
+   */
   private void requireHstoreColumn(ColumnDefinition colDef, String fieldName, String expected) {
     String actual = colDef == null ? null : localTypeName(colDef.typeName());
     if (actual == null) {
       return;
     }
     if (!expected.equalsIgnoreCase(actual)) {
-      throw new TableAlterOrCreateException(
-          String.format(HSTORE_COLUMN_REQUIRED, fieldName, actual, expected));
+      throw new ConnectException(String.format(HSTORE_COLUMN_REQUIRED,
+          fieldName, writableTypeName(actual), writableTypeName(expected)));
     }
+  }
+
+  /**
+   * The form an operator would write in DDL: pgjdbc's {@code _hstore} becomes {@code hstore[]}.
+   * Both name the same type, but only the latter is what they would type to create the column.
+   */
+  private static String writableTypeName(String typeName) {
+    return typeName.startsWith(ARRAY_TYPE_PREFIX)
+        ? typeName.substring(ARRAY_TYPE_PREFIX.length()) + "[]"
+        : typeName;
   }
 
   /** Bind a map as hstore text for the ::hstore cast to parse; false if the shape differs. */

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -111,7 +111,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
 
     /** The catalog answered; a null name means the extension is not installed. */
-    static HstoreType installedAs(String name) {
+    static HstoreType fromTypeName(String name) {
       return name == null ? ABSENT : new HstoreType(State.INSTALLED, name);
     }
 
@@ -270,7 +270,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       return;
     }
     try {
-      hstoreType = HstoreType.installedAs(resolveHstoreTypeName(connection));
+      hstoreType = HstoreType.fromTypeName(resolveHstoreTypeName(connection));
     } catch (SQLException e) {
       // Unresolved, not absent: a write assumes the bare name and lets PostgreSQL say why.
       log.warn("Could not read the catalog to find where the hstore extension is installed — this "

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -761,10 +761,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     if (value == null) {
       return null;
     }
-    Map<String, String> map;
+    Map<?, ?> map;
     try {
       map = value instanceof Map
-          ? asStringMap(value)
+          ? (Map<?, ?>) value
           : HstoreConverter.hstoreToConnectMap(value.toString());
     } catch (DataException e) {
       // Element schemas are always optional, so degrade as the scalar path does.
@@ -775,11 +775,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     return hstoreHandlingMode() == HstoreHandlingMode.JSON
         ? JsonConverter.connectMapToJson(map)
         : map;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, String> asStringMap(Object value) {
-    return (Map<String, String>) value;
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -99,6 +99,13 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   volatile boolean hstoreTypeResolved;
 
   /**
+   * Set when the catalog could not be read, so the lookup is attempted once rather than on every
+   * connection. Kept separate from {@link #hstoreTypeResolved}, which stays false: an unreadable
+   * catalog is not a confirmed absence, and must not be reported as one.
+   */
+  private volatile boolean hstoreTypeLookupFailed;
+
+  /**
    * The provider for {@link PostgreSqlDatabaseDialect}.
    */
   public static class Provider extends SubprotocolBasedProvider {
@@ -218,20 +225,35 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         maxIdentifierLength = computeMaxIdentifierLength(result);
       }
       // Only the sink writes hstore columns, so a source task never pays for the lookup.
-      if (!hstoreTypeResolved && complexTypesEnabled() && config instanceof JdbcSinkConfig) {
-        try {
-          hstoreTypeName = resolveHstoreTypeName(result);
-          // Written last: see the ordering note on hstoreTypeResolved.
-          hstoreTypeResolved = true;
-        } catch (SQLException e) {
-          // Leave it unresolved rather than report the extension as missing, which would name the
-          // wrong cause. A write then assumes the bare type name and lets PostgreSQL say why.
-          log.warn("Unable to determine where the hstore extension is installed; hstore columns "
-              + "will be written as the unqualified type", e);
-        }
+      if (complexTypesEnabled() && config instanceof JdbcSinkConfig) {
+        maybeResolveHstoreType(result);
       }
     }
     return result;
+  }
+
+  /**
+   * Resolve the hstore type name at most once, whether the catalog answers or refuses. A refusal
+   * leaves it unresolved so the bare name is still assumed, but is not retried: {@link
+   * #getConnection()} runs per batch, so a persistent failure — a user without permission on
+   * {@code pg_extension}, say — would otherwise cost a round-trip and a WARN on every one of them.
+   * Visible for testing.
+   */
+  void maybeResolveHstoreType(Connection connection) {
+    if (hstoreTypeResolved || hstoreTypeLookupFailed) {
+      return;
+    }
+    try {
+      hstoreTypeName = resolveHstoreTypeName(connection);
+      // Written last: see the ordering note on hstoreTypeResolved.
+      hstoreTypeResolved = true;
+    } catch (SQLException e) {
+      // Leave it unresolved rather than report the extension as missing, which would name the
+      // wrong cause. A write then assumes the bare type name and lets PostgreSQL say why.
+      hstoreTypeLookupFailed = true;
+      log.warn("Unable to determine where the hstore extension is installed; hstore columns "
+          + "will be written as the unqualified type", e);
+    }
   }
 
   /**
@@ -250,9 +272,17 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       try (ResultSet rs = stmt.executeQuery(
           "SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace"
               + " WHERE e.extname = 'hstore'")) {
-        return rs.next() ? "\"" + rs.getString(1) + "\"." + HSTORE_TYPE_NAME : null;
+        return rs.next() ? quoteIdentifier(rs.getString(1)) + "." + HSTORE_TYPE_NAME : null;
       }
     }
+  }
+
+  /**
+   * Quote a PostgreSQL identifier, doubling any embedded quote. Schema names come from the
+   * catalog rather than from config, but they are user-chosen and may legally contain one.
+   */
+  private static String quoteIdentifier(String identifier) {
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -19,6 +19,11 @@ import io.confluent.connect.jdbc.data.Json;
 import io.confluent.connect.jdbc.data.VariableScaleDecimal;
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig.InsertMode;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig.PrimaryKeyMode;
+import io.confluent.connect.jdbc.sink.PreparedStatementBinder;
+import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
+import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
@@ -133,11 +138,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    */
   private final Set<ColumnId> multiDimensionalWarnedColumns = ConcurrentHashMap.newKeySet();
 
-  private static final String HSTORE_OFF_SEARCH_PATH_ERROR =
-      "Cannot map hstore column %s: the driver reports its type as %s, so the hstore extension is "
-          + "not on this connection's search_path. Add the schema owning the extension to the "
-          + "search_path, for example with ?currentSchema=ext,public on connection.url, or set "
-          + "hstore.handling.mode=none to skip hstore columns.";
+  private static final String HSTORE_COLUMN_REQUIRED =
+      "Cannot write field %s as hstore: column type is %s, not %s. Recreate the column with the "
+          + "hstore type, or set " + JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE + "=false.";
 
   private static final String HSTORE_EXTENSION_MISSING =
       "Cannot write %s to an hstore column: the hstore extension is not installed on this "
@@ -257,7 +260,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * to be absent. Where it is merely unresolved — before any connection exists, or after a catalog
    * read failed — the bare name is assumed, since there is nothing to contradict it.
    */
-  private String hstoreTypeName(String fieldName) {
+  private String requireHstoreTypeName(String fieldName) {
     if (hstoreTypeResolved && hstoreTypeName == null) {
       throw new ConnectException(String.format(HSTORE_EXTENSION_MISSING,
           fieldName == null ? "a map value" : "field " + fieldName));
@@ -376,16 +379,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       case Types.OTHER: {
         // Some of these types will have fixed size, but we drop this from the schema conversion
         // since only fixed byte arrays can have a fixed size
-        if (complexTypesEnabled()) {
-          if (isHstoreType(columnDefn)) {
-            if (hstoreMappingSelected()) {
-              builder.field(fieldName, hstoreSchema(columnDefn.isOptional()));
-              return fieldName;
-            }
-            // hstore.handling.mode=none: skipped, as before the feature existed.
-          } else if (isUnresolvedHstoreType(columnDefn.typeName()) && hstoreMappingSelected()) {
-            throw hstoreOffSearchPathError(columnDefn.id(), columnDefn.typeName());
-          }
+        // Under hstore.handling.mode=none this falls through and the column is skipped, as it was
+        // before the feature existed.
+        if (complexTypesEnabled() && hstoreMappingSelected() && isHstoreType(columnDefn)) {
+          builder.field(fieldName, hstoreSchema(columnDefn.isOptional()));
+          return fieldName;
         }
 
         if (isJsonType(columnDefn)) {
@@ -491,27 +489,40 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     return JSON_TYPE_NAME.equalsIgnoreCase(typeName) || JSONB_TYPE_NAME.equalsIgnoreCase(typeName);
   }
 
+  /**
+   * Whether the column is an {@code hstore}, wherever the extension is installed. pgjdbc reports
+   * the type bare while its schema is on the connection's {@code search_path} and qualified
+   * otherwise, so the local name decides — the same normalisation Debezium applies before its own
+   * catalog lookup, and what lets an {@code ext.hstore} column be mapped rather than refused.
+   */
   protected boolean isHstoreType(ColumnDefinition columnDefn) {
-    return HSTORE_TYPE_NAME.equalsIgnoreCase(columnDefn.typeName());
+    return HSTORE_TYPE_NAME.equalsIgnoreCase(localTypeName(columnDefn.typeName()));
   }
 
   /**
-   * The driver's value for an hstore column, as the map both handling modes require. Anything else
-   * follows Debezium's {@code handleUnknownData}: a nullable column degrades to null, a NOT NULL
-   * column fails, and the same text is used either way. The value is never logged, in case it is
-   * sensitive.
+   * The driver's value for an hstore column, as the map both handling modes require. pgjdbc decodes
+   * one only while it can resolve the extension's type OID; off the {@code search_path} it hands
+   * back the raw {@code "k"=>"v"} text instead, which is parsed here — the same normalisation
+   * Debezium performs with the driver's own parser.
+   *
+   * <p>Anything that is neither follows Debezium's {@code handleUnknownData}: a nullable column
+   * degrades to null, a NOT NULL column fails. The value is never logged, in case it is sensitive.
    */
   private Object hstoreValue(ColumnDefinition columnDefn, Object value) {
     if (value == null || value instanceof Map) {
       return value;
     }
-    if (columnDefn.isOptional()) {
-      log.warn("Unexpected value for hstore column {}: class={}; emitting null",
-          columnDefn.id(), value.getClass().getName());
-      return null;
+    try {
+      return HstoreConverter.hstoreToConnectMap(value.toString());
+    } catch (DataException e) {
+      if (columnDefn.isOptional()) {
+        log.warn("Unparseable value for hstore column {}: class={}; emitting null",
+            columnDefn.id(), value.getClass().getName(), e);
+        return null;
+      }
+      throw new DataException("Unparseable value for hstore column " + columnDefn.id()
+          + ": class=" + value.getClass().getName(), e);
     }
-    throw new DataException("Unexpected value for hstore column " + columnDefn.id()
-        + ": class=" + value.getClass().getName());
   }
 
   /**
@@ -556,9 +567,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           // hstore.handling.mode=none: skipped exactly as a scalar hstore column is.
           return null;
         }
-        if (isUnresolvedHstoreArrayType(columnDefn)) {
-          throw hstoreOffSearchPathError(columnDefn.id(), columnDefn.typeName());
-        }
         // Shared with the scalar hstore path; array elements are always optional.
         return hstoreSchema(true);
       case "date":
@@ -587,17 +595,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
     String base = typeName.startsWith("_") ? typeName.substring(1) : typeName;
     return base.toLowerCase();
-  }
-
-  /**
-   * Whether an array column's element type is an hstore the driver could not resolve, i.e. the
-   * column type arrived schema-qualified as {@code "ext"."_hstore"}.
-   */
-  private static boolean isUnresolvedHstoreArrayType(ColumnDefinition columnDefn) {
-    String typeName = columnDefn.typeName();
-    return typeName != null
-        && !typeName.equals(localTypeName(typeName))
-        && HSTORE_TYPE_NAME.equals(arrayElementBaseType(columnDefn));
   }
 
   /**
@@ -727,17 +724,26 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Decode one hstore array element. The element {@link ResultSet} applies the driver's own hstore
-   * decoding, so the value arrives as a Map; json mode then serializes it.
+   * Decode one hstore array element. The element {@link ResultSet} gives a decoded Map where the
+   * driver could resolve the type and the raw text where it could not, so both are normalised here
+   * exactly as the scalar path does; json mode then serializes the result.
    */
   private Object decodeHstoreElement(ResultSet elementRs) throws SQLException {
     Object value = elementRs.getObject(ELEMENT_VALUE_COLUMN);
     if (value == null) {
       return null;
     }
+    Map<String, String> map = value instanceof Map
+        ? asStringMap(value)
+        : HstoreConverter.hstoreToConnectMap(value.toString());
     return hstoreHandlingMode() == HstoreHandlingMode.JSON
-        ? JsonConverter.connectMapToJson(value)
-        : value;
+        ? JsonConverter.connectMapToJson(map)
+        : map;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> asStringMap(Object value) {
+    return (Map<String, String>) value;
   }
 
   /**
@@ -796,6 +802,77 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * <p>Overridden only to carry the table definition into the binder. The interface default drops
+   * it, which leaves every column definition null at bind time; the SQL Server, Oracle and Sybase
+   * dialects override it for the same reason.
+   */
+  @Override
+  public StatementBinder statementBinder(
+      PreparedStatement statement,
+      PrimaryKeyMode pkMode,
+      SchemaPair schemaPair,
+      FieldsMetadata fieldsMetadata,
+      TableDefinition tableDefinition,
+      InsertMode insertMode,
+      boolean replaceNullWithDefault
+  ) {
+    return new PreparedStatementBinder(
+        this,
+        statement,
+        pkMode,
+        schemaPair,
+        fieldsMetadata,
+        tableDefinition,
+        insertMode,
+        replaceNullWithDefault
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>A map is written as hstore text, so the target column has to be an hstore. Checked here
+   * because this is the only bind entry point given the column definition; without it the statement
+   * carries the wrong cast and PostgreSQL reports a syntax error that never mentions hstore.
+   */
+  @Override
+  public void bindField(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value,
+      ColumnDefinition colDef,
+      String fieldName
+  ) throws SQLException {
+    if (value != null && complexTypesEnabled()) {
+      if (isStringToStringMap(schema)) {
+        requireHstoreColumn(colDef, fieldName, HSTORE_TYPE_NAME);
+      } else if (schema.type() == Schema.Type.ARRAY && isStringToStringMap(schema.valueSchema())) {
+        requireHstoreColumn(colDef, fieldName, "_" + HSTORE_TYPE_NAME);
+      }
+    }
+    super.bindField(statement, index, schema, value, colDef, fieldName);
+  }
+
+  /**
+   * Fail unless an existing column can hold hstore text. An unknown column or type is left alone:
+   * either the table is about to be created with the type this dialect chose, or there is nothing
+   * to check against.
+   */
+  private void requireHstoreColumn(ColumnDefinition colDef, String fieldName, String expected) {
+    String actual = colDef == null ? null : localTypeName(colDef.typeName());
+    if (actual == null) {
+      return;
+    }
+    if (!expected.equalsIgnoreCase(actual)) {
+      throw new ConnectException(
+          String.format(HSTORE_COLUMN_REQUIRED, fieldName, actual, expected));
+    }
+  }
+
+  /**
    * Bind a Connect map as hstore text; the {@code ::hstore} cast from {@link #valueTypeCast} parses
    * it server-side. Returns false when the schema is not the supported map shape.
    */
@@ -844,25 +921,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
     int lastDot = typeName.lastIndexOf('.');
     return (lastDot < 0 ? typeName : typeName.substring(lastDot + 1)).replace("\"", "");
-  }
-
-  /**
-   * Whether a type name is an hstore the driver could not resolve, i.e. one that arrived
-   * schema-qualified because the extension is off the {@code search_path}. Shared by the scalar
-   * column path and the array element path, which must agree.
-   */
-  protected static boolean isUnresolvedHstoreType(String typeName) {
-    return typeName != null
-        && !HSTORE_TYPE_NAME.equalsIgnoreCase(typeName)
-        && HSTORE_TYPE_NAME.equalsIgnoreCase(localTypeName(typeName));
-  }
-
-  /**
-   * The failure for an hstore column that a selected mapping mode cannot honour. Failing beats
-   * silently dropping the column, since a mode was explicitly asked for.
-   */
-  protected ConnectException hstoreOffSearchPathError(ColumnId column, String typeName) {
-    return new ConnectException(String.format(HSTORE_OFF_SEARCH_PATH_ERROR, column, typeName));
   }
 
   /**
@@ -996,7 +1054,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return getSqlType(childField) + "[]";
       case MAP:
         if (isStringToStringMap(field.schema()) && complexTypesEnabled()) {
-          return hstoreTypeName(field.name());
+          return requireHstoreTypeName(field.name());
         }
         return super.getSqlType(field);
       default:
@@ -1247,7 +1305,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     if (isStringToStringMap(elementSchema)) {
       // Each element serialized to hstore text -> hstore[].
       return new ArrayElementBinding(
-          hstoreTypeName(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
+          requireHstoreTypeName(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
     }
     String elementName = elementSchema.name();
     if (elementName != null) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -86,12 +86,48 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   // Visible for testing
   volatile int maxIdentifierLength = 0;
 
+  // Visible for testing
+  volatile HstoreType hstoreType = HstoreType.UNRESOLVED;
+
   /**
-   * Type name for hstore columns: bare on the search_path, "schema".hstore elsewhere, null when not
-   * installed. Written before volatile hstoreTypeResolved, so a reader seeing that true sees this.
+   * What the catalog says about the hstore extension, as one value rather than a name plus a flag:
+   * unresolved until it is read, then absent, or installed under a name — bare while the extension
+   * is on the {@code search_path}, {@code "schema".hstore} when it is not. A single volatile
+   * reference also publishes the name and the state together.
    */
-  volatile String hstoreTypeName;
-  volatile boolean hstoreTypeResolved;
+  static final class HstoreType {
+
+    private enum State { UNRESOLVED, ABSENT, INSTALLED }
+
+    static final HstoreType UNRESOLVED = new HstoreType(State.UNRESOLVED, null);
+    static final HstoreType ABSENT = new HstoreType(State.ABSENT, null);
+
+    private final State state;
+    private final String name;
+
+    private HstoreType(State state, String name) {
+      this.state = state;
+      this.name = name;
+    }
+
+    /** The catalog answered; a null name means the extension is not installed. */
+    static HstoreType installedAs(String name) {
+      return name == null ? ABSENT : new HstoreType(State.INSTALLED, name);
+    }
+
+    boolean isResolved() {
+      return state != State.UNRESOLVED;
+    }
+
+    boolean isAbsent() {
+      return state == State.ABSENT;
+    }
+
+    /** The name to write, assuming the bare one until the catalog has been read. */
+    String nameOrBare() {
+      return name == null ? HSTORE_TYPE_NAME : name;
+    }
+  }
 
   /**
    * The provider for {@link PostgreSqlDatabaseDialect}.
@@ -225,17 +261,16 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Resolve the type name once per dialect instance — once resolved it is not re-checked, so a
-   * reconnect keeps the first answer. A failed read leaves it unresolved rather than absent, so the
-   * next connection on this instance retries and a transient failure heals. Visible for testing.
+   * Read the catalog once per dialect instance — once read it is not re-checked, so a reconnect
+   * keeps the first answer. A failed read leaves it unread rather than absent, so the next
+   * connection on this instance retries and a transient failure heals. Visible for testing.
    */
   void maybeResolveHstoreType(Connection connection) {
-    if (hstoreTypeResolved) {
+    if (hstoreType.isResolved()) {
       return;
     }
     try {
-      hstoreTypeName = resolveHstoreTypeName(connection);
-      hstoreTypeResolved = true;
+      hstoreType = HstoreType.installedAs(resolveHstoreTypeName(connection));
     } catch (SQLException e) {
       // Unresolved, not absent: a write assumes the bare name and lets PostgreSQL say why.
       log.warn("Could not read the catalog to find where the hstore extension is installed — this "
@@ -295,16 +330,17 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * Type name, or a failure when the extension is absent; unresolved assumes bare. Absence is a
-   * property of the database, not of a record, so no batch split could find a record that fits:
-   * this fails the task rather than carrying the DDL exception's per-record handling.
+   * The type name to write — schema-qualified when the extension is off the search_path — failing
+   * when the catalog says it is absent. Absence is a property of the database, not of a record, so
+   * no batch split could find a record that fits: this fails the task rather than carrying the DDL
+   * exception's per-record handling.
    */
-  private String requireHstoreTypeName(String fieldName) {
-    if (hstoreTypeResolved && hstoreTypeName == null) {
+  private String hstoreTypeNameOrFail(String fieldName) {
+    if (hstoreType.isAbsent()) {
       throw new ConnectException(String.format(HSTORE_EXTENSION_MISSING,
           fieldName == null ? "a map value" : "field " + fieldName));
     }
-    return hstoreTypeName == null ? HSTORE_TYPE_NAME : hstoreTypeName;
+    return hstoreType.nameOrBare();
   }
 
   static int computeMaxIdentifierLength(Connection connection) {
@@ -879,7 +915,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (isStringToStringMap(schema)) {
         requireHstoreColumn(colDef, fieldName, HSTORE_TYPE_NAME);
       } else if (schema.type() == Schema.Type.ARRAY && isStringToStringMap(schema.valueSchema())) {
-        requireHstoreColumn(colDef, fieldName, ARRAY_TYPE_PREFIX + HSTORE_TYPE_NAME);
+        requireHstoreColumn(colDef, fieldName, HSTORE_TYPE_NAME + "[]");
       }
     }
     super.bindField(statement, index, schema, value, colDef, fieldName);
@@ -891,13 +927,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * the mismatch holds for every record, so unrolling the batch would only find it again.
    */
   private void requireHstoreColumn(ColumnDefinition colDef, String fieldName, String expected) {
-    String actual = colDef == null ? null : localTypeName(colDef.typeName());
-    if (actual == null) {
+    String reported = colDef == null ? null : localTypeName(colDef.typeName());
+    if (reported == null) {
       return;
     }
+    String actual = writableTypeName(reported);
     if (!expected.equalsIgnoreCase(actual)) {
-      throw new ConnectException(String.format(HSTORE_COLUMN_REQUIRED,
-          fieldName, writableTypeName(actual), writableTypeName(expected)));
+      throw new ConnectException(
+          String.format(HSTORE_COLUMN_REQUIRED, fieldName, actual, expected));
     }
   }
 
@@ -1090,7 +1127,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return getSqlType(childField) + "[]";
       case MAP:
         if (isStringToStringMap(field.schema()) && complexTypesEnabled()) {
-          return requireHstoreTypeName(field.name());
+          return hstoreTypeNameOrFail(field.name());
         }
         return super.getSqlType(field);
       default:
@@ -1340,7 +1377,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     }
     if (isStringToStringMap(elementSchema)) {
       return new ArrayElementBinding(
-          requireHstoreTypeName(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
+          hstoreTypeNameOrFail(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
     }
     String elementName = elementSchema.name();
     if (elementName != null) {

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -22,7 +22,6 @@ import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig.InsertMode;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig.PrimaryKeyMode;
 import io.confluent.connect.jdbc.sink.PreparedStatementBinder;
-import io.confluent.connect.jdbc.sink.TableAlterOrCreateException;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
@@ -295,10 +294,14 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         : part;
   }
 
-  /** Type name, or a rollback-and-reportable failure when absent. Unresolved assumes bare. */
+  /**
+   * Type name, or a failure when the extension is absent; unresolved assumes bare. Absence is a
+   * property of the database, not of a record, so no batch split could find a record that fits:
+   * this fails the task rather than carrying the DDL exception's per-record handling.
+   */
   private String requireHstoreTypeName(String fieldName) {
     if (hstoreTypeResolved && hstoreTypeName == null) {
-      throw new TableAlterOrCreateException(String.format(HSTORE_EXTENSION_MISSING,
+      throw new ConnectException(String.format(HSTORE_EXTENSION_MISSING,
           fieldName == null ? "a map value" : "field " + fieldName));
     }
     return hstoreTypeName == null ? HSTORE_TYPE_NAME : hstoreTypeName;

--- a/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
@@ -23,11 +23,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Converts between a Connect {@code MAP<STRING, STRING>} and PostgreSQL {@code hstore} text,
- * {@code "key"=>"value"} — written for a bind through a cast, and read back for the columns the
- * driver hands over as text rather than as a decoded map. pgjdbc's own
- * {@code org.postgresql.util.HStoreConverter} is unusable here: the driver is runtime-scope so that
- * it ships with the connector without any dialect compiling against it.
+ * Converts a Connect {@code MAP<STRING, STRING>} to and from PostgreSQL {@code hstore} text,
+ * {@code "key"=>"value"}. pgjdbc's own converter is unusable here: the driver is runtime-scope, so
+ * no dialect compiles against it.
  */
 public final class HstoreConverter {
 
@@ -46,11 +44,10 @@ public final class HstoreConverter {
   }
 
   /**
-   * Parse PostgreSQL {@code hstore} text into a map, preserving order; null and empty text yield
-   * null and an empty map. The driver returns text rather than a decoded map when it cannot resolve
-   * the type OID — any hstore off the {@code search_path}. Only what {@code hstore_out} emits is
-   * accepted: pairs separated by {@code ", "}, both sides quoted apart from a bare {@code NULL};
-   * anything else throws rather than being guessed at.
+   * Parse {@code hstore} text into a map, preserving order; null and empty text yield null and an
+   * empty map. The driver returns text when it cannot resolve the type OID. Accepts quoted pairs —
+   * what {@code hstore_out} emits, plus the surrounding whitespace and trailing comma
+   * {@code hstore_in} also allows; anything else throws rather than being guessed at.
    */
   public static Map<String, String> hstoreToConnectMap(String text) {
     if (text == null) {

--- a/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
@@ -17,11 +17,15 @@ package io.confluent.connect.jdbc.util;
 
 import org.apache.kafka.connect.errors.DataException;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Serializes a Connect {@code MAP<STRING, STRING>} into the PostgreSQL {@code hstore} text form,
- * {@code "key"=>"value"}, for binding into an {@code hstore} column through a cast.
+ * Converts between a Connect {@code MAP<STRING, STRING>} and the PostgreSQL {@code hstore} text
+ * form, {@code "key"=>"value"} — writing it for a bind through a cast, and reading it back for the
+ * columns the driver hands over as text rather than as a decoded map.
  *
  * <p>pgjdbc's own {@code org.postgresql.util.HStoreConverter} is not usable here: the driver is a
  * runtime-scope dependency so that it ships with the connector without any dialect compiling
@@ -31,7 +35,54 @@ public final class HstoreConverter {
 
   private static final String NULL_VALUE = "NULL";
 
+  /** A quoted token: any run of characters that are neither a quote nor an escape lead-in. */
+  private static final String QUOTED = "\"((?:[^\"\\\\]|\\\\.)*)\"";
+
+  /**
+   * One {@code "key"=>"value"} or {@code "key"=>NULL} pair, and the separator that follows it.
+   */
+  private static final Pattern HSTORE_PAIR =
+      Pattern.compile(QUOTED + "\\s*=>\\s*(?:" + NULL_VALUE + "|" + QUOTED + ")\\s*(?:,\\s*|$)");
+
+  private static final Pattern ESCAPED_CHARACTER = Pattern.compile("\\\\(.)");
+
   private HstoreConverter() {
+  }
+
+  /**
+   * Parse PostgreSQL {@code hstore} text into a map. The driver hands back this form instead of a
+   * decoded map whenever it cannot resolve the extension's type OID, which is the case for any
+   * hstore that is not on the connection's {@code search_path}.
+   *
+   * <p>Only what {@code hstore_out} emits is accepted: {@code "key"=>"value"} pairs separated by
+   * {@code ", "}, with both sides always quoted apart from a bare {@code NULL} value. Anything else
+   * did not come from PostgreSQL and is rejected rather than guessed at.
+   *
+   * @param text the hstore text; null yields null
+   * @return the parsed map, preserving pair order; empty text yields an empty map
+   * @throws DataException if the text is not well-formed hstore
+   */
+  public static Map<String, String> hstoreToConnectMap(String text) {
+    if (text == null) {
+      return null;
+    }
+    String remaining = text.trim();
+    Map<String, String> out = new LinkedHashMap<>();
+    Matcher pair = HSTORE_PAIR.matcher(remaining);
+    int at = 0;
+    while (at < remaining.length()) {
+      if (!pair.find(at) || pair.start() != at) {
+        throw new DataException(
+            "Malformed hstore text at position " + at + " of " + remaining.length());
+      }
+      out.put(unescape(pair.group(1)), pair.group(2) == null ? null : unescape(pair.group(2)));
+      at = pair.end();
+    }
+    return out;
+  }
+
+  private static String unescape(String token) {
+    return ESCAPED_CHARACTER.matcher(token).replaceAll("$1");
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
@@ -23,13 +23,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Converts between a Connect {@code MAP<STRING, STRING>} and the PostgreSQL {@code hstore} text
- * form, {@code "key"=>"value"} — writing it for a bind through a cast, and reading it back for the
- * columns the driver hands over as text rather than as a decoded map.
- *
- * <p>pgjdbc's own {@code org.postgresql.util.HStoreConverter} is not usable here: the driver is a
- * runtime-scope dependency so that it ships with the connector without any dialect compiling
- * against it, which keeps the dialects on JDBC APIs alone.
+ * Converts between a Connect {@code MAP<STRING, STRING>} and PostgreSQL {@code hstore} text,
+ * {@code "key"=>"value"} — written for a bind through a cast, and read back for the columns the
+ * driver hands over as text rather than as a decoded map. pgjdbc's own
+ * {@code org.postgresql.util.HStoreConverter} is unusable here: the driver is runtime-scope so that
+ * it ships with the connector without any dialect compiling against it.
  */
 public final class HstoreConverter {
 
@@ -38,9 +36,7 @@ public final class HstoreConverter {
   /** A quoted token: any run of characters that are neither a quote nor an escape lead-in. */
   private static final String QUOTED = "\"((?:[^\"\\\\]|\\\\.)*)\"";
 
-  /**
-   * One {@code "key"=>"value"} or {@code "key"=>NULL} pair, and the separator that follows it.
-   */
+  /** One "key"=>"value" or "key"=>NULL pair, and the separator that follows it. */
   private static final Pattern HSTORE_PAIR =
       Pattern.compile(QUOTED + "\\s*=>\\s*(?:" + NULL_VALUE + "|" + QUOTED + ")\\s*(?:,\\s*|$)");
 
@@ -50,17 +46,11 @@ public final class HstoreConverter {
   }
 
   /**
-   * Parse PostgreSQL {@code hstore} text into a map. The driver hands back this form instead of a
-   * decoded map whenever it cannot resolve the extension's type OID, which is the case for any
-   * hstore that is not on the connection's {@code search_path}.
-   *
-   * <p>Only what {@code hstore_out} emits is accepted: {@code "key"=>"value"} pairs separated by
-   * {@code ", "}, with both sides always quoted apart from a bare {@code NULL} value. Anything else
-   * did not come from PostgreSQL and is rejected rather than guessed at.
-   *
-   * @param text the hstore text; null yields null
-   * @return the parsed map, preserving pair order; empty text yields an empty map
-   * @throws DataException if the text is not well-formed hstore
+   * Parse PostgreSQL {@code hstore} text into a map, preserving order; null and empty text yield
+   * null and an empty map. The driver returns text rather than a decoded map when it cannot resolve
+   * the type OID — any hstore off the {@code search_path}. Only what {@code hstore_out} emits is
+   * accepted: pairs separated by {@code ", "}, both sides quoted apart from a bare {@code NULL};
+   * anything else throws rather than being guessed at.
    */
   public static Map<String, String> hstoreToConnectMap(String text) {
     if (text == null) {
@@ -86,12 +76,9 @@ public final class HstoreConverter {
   }
 
   /**
-   * Serialize a map of strings into hstore text. Every key and value is quoted, so no value can be
-   * read back as the unquoted {@code NULL} literal; a null value is written as that literal.
-   *
-   * @param value the map to serialize; null yields null
-   * @return the hstore text, or null when the value is null
-   * @throws DataException if the value is not a map of strings, or has a null key
+   * Serialize a map of strings into hstore text; null yields null. Keys and values are always
+   * quoted, so none reads back as the unquoted {@code NULL} that a null value is written as.
+   * Throws unless the value is a map of strings with no null key.
    */
   public static String connectMapToHstore(Object value) {
     if (value == null) {
@@ -119,11 +106,7 @@ public final class HstoreConverter {
     return out.toString();
   }
 
-  /**
-   * Rejects a non-String rather than coercing it through {@code toString}, so a schema and value
-   * that disagree fail here instead of reaching the database. {@link JsonConverter} makes the same
-   * choice for jsonb, through a typed writer.
-   */
+  /** Rejects a non-String rather than coercing it, as JsonConverter does for jsonb. */
   private static String asString(Object entry, String part) {
     if (!(entry instanceof String)) {
       throw new DataException(

--- a/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import java.util.Map;
+
+/**
+ * Serializes a Connect {@code MAP<STRING, STRING>} into the PostgreSQL {@code hstore} text form,
+ * {@code "key"=>"value"}, for binding into an {@code hstore} column through a cast.
+ *
+ * <p>The driver's own converter is not usable here: pgjdbc is a runtime-scope dependency, so no
+ * dialect compiles against it.
+ */
+public final class HstoreConverter {
+
+  private static final String NULL_VALUE = "NULL";
+
+  private HstoreConverter() {
+  }
+
+  /**
+   * Serialize a map of strings into hstore text. Every key and value is quoted, so no value can be
+   * read back as the unquoted {@code NULL} literal; a null value is written as that literal.
+   *
+   * @param value the map to serialize; null yields null
+   * @return the hstore text, or null when the value is null
+   * @throws DataException if the value is not a map, or has a null key
+   */
+  public static String connectMapToHstore(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof Map)) {
+      throw new DataException("Expected a Map to serialize to hstore but was " + value.getClass());
+    }
+    StringBuilder out = new StringBuilder();
+    for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+      if (entry.getKey() == null) {
+        throw new DataException("An hstore key may not be null");
+      }
+      if (out.length() > 0) {
+        out.append(',');
+      }
+      appendQuoted(out, entry.getKey().toString());
+      out.append("=>");
+      if (entry.getValue() == null) {
+        out.append(NULL_VALUE);
+      } else {
+        appendQuoted(out, entry.getValue().toString());
+      }
+    }
+    return out.toString();
+  }
+
+  private static void appendQuoted(StringBuilder out, String text) {
+    out.append('"');
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
+      if (c == '"' || c == '\\') {
+        out.append('\\');
+      }
+      out.append(c);
+    }
+    out.append('"');
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
@@ -91,7 +91,7 @@ public final class HstoreConverter {
    *
    * @param value the map to serialize; null yields null
    * @return the hstore text, or null when the value is null
-   * @throws DataException if the value is not a map, or has a null key
+   * @throws DataException if the value is not a map of strings, or has a null key
    */
   public static String connectMapToHstore(Object value) {
     if (value == null) {
@@ -108,15 +108,28 @@ public final class HstoreConverter {
       if (out.length() > 0) {
         out.append(',');
       }
-      appendQuoted(out, entry.getKey().toString());
+      appendQuoted(out, asString(entry.getKey(), "key"));
       out.append("=>");
       if (entry.getValue() == null) {
         out.append(NULL_VALUE);
       } else {
-        appendQuoted(out, entry.getValue().toString());
+        appendQuoted(out, asString(entry.getValue(), "value"));
       }
     }
     return out.toString();
+  }
+
+  /**
+   * Rejects a non-String rather than coercing it through {@code toString}, so a schema and value
+   * that disagree fail here instead of reaching the database. {@link JsonConverter} makes the same
+   * choice for jsonb, through a typed writer.
+   */
+  private static String asString(Object entry, String part) {
+    if (!(entry instanceof String)) {
+      throw new DataException(
+          "An hstore " + part + " must be a string but was " + entry.getClass());
+    }
+    return (String) entry;
   }
 
   private static void appendQuoted(StringBuilder out, String text) {

--- a/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/HstoreConverter.java
@@ -23,8 +23,9 @@ import java.util.Map;
  * Serializes a Connect {@code MAP<STRING, STRING>} into the PostgreSQL {@code hstore} text form,
  * {@code "key"=>"value"}, for binding into an {@code hstore} column through a cast.
  *
- * <p>The driver's own converter is not usable here: pgjdbc is a runtime-scope dependency, so no
- * dialect compiles against it.
+ * <p>pgjdbc's own {@code org.postgresql.util.HStoreConverter} is not usable here: the driver is a
+ * runtime-scope dependency so that it ships with the connector without any dialect compiling
+ * against it, which keeps the dialects on JDBC APIs alone.
  */
 public final class HstoreConverter {
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1268,8 +1268,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
     SinkRecordField field = new SinkRecordField(stringToStringMap(), "col", false);
 
-    sink.hstoreTypeName = "\"ext\".hstore";
-    sink.hstoreTypeResolved = true;
+    sink.hstoreType = PostgreSqlDatabaseDialect.HstoreType.installedAs("\"ext\".hstore");
     assertEquals("\"ext\".hstore", sink.getSqlType(field));
     assertEquals("\"ext\".hstore[]",
         sink.getSqlType(new SinkRecordField(arraySchema(stringToStringMap()), "col", false)));
@@ -1323,13 +1322,13 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
 
     sink.maybeResolveHstoreType(connection);
-    assertFalse("a failed read is not a resolution", sink.hstoreTypeResolved);
+    assertFalse("a failed read is not a resolution", sink.hstoreType.isResolved());
     assertEquals("the bare name is assumed while unresolved", "hstore",
         sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
 
     // The next connection retries, so a transient failure heals.
     sink.maybeResolveHstoreType(connection);
-    assertTrue("the retry should resolve", sink.hstoreTypeResolved);
+    assertTrue("the retry should resolve", sink.hstoreType.isResolved());
     verify(statement, times(2)).executeQuery("SELECT to_regtype('hstore') IS NOT NULL");
   }
 
@@ -1373,8 +1372,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldRaiseAMissingHstoreExtensionAsConnectException() {
     PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-    sink.hstoreTypeName = null;
-    sink.hstoreTypeResolved = true;
+    sink.hstoreType = PostgreSqlDatabaseDialect.HstoreType.ABSENT;
     ConnectException e = assertThrows(ConnectException.class,
         () -> sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
     assertEquals("a missing extension must not carry the DDL exception",
@@ -1399,8 +1397,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldFailWhenTheHstoreExtensionIsNotInstalled() {
     PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-    sink.hstoreTypeName = null;
-    sink.hstoreTypeResolved = true;
+    sink.hstoreType = PostgreSqlDatabaseDialect.HstoreType.ABSENT;
 
     ConnectException thrown = assertThrows(ConnectException.class, () -> sink.getSqlType(
         new SinkRecordField(stringToStringMap(), "tags", false)));
@@ -1515,7 +1512,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldAssumeTheBareHstoreTypeNameWhileUnresolved() {
     PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-    assertFalse("precondition: nothing has been resolved yet", sink.hstoreTypeResolved);
+    assertFalse("precondition: nothing has been read yet", sink.hstoreType.isResolved());
 
     assertEquals("hstore",
         sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -22,7 +22,6 @@ import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
-import io.confluent.connect.jdbc.util.HstoreConverter;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
@@ -1257,98 +1256,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         new PostgreSqlDatabaseDialect(sinkConfigWithUrl("jdbc:postgresql://something"));
     assertThrows(ConnectException.class,
         () -> disabled.bindField(mock(PreparedStatement.class), 1, schema, value));
-  }
-
-  /**
-   * The hstore text form the bind produces. Everything is quoted, so a delimiter inside a key or
-   * value is inert and the string {@code NULL} stays distinct from a NULL value.
-   */
-  @Test
-  public void shouldSerializeMapsToHstoreText() {
-    Map<String, String> map = new LinkedHashMap<>();
-    map.put("env", "prod");
-    map.put("absent", null);
-    map.put("literal", "NULL");
-    map.put("a=>b", "c,d");
-    map.put("say \"hi\"", "back\\slash");
-
-    assertEquals("\"env\"=>\"prod\",\"absent\"=>NULL,\"literal\"=>\"NULL\","
-            + "\"a=>b\"=>\"c,d\",\"say \\\"hi\\\"\"=>\"back\\\\slash\"",
-        HstoreConverter.connectMapToHstore(map));
-
-    assertEquals("", HstoreConverter.connectMapToHstore(Collections.emptyMap()));
-    assertNull(HstoreConverter.connectMapToHstore(null));
-  }
-
-  /**
-   * The text form the driver hands back for an hstore it could not resolve. Quoting makes the
-   * delimiters inert, and a bare NULL is a null value while a quoted one is the string.
-   */
-  @Test
-  public void shouldParseHstoreText() {
-    Map<String, String> expected = new LinkedHashMap<>();
-    expected.put("env", "prod");
-    expected.put("absent", null);
-    expected.put("literal", "NULL");
-    expected.put("a=>b", "c,d");
-    expected.put("say \"hi\"", "back\\slash");
-
-    // PostgreSQL renders pairs separated by ", " and escapes quotes and backslashes.
-    assertEquals(expected, HstoreConverter.hstoreToConnectMap(
-        "\"env\"=>\"prod\", \"absent\"=>NULL, \"literal\"=>\"NULL\", "
-            + "\"a=>b\"=>\"c,d\", \"say \\\"hi\\\"\"=>\"back\\\\slash\""));
-
-    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap(""));
-    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap("   "));
-    assertNull(HstoreConverter.hstoreToConnectMap(null));
-  }
-
-  /** Whatever the serializer writes, the parser must read back identically. */
-  @Test
-  public void shouldRoundTripHstoreTextThroughBothDirections() {
-    Map<String, String> original = new LinkedHashMap<>();
-    original.put("env", "prod");
-    original.put("absent", null);
-    original.put("literal", "NULL");
-    original.put("a=>b", "c,d");
-    original.put("say \"hi\"", "back\\slash");
-    original.put("key 2", " ##123 78");
-    original.put("empty", "");
-
-    assertEquals(original, HstoreConverter.hstoreToConnectMap(
-        HstoreConverter.connectMapToHstore(original)));
-    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap(
-        HstoreConverter.connectMapToHstore(Collections.emptyMap())));
-  }
-
-  @Test
-  public void shouldRejectMalformedHstoreText() {
-    for (String malformed : new String[]{
-        "not hstore at all",          // no => at all
-        "\"k\"",                      // key with no value
-        "\"k\"=>",                    // separator with no value
-        "\"k\"=>\"unterminated",      // unclosed quote
-        "\"a\"=>\"1\" \"b\"=>\"2\"",     // missing comma between pairs
-        "a=>1",                       // unquoted: hstore_out always quotes, so this is not ours
-        "\"a\"=>1",                   // unquoted value, likewise
-        "\"a\"=>null"                 // lowercase null is the string, never the NULL literal
-    }) {
-      assertThrows("should reject: " + malformed, DataException.class,
-          () -> HstoreConverter.hstoreToConnectMap(malformed));
-    }
-  }
-
-  @Test
-  public void shouldRejectValuesThatAreNotStringMaps() {
-    assertThrows(DataException.class, () -> HstoreConverter.connectMapToHstore("not a map"));
-    assertThrows(DataException.class,
-        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(null, "v")));
-    // A non-String key or value fails rather than being coerced through toString, so a schema and
-    // value that disagree surface here instead of silently reaching the database.
-    assertThrows(DataException.class,
-        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap("k", 1)));
-    assertThrows(DataException.class,
-        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(1, "v")));
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1521,15 +1521,36 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   /** An hstore column off the search_path is reported qualified and must be cast by that name. */
   @Test
   public void shouldCastHstoreColumnsByTheirReportedTypeName() {
+    PostgreSqlDatabaseDialect enabled = complexTypesSinkDialect();
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("plain").type("hstore", JDBCType.OTHER, Object.class);
     builder.withColumn("qualified").type("\"ext\".\"hstore\"", JDBCType.OTHER, Object.class);
     TableDefinition tableDefn = builder.build();
 
     assertEquals("::hstore",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("plain").id()));
+        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("plain").id()));
     assertEquals("::\"ext\".\"hstore\"",
+        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("qualified").id()));
+  }
+
+  /**
+   * The cast is behind the flag like the rest of the feature, so with it off an hstore column gets
+   * none and PostgreSQL rejects the uncast parameter exactly as it did before the feature. The
+   * built-in cast types are untouched, since those pre-date it.
+   */
+  @Test
+  public void shouldNotCastHstoreColumnsWhenComplexTypesDisabled() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("plain").type("hstore", JDBCType.OTHER, Object.class);
+    builder.withColumn("qualified").type("\"ext\".\"hstore\"", JDBCType.OTHER, Object.class);
+    builder.withColumn("u").type("uuid", JDBCType.OTHER, Object.class);
+    TableDefinition tableDefn = builder.build();
+
+    assertEquals("", dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("plain").id()));
+    assertEquals("",
         dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("qualified").id()));
+    assertEquals("a pre-feature cast type must still be cast with the flag off", "::uuid",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("u").id()));
   }
 
   /** pgjdbc leaves embedded quotes unescaped, so the cast must requote the reported name. */
@@ -1540,7 +1561,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     TableDefinition tableDefn = builder.build();
 
     assertEquals("::\"e\"\"x\".\"hstore\"",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("hs").id()));
+        complexTypesSinkDialect().valueTypeCast(
+            tableDefn, tableDefn.definitionForColumn("hs").id()));
   }
 
   private Schema stringToStringMap() {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1454,12 +1454,12 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   /**
-   * Both refusals must be {@link TableAlterOrCreateException}: that is what the writer rolls the
-   * batch back on and what the task routes to a reporter, so a plain ConnectException would leak
-   * an open transaction and bypass the DLQ.
+   * A missing extension surfaces from {@code getSqlType} while the table is being built, so it
+   * keeps {@link TableAlterOrCreateException}: the writer rolls back and unrolls, which can still
+   * place the records that do not need the column.
    */
   @Test
-  public void shouldRaiseHstoreRefusalsAsTableAlterOrCreate() {
+  public void shouldRaiseAMissingHstoreExtensionAsTableAlterOrCreate() {
     PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
     sink.hstoreTypeName = null;
@@ -1467,15 +1467,25 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertThrows("a missing extension must roll back and be reportable",
         TableAlterOrCreateException.class,
         () -> sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
+  }
 
+  /**
+   * A wrong column type is refused at bind time, where the mismatch holds for every record, so it
+   * fails the task as any unbindable value does instead of inheriting the DDL unroll. Asserted on
+   * the exact class: {@link TableAlterOrCreateException} would also satisfy a ConnectException
+   * check, leaving a regression to the DDL type invisible.
+   */
+  @Test
+  public void shouldRaiseAWrongHstoreColumnTypeAsConnectException() {
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("t");
     builder.withColumn("tags").type("jsonb", JDBCType.OTHER, Object.class);
     TableDefinition tableDefn = builder.build();
-    assertThrows("a wrong column type must roll back and be reportable",
-        TableAlterOrCreateException.class,
+    ConnectException e = assertThrows(ConnectException.class,
         () -> sinkDialect().bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
             Collections.singletonMap("k", "v"),
             tableDefn.definitionForColumn("tags"), "tags"));
+    assertEquals("a bind refusal must not carry the DDL exception",
+        ConnectException.class, e.getClass());
   }
 
   /** Selected but unavailable must fail, naming the field and how to install the extension. */
@@ -1515,16 +1525,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     ConnectException thrown = assertThrows(ConnectException.class,
         () -> sink.bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
             Collections.singletonMap("env", "prod"), columnOfType("jsonb"), "tags"));
-    assertTrue("must name the field, but was: " + thrown.getMessage(),
-        thrown.getMessage().contains("tags"));
-    assertTrue("must name the column type, but was: " + thrown.getMessage(),
-        thrown.getMessage().contains("jsonb"));
-
-    // The array element type is checked the same way.
-    assertThrows(ConnectException.class,
-        () -> sink.bindField(mock(PreparedStatement.class), 1, arraySchema(stringToStringMap()),
-            Collections.singletonList(Collections.singletonMap("env", "prod")),
-            columnOfType("_jsonb"), "tags"));
+    assertEquals("Cannot write field tags as hstore: column type is jsonb, not hstore. "
+            + "Recreate the column as hstore, or set sql.complex.types.enable=false.",
+        thrown.getMessage());
 
     // An hstore column is accepted, wherever the extension lives.
     for (String hstore : new String[]{"hstore", "\"ext\".\"hstore\""}) {
@@ -1532,10 +1535,60 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     }
   }
 
+  /**
+   * The array branch must name {@code hstore[]}, not pgjdbc's internal {@code _hstore}. This
+   * dialect writes maps to native hstore where an earlier build wrote jsonb, so an upgrade over an
+   * existing {@code jsonb[]} column lands here — and a remediation reading "recreate the column as
+   * hstore" would produce a scalar that fails the very next batch.
+   */
+  @Test
+  public void shouldNameTheArrayFormWhenRefusingAnHstoreArrayColumn() {
+    PostgreSqlDatabaseDialect sink = complexTypesSinkDialect();
+
+    ConnectException thrown = assertThrows(ConnectException.class,
+        () -> sink.bindField(mock(PreparedStatement.class), 1, arraySchema(stringToStringMap()),
+            Collections.singletonList(Collections.singletonMap("env", "prod")),
+            columnOfType("_jsonb"), "tags"));
+    assertEquals("Cannot write field tags as hstore: column type is jsonb[], not hstore[]. "
+            + "Recreate the column as hstore[], or set sql.complex.types.enable=false.",
+        thrown.getMessage());
+
+    // An hstore[] column is accepted, wherever the extension lives.
+    for (String hstoreArray : new String[]{"_hstore", "\"ext\".\"_hstore\""}) {
+      sinkBindMapArray(sink, hstoreArray);
+    }
+  }
+
+  /** A non-array column reported without the prefix is named as-is, with no {@code []} appended. */
+  @Test
+  public void shouldNameANonArrayColumnWithoutAnArraySuffix() {
+    PostgreSqlDatabaseDialect sink = complexTypesSinkDialect();
+
+    ConnectException thrown = assertThrows(ConnectException.class,
+        () -> sink.bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
+            Collections.singletonMap("env", "prod"), columnOfType("\"ext\".\"text\""), "tags"));
+    assertFalse("a scalar column must not be reported as an array: " + thrown.getMessage(),
+        thrown.getMessage().contains("[]"));
+  }
+
   private void sinkBindMap(PostgreSqlDatabaseDialect sink, String columnType) {
     try {
       sink.bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
           Collections.singletonMap("env", "prod"), columnOfType(columnType), "tags");
+    } catch (SQLException e) {
+      throw new AssertionError("binding into a " + columnType + " column should succeed", e);
+    }
+  }
+
+  private void sinkBindMapArray(PostgreSqlDatabaseDialect sink, String columnType) {
+    try {
+      PreparedStatement statement = mock(PreparedStatement.class);
+      Connection connection = mock(Connection.class);
+      when(statement.getConnection()).thenReturn(connection);
+      when(connection.createArrayOf(any(), any())).thenReturn(mock(Array.class));
+      sink.bindField(statement, 1, arraySchema(stringToStringMap()),
+          Collections.singletonList(Collections.singletonMap("env", "prod")),
+          columnOfType(columnType), "tags");
     } catch (SQLException e) {
       throw new AssertionError("binding into a " + columnType + " column should succeed", e);
     }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.dialect;
 
 import io.confluent.connect.jdbc.data.Json;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.TableAlterOrCreateException;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
@@ -999,7 +1000,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void shouldRejectMapShapesOtherThanStringToString() {
-    // Only MAP<STRING,STRING> — the shape hstore produces — maps to JSONB. Every other map shape
+    // Only MAP<STRING,STRING> — the shape hstore produces — maps to hstore. Every other map shape
     // must fall through to the generic dialect and fail rather than silently become jsonb.
     List<Schema> unsupported = Arrays.asList(
         SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).optional().build(),
@@ -1399,10 +1400,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
    * unresolved, so the bare name is assumed rather than the extension reported as missing.
    */
   @Test
-  public void shouldNotRetryTheHstoreLookupAfterACatalogFailure() throws Exception {
+  public void shouldRetryTheHstoreLookupAfterACatalogFailure() throws Exception {
+    ResultSet resolved = mock(ResultSet.class);
+    when(resolved.next()).thenReturn(true);
+    when(resolved.getBoolean(1)).thenReturn(true);
+
     Statement statement = mock(Statement.class);
-    when(statement.executeQuery(any(String.class)))
-        .thenThrow(new SQLException("permission denied for table pg_extension"));
+    when(statement.executeQuery("SELECT to_regtype('hstore') IS NOT NULL"))
+        .thenThrow(new SQLException("permission denied for table pg_extension"))
+        .thenReturn(resolved);
     Connection connection = mock(Connection.class);
     when(connection.createStatement()).thenReturn(statement);
 
@@ -1410,12 +1416,66 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
 
     sink.maybeResolveHstoreType(connection);
-    sink.maybeResolveHstoreType(connection);
-
     assertFalse("a failed read is not a resolution", sink.hstoreTypeResolved);
     assertEquals("the bare name is assumed while unresolved", "hstore",
         sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
-    verify(statement, times(1)).executeQuery("SELECT to_regtype('hstore') IS NOT NULL");
+
+    // The next connection retries, so a transient failure heals.
+    sink.maybeResolveHstoreType(connection);
+    assertTrue("the retry should resolve", sink.hstoreTypeResolved);
+    verify(statement, times(2)).executeQuery("SELECT to_regtype('hstore') IS NOT NULL");
+  }
+
+  /**
+   * An unparseable array element degrades to null, as the scalar path does for an optional column,
+   * rather than failing the whole source task on one bad element.
+   */
+  @Test
+  public void shouldEmitNullForAnUnparseableHstoreArrayElement() throws Exception {
+    PostgreSqlDatabaseDialect dialect = complexTypesDialect(
+        JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "map");
+    ColumnDefinition column = column(Types.ARRAY, "_hstore");
+    ColumnMapping mapping = new ColumnMapping(
+        column, 1, new Field("col", 0, arraySchema(stringToStringMap())));
+    DatabaseDialect.ColumnConverter converter =
+        dialect.columnConverterFor(mapping, column, 1, true);
+    assertNotNull(converter);
+
+    ResultSet resultSet = mock(ResultSet.class);
+    Array array = mock(Array.class);
+    ResultSet elementRs = mock(ResultSet.class);
+    when(resultSet.getArray(1)).thenReturn(array);
+    when(array.getArray()).thenReturn(new Object[]{"not hstore at all"});
+    when(array.getResultSet()).thenReturn(elementRs);
+    when(elementRs.next()).thenReturn(true, false);
+    when(elementRs.getObject(2)).thenReturn("not hstore at all");
+
+    assertEquals(Collections.singletonList(null), converter.convert(resultSet));
+  }
+
+  /**
+   * Both refusals must be {@link TableAlterOrCreateException}: that is what the writer rolls the
+   * batch back on and what the task routes to a reporter, so a plain ConnectException would leak
+   * an open transaction and bypass the DLQ.
+   */
+  @Test
+  public void shouldRaiseHstoreRefusalsAsTableAlterOrCreate() {
+    PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
+        "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+    sink.hstoreTypeName = null;
+    sink.hstoreTypeResolved = true;
+    assertThrows("a missing extension must roll back and be reportable",
+        TableAlterOrCreateException.class,
+        () -> sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
+
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("t");
+    builder.withColumn("tags").type("jsonb", JDBCType.OTHER, Object.class);
+    TableDefinition tableDefn = builder.build();
+    assertThrows("a wrong column type must roll back and be reportable",
+        TableAlterOrCreateException.class,
+        () -> sinkDialect().bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
+            Collections.singletonMap("k", "v"),
+            tableDefn.definitionForColumn("tags"), "tags"));
   }
 
   /** Selected but unavailable must fail, naming the field and how to install the extension. */
@@ -1514,6 +1574,17 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("plain").id()));
     assertEquals("::\"ext\".\"hstore\"",
         dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("qualified").id()));
+  }
+
+  /** pgjdbc leaves embedded quotes unescaped, so the cast must requote the reported name. */
+  @Test
+  public void shouldRequoteAnHstoreTypeNameTheDriverLeftUnescaped() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("hs").type("\"e\"x\".\"hstore\"", JDBCType.OTHER, Object.class);
+    TableDefinition tableDefn = builder.build();
+
+    assertEquals("::\"e\"\"x\".\"hstore\"",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("hs").id()));
   }
 
   private Schema stringToStringMap() {

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -932,8 +932,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void offSearchPathHstoreIsSkippedWhenHandlingModeIsNone() {
-    // An operator who asked for none must not be failed over a type they chose to ignore, so the
-    // column is simply skipped. Also holds when the feature flag itself is off.
+    // none means skip, wherever the extension lives. Also holds when the feature flag itself is off.
     assertNull(sourceFieldSchema(
         hstoreDialect("true", "none"), Types.OTHER, "\"ext\".\"hstore\""));
     assertNull(sourceFieldSchema(
@@ -948,22 +947,40 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertNull(sourceFieldSchema(disabled, Types.OTHER, "hstore"));
   }
 
+  /**
+   * The raw text form is what the driver returns for an hstore it could not resolve, so it is valid
+   * input and must decode to the same map a resolved column would give.
+   */
   @Test
-  public void hstoreValueThatIsNotAMapShouldFollowColumnNullability() throws Exception {
-    // Defence in depth for any non-Map shape the driver might hand back. Off the search_path the
-    // type name is qualified, so the column is skipped before this runs; whatever else could reach
-    // here has no known cause. Follows Debezium's handleUnknownData: a nullable column degrades to
-    // null, a NOT NULL column fails because null would breach its schema anyway.
-    ResultSet rawText = hstoreResultSet("\"env\"=>\"prod\"");
+  public void hstoreRawTextShouldDecodeLikeADriverMap() throws Exception {
+    ResultSet rawText = hstoreResultSet("\"env\"=>\"prod\", \"absent\"=>NULL");
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("env", "prod");
+    expected.put("absent", null);
+
+    assertEquals(expected, hstoreConverter(hstoreDialect("true", "map")).convert(rawText));
+    assertEquals("{\"env\":\"prod\",\"absent\":null}",
+        hstoreConverter(jsonHstoreDialect()).convert(hstoreResultSet(
+            "\"env\"=>\"prod\", \"absent\"=>NULL")));
+  }
+
+  /**
+   * Anything that is neither a map nor parseable hstore text follows Debezium's handleUnknownData:
+   * a nullable column degrades to null, a NOT NULL column fails because null would breach its
+   * schema anyway.
+   */
+  @Test
+  public void hstoreValueThatIsNotParseableShouldFollowColumnNullability() throws Exception {
+    ResultSet garbage = hstoreResultSet("not hstore at all");
 
     PostgreSqlDatabaseDialect jsonDialect = complexTypesDialect(
         JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "json");
 
     for (PostgreSqlDatabaseDialect dialect : Arrays.asList(hstoreDialect("true", "map"), jsonDialect)) {
-      assertNull(hstoreConverter(dialect, ColumnDefinition.Nullability.NULL).convert(rawText));
+      assertNull(hstoreConverter(dialect, ColumnDefinition.Nullability.NULL).convert(garbage));
 
       DataException e = assertThrows(DataException.class, () ->
-          hstoreConverter(dialect, ColumnDefinition.Nullability.NOT_NULL).convert(rawText));
+          hstoreConverter(dialect, ColumnDefinition.Nullability.NOT_NULL).convert(garbage));
       assertTrue(e.getMessage().contains("hstore"));
     }
   }
@@ -1011,18 +1028,18 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         mock(PreparedStatement.class), 1, intKeyed, Collections.singletonMap(1, "v")));
   }
 
+  /**
+   * An hstore installed outside the search_path is reported schema-qualified, and is mapped exactly
+   * as a bare one — the extension's location is not the operator's problem. Any schema qualifies.
+   */
   @Test
-  public void offSearchPathHstoreFailsWhenAMappingModeIsSelected() {
-    // A mapping mode was asked for and this column cannot honour it, so the task fails rather than
-    // silently dropping the column. The message has to carry the remedy, since it is what an
-    // operator sees.
-    ConnectException e = assertThrows(ConnectException.class,
-        () -> sourceFieldSchema(hstoreDialect("true", "map"), Types.OTHER, "\"ext\".\"hstore\""));
-    assertTrue("must name the cause", e.getMessage().contains("search_path"));
-    assertTrue("must offer the escape hatch", e.getMessage().contains("hstore.handling.mode=none"));
-
-    assertThrows("json mode must fail the same way", ConnectException.class,
-        () -> sourceFieldSchema(hstoreDialect("true", "json"), Types.OTHER, "\"ext\".\"hstore\""));
+  public void offSearchPathHstoreIsMappedInEveryMode() {
+    for (String qualified : new String[]{"\"ext\".\"hstore\"", "\"my_extensions\".\"hstore\""}) {
+      assertEquals(hstoreDialect("true", "map").hstoreSchema(true),
+          sourceFieldSchema(hstoreDialect("true", "map"), Types.OTHER, qualified));
+      assertEquals(Json.optionalSchema(),
+          sourceFieldSchema(hstoreDialect("true", "json"), Types.OTHER, qualified));
+    }
   }
 
   @Test
@@ -1143,16 +1160,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
-  public void shouldRecogniseAnOffSearchPathHstoreTypeName() {
-    // Shared by the scalar column path (#1661) and the array element path (#1662): pgjdbc qualifies
-    // the name only when the extension is off the search_path, whatever the schema is called.
-    assertTrue(PostgreSqlDatabaseDialect.isUnresolvedHstoreType("\"ext\".\"hstore\""));
-    assertTrue(PostgreSqlDatabaseDialect.isUnresolvedHstoreType("\"my_extensions\".\"hstore\""));
-    assertFalse("on the search_path it arrives bare",
-        PostgreSqlDatabaseDialect.isUnresolvedHstoreType("hstore"));
-    assertFalse(PostgreSqlDatabaseDialect.isUnresolvedHstoreType("\"ext\".\"citext\""));
-    assertFalse(PostgreSqlDatabaseDialect.isUnresolvedHstoreType("hstore_extra"));
-    assertFalse(PostgreSqlDatabaseDialect.isUnresolvedHstoreType(null));
+  public void shouldRecogniseAnHstoreTypeInAnySchema() {
+    // pgjdbc reports the type bare while its schema is on the search_path and qualified otherwise;
+    // both are the same type, so both must be recognised, whatever the schema is called.
+    PostgreSqlDatabaseDialect dialect = hstoreDialect("true", "map");
+    assertTrue(dialect.isHstoreType(column(Types.OTHER, "hstore")));
+    assertTrue(dialect.isHstoreType(column(Types.OTHER, "\"ext\".\"hstore\"")));
+    assertTrue(dialect.isHstoreType(column(Types.OTHER, "\"my_extensions\".\"hstore\"")));
+    assertFalse(dialect.isHstoreType(column(Types.OTHER, "\"ext\".\"citext\"")));
+    assertFalse(dialect.isHstoreType(column(Types.OTHER, "hstore_extra")));
 
     // The array type is its own pg_type row in the same schema, so it qualifies the same way.
     assertEquals("_hstore", PostgreSqlDatabaseDialect.localTypeName("\"ext\".\"_hstore\""));
@@ -1261,6 +1277,64 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertNull(HstoreConverter.connectMapToHstore(null));
   }
 
+  /**
+   * The text form the driver hands back for an hstore it could not resolve. Quoting makes the
+   * delimiters inert, and a bare NULL is a null value while a quoted one is the string.
+   */
+  @Test
+  public void shouldParseHstoreText() {
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("env", "prod");
+    expected.put("absent", null);
+    expected.put("literal", "NULL");
+    expected.put("a=>b", "c,d");
+    expected.put("say \"hi\"", "back\\slash");
+
+    // PostgreSQL renders pairs separated by ", " and escapes quotes and backslashes.
+    assertEquals(expected, HstoreConverter.hstoreToConnectMap(
+        "\"env\"=>\"prod\", \"absent\"=>NULL, \"literal\"=>\"NULL\", "
+            + "\"a=>b\"=>\"c,d\", \"say \\\"hi\\\"\"=>\"back\\\\slash\""));
+
+    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap(""));
+    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap("   "));
+    assertNull(HstoreConverter.hstoreToConnectMap(null));
+  }
+
+  /** Whatever the serializer writes, the parser must read back identically. */
+  @Test
+  public void shouldRoundTripHstoreTextThroughBothDirections() {
+    Map<String, String> original = new LinkedHashMap<>();
+    original.put("env", "prod");
+    original.put("absent", null);
+    original.put("literal", "NULL");
+    original.put("a=>b", "c,d");
+    original.put("say \"hi\"", "back\\slash");
+    original.put("key 2", " ##123 78");
+    original.put("empty", "");
+
+    assertEquals(original, HstoreConverter.hstoreToConnectMap(
+        HstoreConverter.connectMapToHstore(original)));
+    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap(
+        HstoreConverter.connectMapToHstore(Collections.emptyMap())));
+  }
+
+  @Test
+  public void shouldRejectMalformedHstoreText() {
+    for (String malformed : new String[]{
+        "not hstore at all",          // no => at all
+        "\"k\"",                      // key with no value
+        "\"k\"=>",                    // separator with no value
+        "\"k\"=>\"unterminated",      // unclosed quote
+        "\"a\"=>\"1\" \"b\"=>\"2\"",     // missing comma between pairs
+        "a=>1",                       // unquoted: hstore_out always quotes, so this is not ours
+        "\"a\"=>1",                   // unquoted value, likewise
+        "\"a\"=>null"                 // lowercase null is the string, never the NULL literal
+    }) {
+      assertThrows("should reject: " + malformed, DataException.class,
+          () -> HstoreConverter.hstoreToConnectMap(malformed));
+    }
+  }
+
   @Test
   public void shouldRejectValuesThatAreNotStringMaps() {
     assertThrows(DataException.class, () -> HstoreConverter.connectMapToHstore("not a map"));
@@ -1308,6 +1382,50 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             mock(ColumnDefinition.class), "tags"));
     assertTrue("array message should name the field, but was: " + fromArray.getMessage(),
         fromArray.getMessage().contains("tags"));
+  }
+
+  /**
+   * A map is written as hstore text, so an existing column of any other type must be refused before
+   * the bind. Otherwise the statement carries that column's cast and PostgreSQL reports a syntax
+   * error that never mentions hstore.
+   */
+  @Test
+  public void shouldRefuseAMapBoundIntoANonHstoreColumn() {
+    PostgreSqlDatabaseDialect sink = complexTypesSinkDialect();
+
+    ConnectException thrown = assertThrows(ConnectException.class,
+        () -> sink.bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
+            Collections.singletonMap("env", "prod"), columnOfType("jsonb"), "tags"));
+    assertTrue("must name the field, but was: " + thrown.getMessage(),
+        thrown.getMessage().contains("tags"));
+    assertTrue("must name the column type, but was: " + thrown.getMessage(),
+        thrown.getMessage().contains("jsonb"));
+
+    // The array element type is checked the same way.
+    assertThrows(ConnectException.class,
+        () -> sink.bindField(mock(PreparedStatement.class), 1, arraySchema(stringToStringMap()),
+            Collections.singletonList(Collections.singletonMap("env", "prod")),
+            columnOfType("_jsonb"), "tags"));
+
+    // An hstore column is accepted, wherever the extension lives.
+    for (String hstore : new String[]{"hstore", "\"ext\".\"hstore\""}) {
+      sinkBindMap(sink, hstore);
+    }
+  }
+
+  private void sinkBindMap(PostgreSqlDatabaseDialect sink, String columnType) {
+    try {
+      sink.bindField(mock(PreparedStatement.class), 1, stringToStringMap(),
+          Collections.singletonMap("env", "prod"), columnOfType(columnType), "tags");
+    } catch (SQLException e) {
+      throw new AssertionError("binding into a " + columnType + " column should succeed", e);
+    }
+  }
+
+  private ColumnDefinition columnOfType(String typeName) {
+    ColumnDefinition colDef = mock(ColumnDefinition.class);
+    when(colDef.typeName()).thenReturn(typeName);
+    return colDef;
   }
 
   /**
@@ -1868,15 +1986,18 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertNull(sourceFieldSchema(disabled, Types.ARRAY, "_hstore"));
   }
 
+  /**
+   * The array type is its own pg_type row in the same schema, so it is qualified exactly as the
+   * scalar type is, and is mapped the same way.
+   */
   @Test
-  public void offSearchPathHstoreArrayFailsWhenAMappingModeIsSelected() {
-    // The array type is its own pg_type row in the same schema, so it is qualified exactly as the
-    // scalar type is; hstore[] must therefore fail the task rather than vanish, as hstore does.
+  public void offSearchPathHstoreArrayIsMappedInEveryMode() {
     for (String mode : new String[]{"map", "json"}) {
-      ConnectException e = assertThrows(mode + " must fail", ConnectException.class,
-          () -> sourceFieldSchema(
-              hstoreDialect("true", mode), Types.ARRAY, "\"ext\".\"_hstore\""));
-      assertTrue("must name the cause", e.getMessage().contains("search_path"));
+      Schema schema = sourceFieldSchema(
+          hstoreDialect("true", mode), Types.ARRAY, "\"ext\".\"_hstore\"");
+      assertNotNull(mode + " must map the column", schema);
+      assertEquals(Type.ARRAY, schema.type());
+      assertEquals(hstoreDialect("true", mode).hstoreSchema(true), schema.valueSchema());
     }
 
     // none stays the escape hatch, and an unrelated array element type is untouched.

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1454,27 +1454,26 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   /**
-   * A missing extension surfaces from {@code getSqlType} while the table is being built, so it
-   * keeps {@link TableAlterOrCreateException}: the writer rolls back and unrolls, which can still
-   * place the records that do not need the column.
+   * Neither hstore refusal is a DDL failure, so neither carries {@link TableAlterOrCreateException}
+   * and its batch-splitting handling. A missing extension is a property of the database and a wrong
+   * column type holds for every record, so no split can find a record that fits: both fail the task
+   * as {@link GenericDatabaseDialect} does for any value it cannot bind.
+   *
+   * <p>Both assert the exact class. {@code TableAlterOrCreateException} extends ConnectException, so
+   * a subclass check would pass either way and leave a regression to the DDL type invisible.
    */
   @Test
-  public void shouldRaiseAMissingHstoreExtensionAsTableAlterOrCreate() {
+  public void shouldRaiseAMissingHstoreExtensionAsConnectException() {
     PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
     sink.hstoreTypeName = null;
     sink.hstoreTypeResolved = true;
-    assertThrows("a missing extension must roll back and be reportable",
-        TableAlterOrCreateException.class,
+    ConnectException e = assertThrows(ConnectException.class,
         () -> sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
+    assertEquals("a missing extension must not carry the DDL exception",
+        ConnectException.class, e.getClass());
   }
 
-  /**
-   * A wrong column type is refused at bind time, where the mismatch holds for every record, so it
-   * fails the task as any unbindable value does instead of inheriting the DDL unroll. Asserted on
-   * the exact class: {@link TableAlterOrCreateException} would also satisfy a ConnectException
-   * check, leaving a regression to the DDL type invisible.
-   */
   @Test
   public void shouldRaiseAWrongHstoreColumnTypeAsConnectException() {
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("t");

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1299,6 +1299,30 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         thrown.getMessage().contains("tags"));
     assertTrue("message should say how to install it, but was: " + thrown.getMessage(),
         thrown.getMessage().contains("CREATE EXTENSION hstore"));
+
+    // An array element fails the same way, and must name its column rather than "a map value".
+    ConnectException fromArray = assertThrows(ConnectException.class,
+        () -> sink.bindField(mock(PreparedStatement.class), 1,
+            arraySchema(stringToStringMap()), Collections.singletonList(
+                Collections.singletonMap("env", "prod")),
+            mock(ColumnDefinition.class), "tags"));
+    assertTrue("array message should name the field, but was: " + fromArray.getMessage(),
+        fromArray.getMessage().contains("tags"));
+  }
+
+  /**
+   * Unresolved is not the same as absent. Before a connection exists, or after a catalog read
+   * failed, the bare type name is assumed rather than reporting the extension as missing — which
+   * would name the wrong cause and fail a write that PostgreSQL might well accept.
+   */
+  @Test
+  public void shouldAssumeTheBareHstoreTypeNameWhileUnresolved() {
+    PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
+        "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+    assertFalse("precondition: nothing has been resolved yet", sink.hstoreTypeResolved);
+
+    assertEquals("hstore",
+        sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
   }
 
   /** An hstore column off the search_path is reported qualified and must be cast by that name. */

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -21,6 +21,7 @@ import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.HstoreConverter;
 import io.confluent.connect.jdbc.util.ColumnId;
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableDefinition;
@@ -865,9 +866,11 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Test
   public void hstoreSourceSchemaShouldMapToSinkSqlTypePerMode() {
     // Starts from the schema the source path actually produces for an hstore column, so this
-    // exercises hstoreSchema() rather than re-asserting generic MAP/STRING behaviour.
+    // exercises hstoreSchema() rather than re-asserting generic MAP/STRING behaviour. The two
+    // modes deliberately land in different columns, matching Debezium: a map is hstore, while a
+    // Json string is a JSON document that happens to have come from hstore.
     Schema mapMode = sourceFieldSchema(hstoreDialect("true", "map"), Types.OTHER, "hstore");
-    assertEquals("JSONB", sinkDialect().getSqlType(sinkField(mapMode)));
+    assertEquals("hstore", sinkDialect().getSqlType(sinkField(mapMode)));
 
     PostgreSqlDatabaseDialect jsonDialect = complexTypesDialect(
         JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "json");
@@ -876,8 +879,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
-  public void shouldBindStringMapAsJsonTextForJsonbColumn() throws SQLException {
-    // The value half of MAP -> JSONB: the map is serialized and bound as text, which the ::jsonb
+  public void shouldBindStringMapAsHstoreTextForHstoreColumn() throws SQLException {
+    // The value half of MAP -> hstore: the map is serialized and bound as text, which the ::hstore
     // cast then parses server-side. Only the DDL half was covered before.
     Map<String, String> value = new LinkedHashMap<>();
     value.put("env", "prod");
@@ -887,9 +890,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     PreparedStatement statement = mock(PreparedStatement.class);
     sinkDialect().bindField(statement, 1, schema, value);
-    verify(statement).setString(1, "{\"env\":\"prod\",\"absent\":null}");
+    verify(statement).setString(1, "\"env\"=>\"prod\",\"absent\"=>NULL");
 
-    // A null map never reaches maybeBindJson: bindFieldInternal short-circuits nulls before
+    // A null map never reaches maybeBindHstore: bindFieldInternal short-circuits nulls before
     // maybeBindPrimitive, so the generic null path binds it.
     PreparedStatement nullStatement = mock(PreparedStatement.class);
     sinkDialect().bindField(nullStatement, 1, schema, null);
@@ -899,7 +902,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   @Test
   public void shouldBindJsonStringAsTextForJsonbColumn() throws SQLException {
     // The bind half for json mode: a Json-tagged STRING is not a string-to-string map, so
-    // maybeBindJson declines and it binds as text — the ::jsonb cast parses it server-side.
+    // maybeBindHstore declines and it binds as text — the ::jsonb cast parses it server-side.
     PreparedStatement statement = mock(PreparedStatement.class);
     sinkDialect().bindField(statement, 1, Json.optionalSchema(), "{\"env\":\"prod\"}");
     verify(statement).setString(1, "{\"env\":\"prod\"}");
@@ -1202,12 +1205,12 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
-  public void shouldMapStringToStringMapToJsonbOnlyWhenComplexTypesEnabled() {
+  public void shouldMapStringToStringMapToHstoreOnlyWhenComplexTypesEnabled() {
     SinkRecordField field = new SinkRecordField(stringToStringMap(), "col", false);
 
     PostgreSqlDatabaseDialect enabled = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-    assertEquals("JSONB", enabled.getSqlType(field));
+    assertEquals("hstore", enabled.getSqlType(field));
 
     // Without the flag the generic dialect fails at DDL time rather than inventing a column type,
     // which is what makes forgetting the flag on the sink a loud error.
@@ -1217,24 +1220,99 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
-  public void shouldBindStringToStringMapAsJsonbTextOnlyWhenComplexTypesEnabled()
+  public void shouldBindStringToStringMapAsHstoreTextOnlyWhenComplexTypesEnabled()
       throws SQLException {
     Schema schema = stringToStringMap();
     Map<String, String> value = new LinkedHashMap<>();
     value.put("env", "prod");
     value.put("absent", null);
 
-    // Serialized and bound as text; the ::jsonb cast from valueTypeCast parses it server-side.
+    // Serialized and bound as text; the ::hstore cast from valueTypeCast parses it server-side.
     PreparedStatement statement = mock(PreparedStatement.class);
     new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"))
         .bindField(statement, 1, schema, value);
-    verify(statement).setString(1, "{\"env\":\"prod\",\"absent\":null}");
+    verify(statement).setString(1, "\"env\"=>\"prod\",\"absent\"=>NULL");
 
     PostgreSqlDatabaseDialect disabled =
         new PostgreSqlDatabaseDialect(sinkConfigWithUrl("jdbc:postgresql://something"));
     assertThrows(ConnectException.class,
         () -> disabled.bindField(mock(PreparedStatement.class), 1, schema, value));
+  }
+
+  /**
+   * The hstore text form the bind produces. Everything is quoted, so a delimiter inside a key or
+   * value is inert and the string {@code NULL} stays distinct from a NULL value.
+   */
+  @Test
+  public void shouldSerializeMapsToHstoreText() {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("env", "prod");
+    map.put("absent", null);
+    map.put("literal", "NULL");
+    map.put("a=>b", "c,d");
+    map.put("say \"hi\"", "back\\slash");
+
+    assertEquals("\"env\"=>\"prod\",\"absent\"=>NULL,\"literal\"=>\"NULL\","
+            + "\"a=>b\"=>\"c,d\",\"say \\\"hi\\\"\"=>\"back\\\\slash\"",
+        HstoreConverter.connectMapToHstore(map));
+
+    assertEquals("", HstoreConverter.connectMapToHstore(Collections.emptyMap()));
+    assertNull(HstoreConverter.connectMapToHstore(null));
+  }
+
+  @Test
+  public void shouldRejectValuesThatAreNotStringMaps() {
+    assertThrows(DataException.class, () -> HstoreConverter.connectMapToHstore("not a map"));
+    assertThrows(DataException.class,
+        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(null, "v")));
+  }
+
+  /**
+   * An extension installed outside the search_path must still be usable: the DDL and the array
+   * element type take the schema-qualified name resolved from the connection.
+   */
+  @Test
+  public void shouldUseTheResolvedHstoreTypeNameForDdl() {
+    PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
+        "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+    SinkRecordField field = new SinkRecordField(stringToStringMap(), "col", false);
+
+    sink.hstoreTypeName = "\"ext\".hstore";
+    sink.hstoreTypeResolved = true;
+    assertEquals("\"ext\".hstore", sink.getSqlType(field));
+    assertEquals("\"ext\".hstore[]",
+        sink.getSqlType(new SinkRecordField(arraySchema(stringToStringMap()), "col", false)));
+  }
+
+  /** Selected but unavailable must fail, naming the field and how to install the extension. */
+  @Test
+  public void shouldFailWhenTheHstoreExtensionIsNotInstalled() {
+    PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
+        "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+    sink.hstoreTypeName = null;
+    sink.hstoreTypeResolved = true;
+
+    ConnectException thrown = assertThrows(ConnectException.class, () -> sink.getSqlType(
+        new SinkRecordField(stringToStringMap(), "tags", false)));
+    assertTrue("message should name the field, but was: " + thrown.getMessage(),
+        thrown.getMessage().contains("tags"));
+    assertTrue("message should say how to install it, but was: " + thrown.getMessage(),
+        thrown.getMessage().contains("CREATE EXTENSION hstore"));
+  }
+
+  /** An hstore column off the search_path is reported qualified and must be cast by that name. */
+  @Test
+  public void shouldCastHstoreColumnsByTheirReportedTypeName() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("plain").type("hstore", JDBCType.OTHER, Object.class);
+    builder.withColumn("qualified").type("\"ext\".\"hstore\"", JDBCType.OTHER, Object.class);
+    TableDefinition tableDefn = builder.build();
+
+    assertEquals("::hstore",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("plain").id()));
+    assertEquals("::\"ext\".\"hstore\"",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("qualified").id()));
   }
 
   private Schema stringToStringMap() {
@@ -1743,15 +1821,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
-  public void hstoreArrayShouldBindToJsonbArrayInBothModes() throws SQLException {
-    // map mode: each element serialized to JSON text, bound as jsonb[].
+  public void hstoreArrayShouldBindPerMode() throws SQLException {
+    // map mode: each element serialized to hstore text, bound as hstore[].
     verifyArrayBind(
         SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
         Arrays.asList(Collections.singletonMap("env", "prod"), null),
-        PostgreSqlDatabaseDialect.JSONB_TYPE_NAME,
-        new Object[]{"{\"env\":\"prod\"}", null});
+        PostgreSqlDatabaseDialect.HSTORE_TYPE_NAME,
+        new Object[]{"\"env\"=>\"prod\"", null});
 
-    // json mode: elements are already JSON text.
+    // json mode: elements are already JSON text, and stay a jsonb[] document array.
     verifyArrayBind(
         Json.optionalSchema(),
         Arrays.asList("{\"env\":\"prod\"}", null),

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1268,7 +1268,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
     SinkRecordField field = new SinkRecordField(stringToStringMap(), "col", false);
 
-    sink.hstoreType = PostgreSqlDatabaseDialect.HstoreType.installedAs("\"ext\".hstore");
+    sink.hstoreType = PostgreSqlDatabaseDialect.HstoreType.fromTypeName("\"ext\".hstore");
     assertEquals("\"ext\".hstore", sink.getSqlType(field));
     assertEquals("\"ext\".hstore[]",
         sink.getSqlType(new SinkRecordField(arraySchema(stringToStringMap()), "col", false)));

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -67,8 +67,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.startsWith;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import io.confluent.connect.jdbc.data.VariableScaleDecimal;
@@ -1340,6 +1342,12 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertThrows(DataException.class, () -> HstoreConverter.connectMapToHstore("not a map"));
     assertThrows(DataException.class,
         () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(null, "v")));
+    // A non-String key or value fails rather than being coerced through toString, so a schema and
+    // value that disagree surface here instead of silently reaching the database.
+    assertThrows(DataException.class,
+        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap("k", 1)));
+    assertThrows(DataException.class,
+        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(1, "v")));
   }
 
   /**
@@ -1357,6 +1365,57 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertEquals("\"ext\".hstore", sink.getSqlType(field));
     assertEquals("\"ext\".hstore[]",
         sink.getSqlType(new SinkRecordField(arraySchema(stringToStringMap()), "col", false)));
+  }
+
+  /**
+   * A schema name is user-chosen and may legally contain a double quote, which has to be doubled
+   * for the qualified type name to parse. Without escaping, a schema named {@code my"schema}
+   * produces {@code "my"schema".hstore}, which terminates the identifier early.
+   */
+  @Test
+  public void shouldEscapeQuotesInTheResolvedHstoreSchemaName() throws Exception {
+    ResultSet searchPath = mock(ResultSet.class);
+    when(searchPath.next()).thenReturn(true);
+    when(searchPath.getBoolean(1)).thenReturn(false);
+
+    ResultSet extension = mock(ResultSet.class);
+    when(extension.next()).thenReturn(true);
+    when(extension.getString(1)).thenReturn("my\"schema");
+
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery("SELECT to_regtype('hstore') IS NOT NULL")).thenReturn(searchPath);
+    when(statement.executeQuery(startsWith("SELECT n.nspname"))).thenReturn(extension);
+
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    assertEquals("\"my\"\"schema\".hstore",
+        PostgreSqlDatabaseDialect.resolveHstoreTypeName(connection));
+  }
+
+  /**
+   * A catalog read that fails is attempted once, not once per connection: a persistent failure
+   * would otherwise cost a round-trip and a WARN on every batch. It still leaves the type
+   * unresolved, so the bare name is assumed rather than the extension reported as missing.
+   */
+  @Test
+  public void shouldNotRetryTheHstoreLookupAfterACatalogFailure() throws Exception {
+    Statement statement = mock(Statement.class);
+    when(statement.executeQuery(any(String.class)))
+        .thenThrow(new SQLException("permission denied for table pg_extension"));
+    Connection connection = mock(Connection.class);
+    when(connection.createStatement()).thenReturn(statement);
+
+    PostgreSqlDatabaseDialect sink = new PostgreSqlDatabaseDialect(sinkConfigWithUrl(
+        "jdbc:postgresql://something", JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+
+    sink.maybeResolveHstoreType(connection);
+    sink.maybeResolveHstoreType(connection);
+
+    assertFalse("a failed read is not a resolution", sink.hstoreTypeResolved);
+    assertEquals("the bare name is assumed while unresolved", "hstore",
+        sink.getSqlType(new SinkRecordField(stringToStringMap(), "tags", false)));
+    verify(statement, times(1)).executeQuery("SELECT to_regtype('hstore') IS NOT NULL");
   }
 
   /** Selected but unavailable must fail, naming the field and how to install the extension. */

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -1074,7 +1074,53 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .put("name", "web-1")
         .put("tags", Collections.singletonMap("env", "prod")));
 
-    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "not hstore");
+    // The remediation has to name a type the operator can create, not just report the mismatch.
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "Recreate the column as hstore");
+  }
+
+  /**
+   * The array form of the same refusal. This is the upgrade path: an earlier build wrote maps to
+   * jsonb, so a pipeline that predates native hstore already has a {@code jsonb[]} column here. The
+   * message must name {@code hstore[]} — pgjdbc reports these types as {@code _jsonb} and
+   * {@code _hstore}, and telling an operator to recreate the column "as hstore" would give them a
+   * scalar that fails the very next batch.
+   */
+  @Test
+  public void testMapArrayIntoNonHstoreArrayColumnIsRefused() throws Exception {
+    execute("CREATE EXTENSION IF NOT EXISTS hstore",
+        "CREATE TABLE " + tableName + "(name text, tags jsonb[])");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(HSTORE_ARRAY_SINK_SCHEMA, new Struct(HSTORE_ARRAY_SINK_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", Collections.singletonList(Collections.singletonMap("env", "prod"))));
+
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "Recreate the column as hstore[]");
+  }
+
+  /**
+   * A missing extension is a property of the database, so no record shape can succeed and the task
+   * fails rather than reporting records one at a time. Reached through the real catalog lookup: the
+   * database is created without the extension rather than the resolved state being forced.
+   */
+  @Test
+  public void testMapArrayFailsWhenExtensionIsNotInstalled() throws Exception {
+    execute("CREATE DATABASE nohstorearray");
+    props.put(JdbcSinkConfig.CONNECTION_URL, jdbcUrl("nohstorearray"));
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(HSTORE_ARRAY_SINK_SCHEMA, new Struct(HSTORE_ARRAY_SINK_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", Collections.singletonList(Collections.singletonMap("env", "prod"))));
+
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "CREATE EXTENSION hstore");
   }
 
   /** Execute statements against a named database rather than the default one. */
@@ -1247,6 +1293,12 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   private static final Schema HSTORE_SINK_SCHEMA = SchemaBuilder.struct().name("com.example.Server")
       .field("name", Schema.STRING_SCHEMA)
       .field("tags", HSTORE_MAP_SCHEMA)
+      .build();
+
+  private static final Schema HSTORE_ARRAY_SINK_SCHEMA = SchemaBuilder.struct()
+      .name("com.example.ServerTags")
+      .field("name", Schema.STRING_SCHEMA)
+      .field("tags", SchemaBuilder.array(HSTORE_MAP_SCHEMA).optional().build())
       .build();
 
   // ---------- hstore round trips: source -> Kafka -> sink ----------

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -1325,6 +1325,59 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   }
 
   /**
+   * The {@code ::hstore} cast is behind {@code sql.complex.types.enable} like the rest of the
+   * feature, so with it off a STRING field is offered to a pre-existing hstore column uncast and
+   * PostgreSQL refuses it — the pre-feature behaviour. Paired with the flag-on case below, this is
+   * what keeps an upgrade from changing anything an existing pipeline can observe.
+   */
+  @Test
+  public void testStringIntoHstoreColumnIsRefusedWhenComplexTypesDisabled() throws Exception {
+    execute("CREATE EXTENSION IF NOT EXISTS hstore",
+        "CREATE TABLE " + tableName + "(name text, tags hstore)");
+    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "false");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(TEXT_TAGS_SCHEMA, new Struct(TEXT_TAGS_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", "\"env\"=>\"prod\""));
+
+    // PostgreSQL's own rejection, because no cast was emitted.
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "is of type hstore");
+  }
+
+  /** With the feature on the same record is cast and lands as a real hstore. */
+  @Test
+  public void testStringIsCastIntoHstoreColumnWhenComplexTypesEnabled() throws Exception {
+    execute("CREATE EXTENSION IF NOT EXISTS hstore",
+        "CREATE TABLE " + tableName + "(name text, tags hstore)");
+    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(TEXT_TAGS_SCHEMA, new Struct(TEXT_TAGS_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", "\"env\"=>\"prod\""));
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+    assertEquals("hstore", queryOne("postgres",
+        "SELECT udt_name FROM information_schema.columns WHERE table_name = '" + tableName
+            + "' AND column_name = 'tags'"));
+    assertEquals("prod", queryOne("postgres", "SELECT tags -> 'env' FROM " + tableName));
+  }
+
+  private static final Schema TEXT_TAGS_SCHEMA = SchemaBuilder.struct()
+      .name("com.example.ServerText")
+      .field("name", Schema.STRING_SCHEMA)
+      .field("tags", Schema.STRING_SCHEMA)
+      .build();
+
+
+  /**
    * Selected but unavailable must fail loudly: without the extension there is no column type that
    * could hold the map, so the task fails with an actionable message rather than inventing one.
    */

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.sql.Array;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -38,7 +39,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.connect.jdbc.data.Json;
 import io.confluent.connect.jdbc.integration.BaseConnectorIT;
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.dialect.PostgreSqlDatabaseDialect;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.TableId;
 import io.confluent.connect.jdbc.JdbcSourceConnector;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 import io.confluent.connect.jdbc.source.JdbcSourceTask;
@@ -72,6 +77,7 @@ import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAM
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -1266,6 +1272,55 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         assertTrue(rs.next());
         assertEquals("prod", rs.getString(1));
       }
+    }
+  }
+
+  /**
+   * A catalog read that fails leaves the type name unresolved, and the fallback assumes the bare
+   * {@code hstore} rather than guessing a schema. That is only safe because PostgreSQL rejects the
+   * bare name when the extension is off the search_path, which nothing else exercises: the unit
+   * tests stop at the name, and every other search_path test runs with the lookup already resolved.
+   *
+   * <p>A dialect pointed at an unreachable database is the same state: the lookup cannot run, so it
+   * stays unresolved. A reachable one would not do — building DDL asks for identifier rules, which
+   * opens a connection, which resolves the type on the way past.
+   */
+  @Test
+  public void testUnresolvedHstoreAssumesTheBareNameAndTheWriteIsRejected() throws Exception {
+    final String database = "extunresolved";
+    execute("CREATE DATABASE " + database);
+    executeIn(database, "CREATE SCHEMA ext", "CREATE EXTENSION hstore SCHEMA ext");
+
+    Map<String, String> dialectProps = new HashMap<>(props);
+    dialectProps.put(JdbcSinkConfig.CONNECTION_URL, "jdbc:postgresql://localhost:1/unreachable");
+    dialectProps.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    DatabaseDialect unresolved =
+        new PostgreSqlDatabaseDialect(new JdbcSinkConfig(dialectProps));
+
+    String ddl = unresolved.buildCreateTableStatement(
+        new TableId(null, null, tableName),
+        Collections.singletonList(new SinkRecordField(HSTORE_MAP_SCHEMA, "tags", false)));
+    assertTrue("unresolved must assume the bare name, but was: " + ddl, ddl.contains("hstore"));
+    assertFalse("unresolved must not invent a schema, but was: " + ddl, ddl.contains("\"ext\""));
+
+    SQLException thrown = assertThrows("the bare name must not resolve here",
+        SQLException.class, () -> executeIn(database, ddl));
+    assertTrue("PostgreSQL should reject the bare type, but was: " + thrown.getMessage(),
+        thrown.getMessage().contains("hstore") && thrown.getMessage().contains("does not exist"));
+
+    // The same guess reaches createArrayOf, so a record write is refused as well as the DDL.
+    executeIn(database, "CREATE TABLE " + tableName + "(tags ext.hstore[])");
+    try (Connection c = pg.getEmbeddedPostgres().getDatabase("postgres", database).getConnection();
+         PreparedStatement insert =
+             c.prepareStatement("INSERT INTO " + tableName + " VALUES (?)")) {
+      SQLException fromBind = assertThrows("the bare element type must not resolve either",
+          SQLException.class,
+          () -> unresolved.bindField(insert, 1, arrayOf(HSTORE_MAP_SCHEMA),
+              Collections.singletonList(Collections.singletonMap("env", "prod")), null, "tags"));
+      assertTrue("the driver should fail resolving the array type, but was: "
+          + fromBind.getMessage(),
+          fromBind.getMessage().contains("hstore")
+              && fromBind.getMessage().contains("array type"));
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -1007,11 +1007,12 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   }
 
   /**
-   * The sink half: a Connect {@code MAP<STRING,STRING>} auto-creates a native jsonb column and lands
-   * as real jsonb, verified through jsonb operators.
+   * The sink half: a Connect {@code MAP<STRING,STRING>} auto-creates a native hstore column and
+   * lands as real hstore, verified through hstore operators.
    */
   @Test
   public void testWriteToTableWithHstoreMapColumn() throws Exception {
+    execute("CREATE EXTENSION IF NOT EXISTS hstore");
     props.put(JdbcSinkConfig.AUTO_CREATE, "true");
     props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
     connect.configureConnector("jdbc-sink-connector", props);
@@ -1032,19 +1033,86 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
          Statement s = c.createStatement()) {
       try (ResultSet rs = s.executeQuery(
-          "SELECT data_type FROM information_schema.columns "
+          "SELECT udt_name FROM information_schema.columns "
               + "WHERE table_name = '" + tableName + "' AND column_name = 'tags'")) {
         assertTrue(rs.next());
-        assertEquals("jsonb", rs.getString(1));
+        assertEquals("hstore", rs.getString(1));
       }
       try (ResultSet rs = s.executeQuery(
-          "SELECT tags->>'env', tags->>'cities' FROM " + tableName)) {
+          "SELECT tags->'env', tags->'cities' FROM " + tableName)) {
         assertTrue(rs.next());
         assertEquals("prod", rs.getString(1));
         assertEquals("Pune, Mumbai", rs.getString(2));
       }
     }
   }
+
+  /**
+   * The extension may be installed in its own schema and kept off the search_path, which is common
+   * where extensions are segregated. The sink resolves where it lives and writes the qualified type
+   * name, so auto-create still produces a real hstore column.
+   */
+  @Test
+  public void testWriteToTableWithHstoreInstalledInAnotherSchema() throws Exception {
+    execute("CREATE DATABASE extsink");
+    try (Connection c = pg.getEmbeddedPostgres().getDatabase("postgres", "extsink").getConnection();
+         Statement s = c.createStatement()) {
+      s.execute("CREATE SCHEMA ext");
+      s.execute("CREATE EXTENSION hstore SCHEMA ext");
+    }
+    props.put(JdbcSinkConfig.CONNECTION_URL, jdbcUrl("extsink"));
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(HSTORE_SINK_SCHEMA, new Struct(HSTORE_SINK_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", Collections.singletonMap("env", "prod")));
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    try (Connection c = pg.getEmbeddedPostgres().getDatabase("postgres", "extsink").getConnection();
+         Statement s = c.createStatement()) {
+      try (ResultSet rs = s.executeQuery("SELECT udt_name FROM information_schema.columns "
+          + "WHERE table_name = '" + tableName + "' AND column_name = 'tags'")) {
+        assertTrue(rs.next());
+        assertEquals("hstore", rs.getString(1));
+      }
+      try (ResultSet rs = s.executeQuery(
+          "SELECT tags OPERATOR(ext.->) 'env' FROM " + tableName)) {
+        assertTrue(rs.next());
+        assertEquals("prod", rs.getString(1));
+      }
+    }
+  }
+
+  /**
+   * Selected but unavailable must fail loudly: without the extension there is no column type that
+   * could hold the map, so the task fails with an actionable message rather than inventing one.
+   */
+  @Test
+  public void testHstoreSinkFailsWhenExtensionIsNotInstalled() throws Exception {
+    execute("CREATE DATABASE nohstore");
+    props.put(JdbcSinkConfig.CONNECTION_URL, jdbcUrl("nohstore"));
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(HSTORE_SINK_SCHEMA, new Struct(HSTORE_SINK_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", Collections.singletonMap("env", "prod")));
+
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "CREATE EXTENSION hstore");
+  }
+
+  private static final Schema HSTORE_SINK_SCHEMA = SchemaBuilder.struct().name("com.example.Server")
+      .field("name", Schema.STRING_SCHEMA)
+      .field("tags", HSTORE_MAP_SCHEMA)
+      .build();
 
   // ---------- hstore round trips: source -> Kafka -> sink ----------
 
@@ -1068,12 +1136,11 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   }
 
   /**
-   * Assert the destination rows written by an hstore round trip. Identical expectations for both
-   * handling modes, since either representation lands in the same {@code jsonb} column — which is the
-   * property worth pinning.
+   * Assert the destination rows written by an hstore round trip in json mode, where the {@code Json}
+   * string is a JSON document that happens to have come from hstore and lands in {@code jsonb}.
    */
-  private void assertHstoreRoundTripRows() throws SQLException {
-    assertEquals("hstore must land in a native jsonb column", "jsonb", destColumnType("hs"));
+  private void assertHstoreJsonRoundTripRows() throws SQLException {
+    assertEquals("json mode must land in a native jsonb column", "jsonb", destColumnType("hs"));
 
     queryDest("id, hs, hs IS NULL AS is_null, jsonb_typeof(hs) AS kind", "id",
         rs -> {
@@ -1108,15 +1175,67 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         });
   }
 
+  /**
+   * Map mode round trips into a native hstore column, matching Debezium, whose PostgreSQL sink
+   * dialect maps the Connect MAP type to hstore unconditionally.
+   */
   @Test
-  public void testHstoreMapModeRoundTripsToJsonb() throws Exception {
+  public void testHstoreMapModeRoundTripsToHstore() throws Exception {
     createHstoreSourceRows();
     Map<String, String> sourceExtras = new HashMap<>();
     sourceExtras.put(JdbcSourceConnectorConfig.SQL_COMPLEX_TYPES_ENABLE_CONFIG, "true");
     sourceExtras.put(JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "map");
     runRoundTrip(7, sourceExtras,
         Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-    assertHstoreRoundTripRows();
+    assertHstoreMapRoundTripRows();
+  }
+
+  /**
+   * Assert the destination rows written by a map-mode hstore round trip: a real hstore column, so
+   * the hstore operators apply, and every scenario from {@link #createHstoreSourceRows()} survives.
+   */
+  private void assertHstoreMapRoundTripRows() throws SQLException {
+    assertEquals("map mode must land in a native hstore column", "USER-DEFINED",
+        destColumnType("hs"));
+    assertEquals("hstore", destColumnUdtName("hs"));
+
+    // Read through the hstore operators rather than its text form, whose pair order is hash order.
+    queryDest("id, hs::text AS text, hs IS NULL AS is_null, hs -> 'key2' AS key2, "
+            + "array_length(akeys(hs), 1) AS pairs, hs -> 'count' AS count, "
+            + "hs -> 'key_#1' AS hashed, hs -> 'key 2' AS spaced", "id",
+        rs -> assertEquals("\"key\"=>\"val\"", rs.getString("text")),
+        rs -> assertEquals(3, rs.getInt("pairs")),
+        // A NULL hstore value survives as a NULL value, with the key still present.
+        rs -> {
+          assertNull(rs.getString("key2"));
+          assertEquals(2, rs.getInt("pairs"));
+        },
+        // Spaces and # inside keys and values survive the hstore text round trip.
+        rs -> {
+          assertEquals("val 1", rs.getString("hashed"));
+          assertEquals(" ##123 78", rs.getString("spaced"));
+        },
+        // Empty hstore stays an empty hstore, not NULL.
+        rs -> {
+          assertEquals("", rs.getString("text"));
+          assertEquals(false, rs.getBoolean("is_null"));
+        },
+        // SQL NULL column stays SQL NULL, distinct from the empty hstore.
+        rs -> assertEquals(true, rs.getBoolean("is_null")),
+        // hstore is text to text: "5" must remain the string 5.
+        rs -> assertEquals("5", rs.getString("count")));
+  }
+
+  /** The underlying type name of a destination column, e.g. {@code hstore} for a USER-DEFINED. */
+  private String destColumnUdtName(String column) throws SQLException {
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
+         Statement s = c.createStatement();
+         ResultSet rs = s.executeQuery(
+             "SELECT udt_name FROM information_schema.columns WHERE table_name = '"
+                 + DST_TABLE + "' AND column_name = '" + column + "'")) {
+      assertTrue("destination table has no column " + column, rs.next());
+      return rs.getString(1);
+    }
   }
 
   @Test
@@ -1140,7 +1259,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
 
     runRoundTrip(7, sourceExtras,
         Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-    assertHstoreRoundTripRows();
+    assertHstoreJsonRoundTripRows();
   }
 
   /**
@@ -1581,8 +1700,12 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   }
 
   protected String jdbcUrl() {
-    return String.format("jdbc:postgresql://localhost:%s/postgres",
-        pg.getEmbeddedPostgres().getPort());
+    return jdbcUrl("postgres");
+  }
+
+  protected String jdbcUrl(String database) {
+    return String.format("jdbc:postgresql://localhost:%s/%s",
+        pg.getEmbeddedPostgres().getPort(), database);
   }
 
   /**
@@ -1979,6 +2102,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
    */
   @Test
   public void testAutoCreateArrayColumnTypes() throws Exception {
+    execute("CREATE EXTENSION IF NOT EXISTS hstore");
     props.put(JdbcSinkConfig.AUTO_CREATE, "true");
     props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
     connect.configureConnector("jdbc-sink-connector", props);
@@ -2041,7 +2165,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     expectedUdtNames.put("a_date", "_date");
     expectedUdtNames.put("a_time", "_time");
     expectedUdtNames.put("a_ts", "_timestamp");
-    expectedUdtNames.put("a_hstore", "_jsonb");
+    expectedUdtNames.put("a_hstore", "_hstore");
     for (Map.Entry<String, String> entry : expectedUdtNames.entrySet()) {
       assertEquals("element type of " + entry.getKey(), entry.getValue(),
           columnUdtName(tableName, entry.getKey()));
@@ -2222,12 +2346,19 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
             + "'\"env\" => \"prod\"'::hstore, '\"k\" => NULL'::hstore, ''::hstore])");
   }
 
-  /**
-   * Both handling modes converge on the same destination: a Connect map and a Json string each
-   * provision {@code jsonb[]}, so the data survives but the hstore target type does not.
-   */
-  private void assertHstoreArrayRoundTripRows() throws SQLException {
-    assertEquals("hstore[] must land in a native jsonb[] column",
+  /** Map mode provisions a native {@code hstore[]}, so the elements stay real hstores. */
+  private void assertHstoreArrayMapRoundTripRows() throws SQLException {
+    assertEquals("hstore[] must land in a native hstore[] column",
+        "_hstore", columnUdtName(DST_TABLE, "hs"));
+    // A NULL hstore value keeps its key with a NULL value; an empty hstore stays empty, not NULL.
+    assertDestArrayText(
+        "hs[1]->'env', hs[2]->'k', array_length(akeys(hs[2]), 1)::text, hs[3]::text",
+        "prod", null, "1", "");
+  }
+
+  /** Json mode carries JSON documents, so the elements provision {@code jsonb[]} as before. */
+  private void assertHstoreArrayJsonRoundTripRows() throws SQLException {
+    assertEquals("a Json string array must land in a native jsonb[] column",
         "_jsonb", columnUdtName(DST_TABLE, "hs"));
     // A NULL hstore value stays a JSON null with its key; an empty hstore stays {} rather than
     // NULL. jsonb_typeof is itself NULL for a NULL element, so "object" distinguishes the two.
@@ -2247,7 +2378,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     runRoundTrip(1, sourceExtras,
         Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
 
-    assertHstoreArrayRoundTripRows();
+    assertHstoreArrayMapRoundTripRows();
   }
 
   @Test
@@ -2274,7 +2405,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     runRoundTrip(1, sourceExtras,
         Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
 
-    assertHstoreArrayRoundTripRows();
+    assertHstoreArrayJsonRoundTripRows();
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -938,36 +938,171 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   }
 
   /**
-   * An hstore type outside the connection's search_path is reported as {@code "ext"."hstore"}, so a
-   * selected mapping mode cannot be honoured. The task fails at schema time, before any value is
-   * read, rather than silently dropping the column.
+   * An hstore installed outside the connection's search_path is reported as {@code "ext"."hstore"}
+   * and its values arrive as raw text rather than a decoded map. Both are normalised, so the column
+   * maps exactly as an on-search_path one does — the extension's location is not the operator's
+   * problem, matching Debezium, which strips the schema before its own catalog lookup.
    */
   @Test
-  public void testHstoreOutsideSearchPathFailsWhenAMappingModeIsSelected() throws Exception {
+  public void testHstoreOutsideSearchPathIsMappedInBothModes() throws Exception {
     execute("CREATE DATABASE offpath");
-    try (Connection c = pg.getEmbeddedPostgres().getDatabase("postgres", "offpath").getConnection();
-         Statement s = c.createStatement()) {
-      s.execute("CREATE SCHEMA ext");
-      s.execute("CREATE EXTENSION hstore SCHEMA ext");
-      s.execute("CREATE TABLE " + tableName + "(id int, hs ext.hstore)");
-      s.execute("INSERT INTO " + tableName + " VALUES (1, 'k=>v'::ext.hstore)");
-    }
+    executeIn("offpath",
+        "CREATE SCHEMA ext",
+        "CREATE EXTENSION hstore SCHEMA ext",
+        "CREATE TABLE " + tableName + "(id int, hs ext.hstore, hsa ext.hstore[])",
+        "INSERT INTO " + tableName + " VALUES (1, '\"k\" => \"v\",\"n\" => NULL'::ext.hstore, "
+            + "ARRAY['\"a\" => \"1\"'::ext.hstore, ''::ext.hstore])");
 
-    // A mapping mode was asked for and this column cannot honour it, so the task fails rather than
-    // silently dropping the column. map mode is set explicitly: under the default none the column
-    // would be skipped and this would prove nothing about search_path.
-    Throwable failure = pollUntilTaskFails(complexTypesSourceProps("offpath",
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("k", "v");
+    expected.put("n", null);
+
+    // map mode: the raw text is parsed into the same map a resolved column would yield.
+    Struct mapRow = pollOneRow(complexTypesSourceProps("offpath",
         JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "map"));
-    assertTrue("expected a ConnectException, got " + failure.getClass().getName(),
-        failure instanceof ConnectException);
-    String messages = causeChain(failure);
-    assertTrue("must name the cause, got: " + messages, messages.contains("search_path"));
-    assertTrue("must offer the escape hatch, got: " + messages,
-        messages.contains("hstore.handling.mode=none"));
+    new SchemaAndValueField("hs", HSTORE_MAP_SCHEMA, expected).assertFor(mapRow);
+    assertEquals("hstore[] elements must decode too",
+        Arrays.asList(Collections.singletonMap("a", "1"), Collections.emptyMap()),
+        mapRow.get("hsa"));
 
-    // none is the escape hatch: the same column is skipped instead of failing.
+    // json mode: the same value, serialized.
+    Struct jsonRow = pollOneRow(complexTypesSourceProps("offpath",
+        JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "json"));
+    SchemaAndValueField.jsonText("hs", Json.optionalSchema(),
+        parsedMapWithNull("k", "v", "n")).assertFor(jsonRow);
+
+    // none still means skip, wherever the extension lives.
     assertFieldAbsent(pollOneRow(complexTypesSourceProps("offpath",
         JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "none")), "hs");
+  }
+
+  /**
+   * The whole feature end to end against an extension in its own schema: source reads
+   * {@code ext.hstore} and {@code ext.hstore[]}, and the sink provisions and writes native hstore
+   * columns in the same database. This is the case that previously failed the source task outright.
+   */
+  @Test
+  public void testHstoreRoundTripWithExtensionOutsideSearchPath() throws Exception {
+    final String database = "extroundtrip";
+    execute("CREATE DATABASE " + database);
+    executeIn(database,
+        "CREATE SCHEMA ext",
+        "CREATE EXTENSION hstore SCHEMA ext",
+        "CREATE TABLE " + SRC_TABLE + "(id int PRIMARY KEY, hs ext.hstore, hsa ext.hstore[])",
+        "INSERT INTO " + SRC_TABLE + " VALUES (1, "
+            + "'\"key\" => \"val\",\"absent\" => NULL'::ext.hstore, "
+            + "ARRAY['\"a\" => \"1\"'::ext.hstore, ''::ext.hstore])",
+        "INSERT INTO " + SRC_TABLE + " VALUES (2, ''::ext.hstore, NULL)");
+
+    Map<String, String> sourceExtras = new HashMap<>();
+    sourceExtras.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, jdbcUrl(database));
+    sourceExtras.put(JdbcSourceConnectorConfig.SQL_COMPLEX_TYPES_ENABLE_CONFIG, "true");
+    sourceExtras.put(JdbcSourceConnectorConfig.HSTORE_HANDLING_MODE_CONFIG, "map");
+    Map<String, String> sinkExtras = new HashMap<>();
+    sinkExtras.put(JdbcSinkConfig.CONNECTION_URL, jdbcUrl(database));
+    sinkExtras.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+
+    runRoundTrip(2, sourceExtras, sinkExtras);
+
+    // Both destination columns are the real extension type, not jsonb or text.
+    assertEquals("hstore", queryOne(database,
+        "SELECT udt_name FROM information_schema.columns WHERE table_name = '" + DST_TABLE
+            + "' AND column_name = 'hs'"));
+    assertEquals("_hstore", queryOne(database,
+        "SELECT udt_name FROM information_schema.columns WHERE table_name = '" + DST_TABLE
+            + "' AND column_name = 'hsa'"));
+
+    // Values survive, read back through the extension's own operators.
+    assertEquals("val", queryOne(database, "SELECT hs OPERATOR(ext.->) 'key' FROM " + DST_TABLE
+        + " WHERE id = 1"));
+    assertNull("a NULL hstore value stays NULL", queryOne(database,
+        "SELECT hs OPERATOR(ext.->) 'absent' FROM " + DST_TABLE + " WHERE id = 1"));
+    assertEquals("the key is still present", "2", queryOne(database,
+        "SELECT array_length(ext.akeys(hs), 1)::text FROM " + DST_TABLE + " WHERE id = 1"));
+    assertEquals("1", queryOne(database,
+        "SELECT hsa[1] OPERATOR(ext.->) 'a' FROM " + DST_TABLE + " WHERE id = 1"));
+    // An empty hstore stays empty rather than becoming NULL, and a NULL array stays NULL.
+    assertEquals("0", queryOne(database,
+        "SELECT coalesce(array_length(ext.akeys(hs), 1), 0)::text FROM " + DST_TABLE
+            + " WHERE id = 2"));
+    assertNull(queryOne(database, "SELECT hsa::text FROM " + DST_TABLE + " WHERE id = 2"));
+  }
+
+  /**
+   * Writing into a hand-created hstore column, rather than one this connector provisioned, and with
+   * the extension off the search_path so the cast has to carry the qualified type name.
+   */
+  @Test
+  public void testWriteToPreExistingHstoreColumnOutsideSearchPath() throws Exception {
+    final String database = "extexisting";
+    execute("CREATE DATABASE " + database);
+    executeIn(database,
+        "CREATE SCHEMA ext",
+        "CREATE EXTENSION hstore SCHEMA ext",
+        "CREATE TABLE " + tableName + "(name text, tags ext.hstore)");
+
+    props.put(JdbcSinkConfig.CONNECTION_URL, jdbcUrl(database));
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(HSTORE_SINK_SCHEMA, new Struct(HSTORE_SINK_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", Collections.singletonMap("env", "prod")));
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    assertEquals("prod", queryOne(database,
+        "SELECT tags OPERATOR(ext.->) 'env' FROM " + tableName));
+  }
+
+  /**
+   * A map is written as hstore text, so an existing column of another type has to be refused with a
+   * message naming it, rather than letting PostgreSQL report a JSON syntax error.
+   */
+  @Test
+  public void testMapIntoNonHstoreColumnIsRefused() throws Exception {
+    execute("CREATE EXTENSION IF NOT EXISTS hstore",
+        "CREATE TABLE " + tableName + "(name text, tags jsonb)");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(HSTORE_SINK_SCHEMA, new Struct(HSTORE_SINK_SCHEMA)
+        .put("name", "web-1")
+        .put("tags", Collections.singletonMap("env", "prod")));
+
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "not hstore");
+  }
+
+  /** Execute statements against a named database rather than the default one. */
+  private void executeIn(String database, String... statements) throws SQLException {
+    try (Connection c = pg.getEmbeddedPostgres().getDatabase("postgres", database).getConnection();
+         Statement s = c.createStatement()) {
+      for (String statement : statements) {
+        s.execute(statement);
+      }
+    }
+  }
+
+  /** The first column of the single row the query returns, from a named database. */
+  private String queryOne(String database, String sql) throws SQLException {
+    try (Connection c = pg.getEmbeddedPostgres().getDatabase("postgres", database).getConnection();
+         Statement s = c.createStatement();
+         ResultSet rs = s.executeQuery(sql)) {
+      assertTrue("query returned no rows: " + sql, rs.next());
+      return rs.getString(1);
+    }
+  }
+
+  /** An expected parsed JSON object whose last named key carries a JSON null. */
+  private static Map<String, Object> parsedMapWithNull(String key, String value, String nullKey) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put(key, value);
+    map.put(nullKey, null);
+    return map;
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/util/HstoreConverterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/HstoreConverterTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class HstoreConverterTest {
+
+  /**
+   * The hstore text form the bind produces. Everything is quoted, so a delimiter inside a key or
+   * value is inert and the string {@code NULL} stays distinct from a NULL value.
+   */
+  @Test
+  public void shouldSerializeMapsToHstoreText() {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("env", "prod");
+    map.put("absent", null);
+    map.put("literal", "NULL");
+    map.put("a=>b", "c,d");
+    map.put("say \"hi\"", "back\\slash");
+
+    assertEquals("\"env\"=>\"prod\",\"absent\"=>NULL,\"literal\"=>\"NULL\","
+            + "\"a=>b\"=>\"c,d\",\"say \\\"hi\\\"\"=>\"back\\\\slash\"",
+        HstoreConverter.connectMapToHstore(map));
+
+    assertEquals("", HstoreConverter.connectMapToHstore(Collections.emptyMap()));
+    assertNull(HstoreConverter.connectMapToHstore(null));
+  }
+
+  /**
+   * The text form the driver hands back for an hstore it could not resolve. Quoting makes the
+   * delimiters inert, and a bare NULL is a null value while a quoted one is the string.
+   */
+  @Test
+  public void shouldParseHstoreText() {
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("env", "prod");
+    expected.put("absent", null);
+    expected.put("literal", "NULL");
+    expected.put("a=>b", "c,d");
+    expected.put("say \"hi\"", "back\\slash");
+
+    // PostgreSQL renders pairs separated by ", " and escapes quotes and backslashes.
+    assertEquals(expected, HstoreConverter.hstoreToConnectMap(
+        "\"env\"=>\"prod\", \"absent\"=>NULL, \"literal\"=>\"NULL\", "
+            + "\"a=>b\"=>\"c,d\", \"say \\\"hi\\\"\"=>\"back\\\\slash\""));
+
+    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap(""));
+    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap("   "));
+    assertNull(HstoreConverter.hstoreToConnectMap(null));
+  }
+
+  /**
+   * Insertion order is preserved, which {@link Map#equals} cannot show: the parser returns a
+   * {@link LinkedHashMap} so a round trip through Kafka keeps the column's own pair order.
+   */
+  @Test
+  public void shouldPreserveKeyOrderWhenParsing() {
+    Map<String, String> parsed = HstoreConverter.hstoreToConnectMap(
+        "\"z\"=>\"1\", \"a\"=>\"2\", \"m\"=>\"3\"");
+
+    assertEquals(Arrays.asList("z", "a", "m"), new ArrayList<>(parsed.keySet()));
+  }
+
+  /**
+   * {@code hstore_in} tolerates padding and a trailing comma even though {@code hstore_out} never
+   * emits them, so text assembled by hand rather than by the driver still parses.
+   */
+  @Test
+  public void shouldAcceptWhitespaceAndATrailingComma() {
+    Map<String, String> expected = new LinkedHashMap<>();
+    expected.put("env", "prod");
+    expected.put("tier", "web");
+
+    assertEquals(expected, HstoreConverter.hstoreToConnectMap(
+        "  \"env\" => \"prod\" ,  \"tier\" => \"web\" ,  "));
+  }
+
+  /** Whatever the serializer writes, the parser must read back identically. */
+  @Test
+  public void shouldRoundTripHstoreTextThroughBothDirections() {
+    Map<String, String> original = new LinkedHashMap<>();
+    original.put("env", "prod");
+    original.put("absent", null);
+    original.put("literal", "NULL");
+    original.put("a=>b", "c,d");
+    original.put("say \"hi\"", "back\\slash");
+    original.put("key 2", " ##123 78");
+    original.put("empty", "");
+
+    assertEquals(original, HstoreConverter.hstoreToConnectMap(
+        HstoreConverter.connectMapToHstore(original)));
+    assertEquals(Collections.emptyMap(), HstoreConverter.hstoreToConnectMap(
+        HstoreConverter.connectMapToHstore(Collections.emptyMap())));
+  }
+
+  @Test
+  public void shouldRejectMalformedHstoreText() {
+    for (String malformed : new String[]{
+        "not hstore at all",          // no => at all
+        "\"k\"",                      // key with no value
+        "\"k\"=>",                    // separator with no value
+        "\"k\"=>\"unterminated",      // unclosed quote
+        "\"a\"=>\"1\" \"b\"=>\"2\"",     // missing comma between pairs
+        "a=>1",                       // unquoted: hstore_out always quotes, so this is not ours
+        "\"a\"=>1",                   // unquoted value, likewise
+        "\"a\"=>null"                 // lowercase null is the string, never the NULL literal
+    }) {
+      assertThrows("should reject: " + malformed, DataException.class,
+          () -> HstoreConverter.hstoreToConnectMap(malformed));
+    }
+  }
+
+  /**
+   * The refusal locates the offending text. A malformed value is a data problem an operator has to
+   * find in a column that may hold many pairs, so the offset earns its place in the message.
+   */
+  @Test
+  public void shouldNameThePositionOfMalformedText() {
+    DataException e = assertThrows(DataException.class,
+        () -> HstoreConverter.hstoreToConnectMap("\"a\"=>\"1\", oops"));
+
+    assertTrue("should locate the failure, but was: " + e.getMessage(),
+        e.getMessage().contains("position"));
+  }
+
+  @Test
+  public void shouldRejectValuesThatAreNotStringMaps() {
+    assertThrows(DataException.class, () -> HstoreConverter.connectMapToHstore("not a map"));
+    assertThrows(DataException.class,
+        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(null, "v")));
+    // A non-String key or value fails rather than being coerced through toString, so a schema and
+    // value that disagree surface here instead of silently reaching the database.
+    assertThrows(DataException.class,
+        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap("k", 1)));
+    assertThrows(DataException.class,
+        () -> HstoreConverter.connectMapToHstore(Collections.singletonMap(1, "v")));
+  }
+}


### PR DESCRIPTION
## Problem

**1. An hstore column could not be written back as an hstore column.**

#1661 taught the source to read `hstore` as a Connect `MAP<STRING,STRING>` (map mode) or a logical JSON string (json mode). The sink, however, mapped `MAP<STRING,STRING>` to `jsonb`, so a Postgres-to-Postgres pipeline turned an `hstore` column into a `jsonb` one. The values survived, but the target type did not, and none of the hstore operators worked at the destination.

Debezium does not have this gap: its PostgreSQL sink dialect registers `MapToHstoreType`, which maps the Connect MAP type to `hstore` with `cast(? as hstore)`. The decision is made by the dialect, with no config and no metadata on the record — the MySQL dialect registers `MapToJsonType` for the same Connect type.

**2. An hstore installed outside the connection's `search_path` was refused outright.**

`CREATE EXTENSION hstore SCHEMA ext` is a common way to segregate extensions. When the extension is not on the `search_path`, pgjdbc cannot resolve its type OID, and two things follow: `getColumnTypeName` returns the qualified `"ext"."hstore"`, and values arrive as a `PGobject` carrying raw `"k"=>"v"` text rather than a decoded `Map`.

The source recognised that state and **failed the whole task**, with a message telling the operator to change their `search_path` or set `hstore.handling.mode=none`. The sink had no way to name the type at all.

Debezium handles this transparently: `TypeRegistry.get(String)` strips the schema and quotes before its catalog lookup, and `convertHstoreToMap` parses the text form with the driver's own `HStoreConverter.fromString`. There is no reason the extension's location should be the operator's problem.

**3. Selecting hstore with no extension installed had no clear failure**, and a `MAP` bound into a column that is not an hstore failed with a raw PostgreSQL parse error that never mentioned hstore.

## Solution

**1. A Connect `MAP<STRING,STRING>` now maps to `hstore`**, matching `MapToHstoreType`. Values are serialized to hstore text and bound as text for a `::hstore` cast to parse server-side, as Debezium's `cast(? as hstore)` does.

Two guards are deliberately kept rather than copying Debezium exactly:

- The mapping stays behind `sql.complex.types.enable`. Debezium has no equivalent gate only because it had no prior MAP behaviour to preserve; we do, so upgrading alone must not change an existing pipeline.
- Only `MAP<STRING,STRING>` is accepted. `MapToHstoreType` casts to `Map<String,String>` unconditionally and would `ClassCastException` on, say, `MAP<STRING,INT32>`; the shape check turns that into the ordinary "no mapping to the SQL database column type" failure at DDL time.

json mode is unchanged and still lands in `jsonb`. A `Json` string is a JSON document that happens to have come from hstore, and that is how Debezium routes it too. So `hstore[]` round trips to `hstore[]` in map mode and to `jsonb[]` in json mode.

**2. An hstore is now recognised wherever the extension is installed, on both sides.**

- *Source*: `isHstoreType` compares the local type name, so `"ext"."hstore"` is the same type as `hstore` — the same normalisation Debezium applies before its catalog lookup. Values that arrive as raw text are parsed into the map both handling modes require, and `hstore[]` elements are normalised identically. The refusal path is gone: `isUnresolvedHstoreType`, `isUnresolvedHstoreArrayType`, `hstoreOffSearchPathError` and its message are deleted.
- *Sink*: the extension's location is resolved once per dialect instance — `to_regtype('hstore')` first, then `pg_extension` joined to `pg_namespace` — and cached alongside the maximum identifier length, which already resolves that way. The answer is held as a single `HstoreType` value (`UNRESOLVED`, `ABSENT`, or installed under a name) rather than a name plus a flag, so the three states are named and one volatile reference publishes them together. DDL and the array element type use the resulting name, so an extension in `ext` produces `"ext".hstore`, and the cast follows the type name the driver reports for the column, giving `?::"ext"."hstore"` for a pre-existing one — requoted rather than interpolated, since pgjdbc builds that qualified name without escaping an embedded quote.

**3. Both failure modes now name their cause.** With no extension installed anywhere, writing a map fails with *"the hstore extension is not installed on this database. Install it with CREATE EXTENSION hstore, in any schema."* Writing a map into a column that is not an hstore fails with *"column type is jsonb, not hstore. Recreate the column as hstore, or set sql.complex.types.enable=false"* rather than PostgreSQL's `invalid input syntax for type json`. The remediation names the type the operator would actually create, so the array form reads `column type is jsonb[], not hstore[]. Recreate the column as hstore[]` — pgjdbc reports those as `_jsonb`/`_hstore`, which is not what anyone writes in DDL. This adds no capability — `MAP` still maps to `hstore` only — it just makes the required failure legible.

Both are raised as `ConnectException`, which fails the task. Neither is a DDL failure — one throw site is `bindField` — and both conditions are properties of the database or the target table rather than of a record, so no batch split can find a record that fits and reporting each one in turn only drains a stream into a DLQ while the task reports healthy. This matches `GenericDatabaseDialect`, which raises `ConnectException` for any value it cannot bind.

A failed catalog read is deliberately distinct from an absent extension: `resolveHstoreTypeName` propagates its `SQLException` rather than returning null, so an unreadable catalog leaves the type *unresolved*, falls back to the bare name and lets PostgreSQL report the real problem. Only a confirmed absence produces the connector's own message. Because the type stays unresolved, the next connection retries the lookup, so a transient failure heals rather than pinning the bare name for the life of the task — the dialect's `getConnection()` runs when the cached connection is opened or replaced, not per batch. The resolution is skipped entirely for source tasks, which never write hstore.

### Changes from code review

Four behavioural corrections after review, none in the hstore mapping itself:

- **Both refusals are `ConnectException`.** An earlier revision raised them as `TableAlterOrCreateException` to gain the writer's rollback and the task's error-reporter routing. That was reverted: neither refusal is DDL, and both are deterministic for the whole stream, so the batch-splitting the DDL type triggers finds nothing to salvage and a DLQ would quietly absorb every record while the task looked healthy. Failing loudly is the intended outcome; the rollback and DLQ routing are given up deliberately. `TableAlterOrCreateException` no longer appears in the dialect at all.
- **The extension lookup is no longer latched off after a failure.** An earlier revision set a flag so a failed catalog read was never retried, on the premise that `getConnection()` runs per batch. It does not: `CachedConnectionProvider` calls the dialect only when the connection is opened or replaced, so the lookup already ran once per physical connection. The latch bought nothing and blocked recovery — one transient failure pinned the bare type name for the life of the task. Removed, so the next connection retries.
- **An unparseable `hstore[]` element degrades to null** instead of failing the task, matching what the scalar path already did for an optional column. Array element schemas are always optional, so the strict behaviour contradicted the mapping's own policy.
- **The `::hstore` cast requotes the driver-reported type name.** pgjdbc assembles `"schema"."type"` without escaping (its `TypeInfoCache` carries a `TODO: escaping !?`), so a schema containing a quote produced invalid DML. `resolveHstoreTypeName` already doubled quotes; this makes the two paths symmetric.

A later review round produced four more, none changing the mapping:

- **The refusal remediation names a creatable type.** The array branch fed pgjdbc's `_hstore` into the message, so it read *"column type is `_jsonb`, not `_hstore`. Recreate the column with the hstore type"* — which, followed literally, produces a scalar column that fails the next batch. It now renders `hstore[]` and names the expected type in the remediation.
- **The lookup state is one value.** `hstoreTypeName` plus `hstoreTypeResolved` made a reader reconstruct three states from two fields, where `null` meant either "not read" or "absent" depending on the flag — the source of two separate review questions. Replaced by an `HstoreType` value with named states and a `fromTypeName` factory, which also retires the hand-rolled write ordering the old field comment had to explain. `requireHstoreTypeName` became `hstoreTypeNameOrFail`, since it both returns a name and throws.
- **The unchecked cast in the array read is gone.** `asStringMap` existed only to host a `@SuppressWarnings("unchecked")` for a cast to `Map<String,String>` that erasure never verified — and the neighbouring `catch (ClassCastException)` could not fire for the same reason. Declaring the local as `Map<?, ?>` needs no cast at all: `connectMapToJson` takes `Object` and the method returns `Object`, so the type arguments were never load-bearing.
- **The `::hstore` cast is behind the flag.** It was ungated, so a STRING field carrying hstore text reached a pre-existing hstore column with the feature off, where the uncast parameter was previously rejected. The same early return also drops the local-name match that let a schema-qualified type reach `CAST_TYPES`, so with the flag off the method is the pre-feature expression exactly.
- **The `_` array prefix is a named constant.** `ARRAY_TYPE_PREFIX` replaces two unrelated literals — one building the prefix, one stripping it.

### Why a local `HstoreConverter` rather than pgjdbc's

pgjdbc ships `org.postgresql.util.HStoreConverter`, but it is not available to us: the driver is declared `runtime` scope in `pom.xml`, which is what packages it into the connector archive while keeping it off the compile classpath, so no dialect compiles against driver classes. Widening the scope to make one helper reachable would trade that property away; `provided` would additionally drop the driver from the shipped archive.

It is a separate class rather than private methods on the dialect for three reasons: `JsonConverter` is the same thing for JSON in the same package with the same single consumer; Debezium made the identical call, with a 74-line `HstoreConverter` in its `dialect/postgres` package rather than inlining it; and it is a pure text codec with no dialect state, which does not belong inside an already 1,500-line stateful class.

The parser accepts quoted pairs — what `hstore_out` emits (`"key"=>"value"` separated by `", "`, both sides quoted apart from a bare `NULL`), plus the surrounding whitespace and trailing comma that `hstore_in` also allows. Anything that is not a quoted-pair sequence did not come from PostgreSQL and is rejected rather than guessed at.

### Two overrides worth explaining

`statementBinder(…, TableDefinition, …)` is overridden **only** to carry the table definition into the binder. The interface default silently discards it, which leaves every `ColumnDefinition` null at bind time; `SqlServerDatabaseDialect`, `OracleDatabaseDialect` and `SybaseDatabaseDialect` all already override it for the same mechanical reason, so this closes a pre-existing gap rather than introducing a pattern — though they read the definition to choose a better bind (`setNString`, `setBlob`) rather than to reject one, and Sybase does not read it at all. It is safe: `colDef` is otherwise unused in the generic bind path, so the only consumer of the now-non-null value is the hstore column check.

`bindField(…, ColumnDefinition, String)` is overridden because it is the only bind entry point given the column definition — `maybeBindPrimitive`, where the hstore bind happens, does not receive it.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?

`hstore` is a PostgreSQL extension type, so this is contained in `PostgreSqlDatabaseDialect`.

## Test Strategy

**Unit** — the hstore text form in both directions: quoting, escaping, a NULL value versus the string `"NULL"`, delimiters inside keys and values, the empty map, a serialize/parse round trip, and rejection of anything that is not a quoted-pair sequence. Plus `isHstoreType` across schemas, the DDL and bind for both handling modes, the schema-qualified type name for an extension in another schema, the cast following the driver-reported column type, unresolved-is-not-absent, and both new failures naming their field and column type.

The hstore text codec is covered by its own `HstoreConverterTest` in `util`, alongside `JsonConverterTest` for its sibling class. Those assertions previously lived in the dialect test; moving them adds key-order preservation (which `Map.equals` cannot show), the whitespace and trailing comma `hstore_in` tolerates, and the position named in a malformed-text failure.

**Integration** — auto-create producing a real `hstore` column and reading it back through the hstore operators; the same against an extension installed in `ext` and off the `search_path`; writing into a hand-created `ext.hstore` column; the task failing when the extension is missing; the task failing when the target column is not an hstore; source reads of a qualified `ext.hstore` and `ext.hstore[]` in map and json modes; and map-mode and json-mode round trips for both `hstore` and `hstore[]`, covering a single pair, several pairs, a NULL hstore *value*, special characters, an empty hstore, a SQL NULL column and a numeric-looking value that must stay text.

The cast gate is covered in both directions end to end: with the flag off a STRING into a pre-existing hstore column is refused by PostgreSQL, and with it on the same record lands as a real hstore, queryable through `->`.

One integration test covers the deliberate degradation rather than a success path: when the catalog read fails, the type name stays unresolved and the bare `hstore` is assumed, which is only safe because PostgreSQL then rejects it. `testUnresolvedHstoreAssumesTheBareNameAndTheWriteIsRejected` pins both routes the guess reaches — the DDL fails with `type "hstore" does not exist`, and the array bind fails in `createArrayOf` with *Unable to find server array type for provided name hstore* — against a database with the extension in `ext`. It reaches the unresolved state via an unreachable URL rather than a refused catalog read; the state and both failures are identical, and forcing a real permission error needs a restricted role plus a `REVOKE` on a system catalog.

**End to end** — `testHstoreRoundTripWithExtensionOutsideSearchPath` runs the whole feature against an extension in its own schema: a dedicated database with `CREATE EXTENSION hstore SCHEMA ext`, the source reading `ext.hstore` and `ext.hstore[]`, and the sink provisioning and writing native `hstore` and `_hstore` columns, verified through `OPERATOR(ext.->)` and `ext.akeys`. This is the case that previously failed the source task outright.

Run locally against the embedded Postgres:

- `PostgreSqlDatabaseDialectTest` — 126/126 and `HstoreConverterTest` — 8/8, so 134 unit tests for the dialect and the codec at `ecc2781a`
- `PostgresDatatypeIT` — 74/74 passing at `ecc2781a` (full class, not just the new cases; 920s against embedded Postgres)
- Semaphore green on `ecc2781a` — **1731 tests passed**
- Full unit suite locally — the only error is the pre-existing `JdbcSourceTaskLifecycleTest` Derby teardown flake (`DirectoryNotEmptyException`), which passes 10/10 in isolation and is in a file this PR does not touch
- `mvn -o validate` checkstyle clean

**Not run:** the Docker-based Postgres IT classes, including `PostgreSqlSourceDialectIT` and `PostgresSinkDialectIT`. They cannot start on a current Docker Engine: `testcontainers.version` is 1.17.3, whose docker-java speaks Engine API 1.32, while Docker 29 reports `MinAPIVersion 1.40` and rejects the client outright. That blocks 15 of the 17 Postgres IT classes for anyone on Docker 29 and is unrelated to this change — worth its own `testcontainers.version` bump. `PostgresDatatypeIT` is unaffected because it uses embedded Postgres rather than Testcontainers.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? -->

Targets `10.9.x`, to be forward-merged to `master` with the rest of the complex-types work. No new configuration.

Behaviour changes to call out in the release notes, all under `sql.complex.types.enable=true`:

- A Connect `MAP<STRING,STRING>` that previously auto-created a `jsonb` column now creates an `hstore` one, and the hstore extension becomes a requirement for any such field — including maps that did not originate from an hstore column.
- Writing a `MAP` into a **pre-existing** non-hstore column now fails with a message naming the required type — and this is a genuine behaviour change, not only a better diagnostic. Before, a `MAP` was serialized to JSON, which **every** candidate column accepted: `jsonb` and `json` via their casts, and `text`/`varchar` with no cast at all. All of those writes succeeded. They now fail. For `jsonb`/`json` the write would fail regardless once the value became hstore text (`invalid input syntax for type json`), so there the check only improves the message; for `text`/`varchar` the check itself is what converts a success into a failure. That is deliberate: silently storing `"k"=>"v"` in a text column changes the on-disk format without telling anyone. Only reachable with `sql.complex.types.enable=true`, which has never shipped.
- A source that previously **failed the task** on an hstore outside the `search_path` now maps the column. This is a fix, but it is a behaviour change: the old `search_path` error no longer exists, and such columns start flowing where they were previously fatal.

Nothing is visible with the flag at its default. That includes the `::hstore` cast: it takes the destination column's type, so it would otherwise have applied to any pipeline writing a STRING into a pre-existing hstore column, turning a rejection into a success without the flag being touched. It is gated, so a flag-off pipeline behaves exactly as on `10.9.x` — verified by running the cast over 52 column types on both and diffing, identical. The scalar `::json`, `::jsonb` and `::uuid` casts pre-date the feature and are untouched.

The complex types have not shipped, so no released pipeline is affected.

Reverting is safe and self-contained — no config, schema or offset format changes.

Note for whoever merges second: this PR and #1677 both touch `PostgreSqlDatabaseDialect.java` and `PostgresDatatypeIT.java`. I performed the merge locally to verify it — **four** conflicts, all union merges:

| Conflict | Resolution |
|---|---|
| `bindArray` javadoc | keep `bytea` in the element list **and** the `arrayElementBinding(Schema, String)` signature |
| `byteArrayFor`/`bytesOf` vs `hstoreArrayFor` | keep all three; `hstoreArrayFor` keeps its own javadoc |
| `valueTypeCast` | union on the local name — hstore first (returning the reported qualified name), then `CAST_TYPES`, then the `_`-prefixed array form |
| `testAutoCreateArrayColumnTypes` | keep both expectations: `a_hstore → _hstore` and `a_bytes → _bytea` |

That merge was verified when this branch was at `950c70db`; both branches have since moved, so the conflict list is a guide rather than a guarantee — re-run the merge before relying on it. Note that both PRs add the same `fieldName` parameter to `bindArray`/`arrayElementBinding`, so that part merges as an identical change rather than a divergence.






