### PR TITLE
Fix gated array element failures and add bytea[]/uuid[] support for PostgreSQL

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -580,7 +580,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Read a PostgreSQL array column into a Connect list. The shared handling — SQL NULL, skipping
-   * multi-dimensional columns (see {@link #isMultiDimensional(Object[], String)}), and freeing the
+   * multi-dimensional columns (see {@link #isMultiDimensional(Object[])}), and freeing the
    * array — lives here. Temporal elements are decoded via the element {@link ResultSet} so each
    * can honor the configured {@code db.timezone}; all other elements come straight from
    * {@code getArray()}.
@@ -596,7 +596,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (raw == null) {
         return null;
       }
-      if (raw instanceof Object[] && isMultiDimensional((Object[]) raw, elementType)) {
+      if (raw instanceof Object[] && isMultiDimensional((Object[]) raw)) {
         if (multiDimensionalWarnedColumns.add(columnId)) {
           log.warn(MULTI_DIMENSIONAL_ARRAY_MESSAGE, columnId);
         } else {
@@ -724,14 +724,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * Postgres allows these, but JDBC reports the same type name as 1-D, so they are only
    * detectable from values; with no 1-D Connect ARRAY schema, callers skip them, returning null.
    *
-   * <p>A {@code bytea} element is legitimately a {@code byte[]}, so for that type only a nested
-   * {@code Object[]} — {@code byte[][][]}, from a {@code bytea[][]} column — is multi-dimensional.
+   * <p>Tested as an object array rather than any array: {@code bytea} is the one element type whose
+   * value is itself a {@code byte[]}, and its primitive component keeps it out of {@code Object[]}
+   * while a real {@code bytea[][]} still nests. Every other decoder yields a reference array, so
+   * the same question is correct for all of them.
    */
-  private static boolean isMultiDimensional(Object[] elements, String elementType) {
+  private static boolean isMultiDimensional(Object[] elements) {
     for (Object element : elements) {
       if (element != null) {
-        return BYTEA_TYPE_NAME.equals(elementType)
-            ? element instanceof Object[] : element.getClass().isArray();
+        return element instanceof Object[];
       }
     }
     return false;
@@ -889,7 +890,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * Shared by the DDL and bind paths for one actionable message. Not a DDL failure: the flag is
    * off for the whole connector, so no record can succeed and a batch split would find nothing.
    */
-  private static ConnectException complexArrayElementDisabled(
+  private static ConnectException complexArrayElementDisabledError(
       Schema element, String fieldName) {
     return new ConnectException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
         element.name() == null ? element.type() : element.name(),
@@ -976,7 +977,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           return super.getSqlType(field);
         }
         if (!complexTypesEnabled() && isComplexArrayElement(element)) {
-          throw complexArrayElementDisabled(element, field.name());
+          throw complexArrayElementDisabledError(element, field.name());
         }
         SinkRecordField childField = new SinkRecordField(
             element,
@@ -1191,7 +1192,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     Schema elementSchema = schema.valueSchema();
     if (!complexTypesEnabled() && isComplexArrayElement(elementSchema)) {
       // The primitive fallback would fail on the element's Java type rather than say why.
-      throw complexArrayElementDisabled(elementSchema, fieldName);
+      throw complexArrayElementDisabledError(elementSchema, fieldName);
     }
     ArrayElementBinding binding =
         complexTypesEnabled() ? arrayElementBinding(elementSchema) : null;

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -1454,8 +1454,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           if (CAST_TYPES.contains(typeName)) {
             return "::" + typeName;
           }
-          // The array of a cast type needs the same cast, e.g. text[] into a uuid[] column.
-          if (typeName.startsWith("_") && CAST_TYPES.contains(typeName.substring(1))) {
+          // Behind the flag: the array form is new, the scalar cast above pre-dates the feature.
+          if (complexTypesEnabled()
+              && typeName.startsWith("_") && CAST_TYPES.contains(typeName.substring(1))) {
             return "::" + typeName.substring(1) + "[]";
           }
         }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -103,6 +104,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   static final String TIME_TYPE_NAME = "time";
   static final String TIMESTAMP_TYPE_NAME = "timestamp";
   static final String TIMESTAMPTZ_TYPE_NAME = "timestamptz";
+  static final String BYTEA_TYPE_NAME = "bytea";
 
   // Array.getResultSet() yields two columns per element: 1 is the index, 2 the value.
   private static final int ELEMENT_VALUE_COLUMN = 2;
@@ -135,6 +137,25 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           UUID_TYPE_NAME
       ))
   );
+
+  /**
+   * Logical array element types that only {@link #arrayElementBinding(Schema)} can write. Their
+   * Connect values are {@code java.util.Date}/{@code Struct}, so the primitive fallback cannot bind
+   * them; without the complex types they must fail rather than advertise an unwritable column.
+   * {@code Json} is excluded deliberately: it is STRING-based and degrades losslessly to text[].
+   */
+  private static final Set<String> COMPLEX_ARRAY_ELEMENT_TYPES = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          Decimal.LOGICAL_NAME,
+          Date.LOGICAL_NAME,
+          Time.LOGICAL_NAME,
+          Timestamp.LOGICAL_NAME
+      ))
+  );
+
+  private static final String COMPLEX_ARRAY_ELEMENT_DISABLED =
+      "Cannot write an array of %s into column %s while %s is false; set it to true to map "
+          + "complex column types.";
 
   /**
    * Create a new dialect instance with the given connector configuration.
@@ -478,6 +499,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       case "bool":
       case "boolean":
         return Schema.OPTIONAL_BOOLEAN_SCHEMA;
+      case BYTEA_TYPE_NAME:
+        return Schema.OPTIONAL_BYTES_SCHEMA;
+      case UUID_TYPE_NAME:
+        // Rendered as text, matching the scalar uuid mapping.
+        return Schema.OPTIONAL_STRING_SCHEMA;
       case "numeric":
       case "decimal":
         // Per-value scale carried via VariableScaleDecimal (array typmod is -1 in JDBC metadata).
@@ -584,7 +610,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (raw == null) {
         return null;
       }
-      if (raw instanceof Object[] && isMultiDimensional((Object[]) raw)) {
+      if (raw instanceof Object[] && isMultiDimensional((Object[]) raw, elementType)) {
         if (multiDimensionalWarnedColumns.add(columnId)) {
           log.warn(MULTI_DIMENSIONAL_ARRAY_MESSAGE, columnId);
         } else {
@@ -636,7 +662,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       case JSONB_TYPE_NAME:
         // Raw JSON text; toString() covers both String and PGobject.
         return element.toString();
+      case UUID_TYPE_NAME:
+        // The driver yields java.util.UUID; the scalar path emits the canonical text.
+        return element.toString();
       default:
+        // Primitives and bytea (already a byte[]) pass through.
         return element;
     }
   }
@@ -709,11 +739,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * Whether the elements are themselves arrays — a multi-dimensional column like {@code int[][]}.
    * Postgres allows these, but JDBC reports the same type name as 1-D, so they are only
    * detectable from values; with no 1-D Connect ARRAY schema, callers skip them, returning null.
+   *
+   * <p>A {@code bytea} element is legitimately a {@code byte[]}, so for that type only a nested
+   * {@code Object[]} — {@code byte[][][]}, from a {@code bytea[][]} column — is multi-dimensional.
    */
-  private static boolean isMultiDimensional(Object[] elements) {
+  private static boolean isMultiDimensional(Object[] elements, String elementType) {
+    boolean elementIsBytes = BYTEA_TYPE_NAME.equals(elementType);
     for (Object element : elements) {
       if (element != null) {
-        return element.getClass().isArray();
+        return elementIsBytes ? element instanceof Object[] : element.getClass().isArray();
       }
     }
     return false;
@@ -837,20 +871,36 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Whether an array field's elements are ones {@link #bindArray} cannot write, so no column type
-   * is advertised: a nested array, a plain BYTES element, or any element under
-   * {@code timestamp.fields.list}, which selects TIMESTAMP by field name but has no binding for
-   * arrays. Advertising these would let auto-create build a column every insert then fails on.
+   * is advertised: a nested array, or any element under {@code timestamp.fields.list}, which
+   * selects TIMESTAMP by field name but has no binding for arrays. Advertising these would let
+   * auto-create build a column every insert then fails on.
    */
   private boolean isUnbindableArrayElement(SinkRecordField field) {
-    Schema element = field.schema().valueSchema();
-    if (element.type() == Schema.Type.ARRAY) {
-      return true;
-    }
-    if (element.type() == Schema.Type.BYTES && element.name() == null) {
+    if (field.schema().valueSchema().type() == Schema.Type.ARRAY) {
       return true;
     }
     return config instanceof JdbcSinkConfig
         && config.getList(JdbcSinkConfig.TIMESTAMP_FIELDS_LIST).contains(field.name());
+  }
+
+  /**
+   * Whether an element is written only by {@link #arrayElementBinding(Schema)}: a bytea-bound plain
+   * BYTES element, or one of the {@link #COMPLEX_ARRAY_ELEMENT_TYPES} logical types.
+   */
+  private static boolean isComplexArrayElement(Schema element) {
+    return (element.type() == Schema.Type.BYTES && element.name() == null)
+        || COMPLEX_ARRAY_ELEMENT_TYPES.contains(element.name());
+  }
+
+  /**
+   * The failure for an array element the complex types would bind but the feature is off. Raised
+   * from both the DDL and the bind path so an operator sees the same actionable message either way,
+   * rather than an unwritable column or a driver-level type error.
+   */
+  private static ConnectException complexArrayElementDisabled(Schema element, String fieldName) {
+    return new ConnectException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
+        element.name() == null ? element.type() : element.name(),
+        fieldName, JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
   }
 
   /**
@@ -925,16 +975,18 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return "TEXT";
       case BYTES:
         return "BYTEA";
-      case ARRAY:
+      case ARRAY: {
+        Schema element = field.schema().valueSchema();
+        if (!complexTypesEnabled() && isComplexArrayElement(element)) {
+          throw complexArrayElementDisabled(element, field.name());
+        }
         if (isUnbindableArrayElement(field)) {
           return super.getSqlType(field);
         }
-        SinkRecordField childField = new SinkRecordField(
-            field.schema().valueSchema(),
-            field.name(),
-            field.isPrimaryKey()
-        );
+        SinkRecordField childField =
+            new SinkRecordField(element, field.name(), field.isPrimaryKey());
         return getSqlType(childField) + "[]";
+      }
       case MAP:
         if (isStringToStringMap(field.schema()) && complexTypesEnabled()) {
           return JSONB_TYPE_NAME.toUpperCase();
@@ -1108,7 +1160,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   ) throws SQLException {
     switch (schema.type()) {
       case ARRAY:
-        if (bindArray(statement, index, schema, value)) {
+        if (bindArray(statement, index, schema, value, fieldName)) {
           return true;
         }
         break;
@@ -1125,17 +1177,28 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Bind a Connect ARRAY value to a native PostgreSQL array parameter. When complex types are
-   * enabled, element types with a dedicated PostgreSQL array type (json, numeric and the
+   * enabled, element types with a dedicated PostgreSQL array type (bytea, json, numeric and the
    * temporals) are resolved by {@link #arrayElementBinding(Schema)} and bound via
    * {@code createArrayOf}; any other (primitive) element type falls back to the pre-existing
    * {@link #maybeBindPrimitiveArray}. Returns false if the element type is not handled here.
    */
-  private boolean bindArray(PreparedStatement statement, int index, Schema schema, Object value)
-      throws SQLException {
+  private boolean bindArray(
+      PreparedStatement statement,
+      int index,
+      Schema schema,
+      Object value,
+      String fieldName
+  ) throws SQLException {
     Collection<?> values = arrayValueCollection(value);
     Schema elementSchema = schema.valueSchema();
-    ArrayElementBinding binding =
-        complexTypesEnabled() ? arrayElementBinding(elementSchema) : null;
+    if (!complexTypesEnabled()) {
+      if (isComplexArrayElement(elementSchema)) {
+        // The primitive fallback would fail on the element's Java type rather than say why.
+        throw complexArrayElementDisabled(elementSchema, fieldName);
+      }
+      return maybeBindPrimitiveArray(statement, index, elementSchema, values);
+    }
+    ArrayElementBinding binding = arrayElementBinding(elementSchema);
     if (binding == null) {
       return maybeBindPrimitiveArray(statement, index, elementSchema, values);
     }
@@ -1182,6 +1245,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     if (isStringToStringMap(elementSchema)) {
       // hstore map mode -> each element serialized to JSON text -> jsonb[].
       return new ArrayElementBinding(JSONB_TYPE_NAME, PostgreSqlDatabaseDialect::jsonArrayFor);
+    }
+    if (elementSchema.type() == Schema.Type.BYTES && elementSchema.name() == null) {
+      return new ArrayElementBinding(BYTEA_TYPE_NAME, PostgreSqlDatabaseDialect::byteArrayFor);
     }
     String elementName = elementSchema.name();
     if (elementName != null) {
@@ -1252,6 +1318,23 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
             : VariableScaleDecimal.toLogical(
                 (Struct) o))
         .toArray(BigDecimal[]::new);
+  }
+
+  /**
+   * Decode a collection of Connect BYTES elements into a {@code byte[][]} for binding into a native
+   * {@code bytea[]} column. Connect permits either representation. Null elements are preserved.
+   */
+  private static Object[] byteArrayFor(Collection<?> valueCollection) {
+    return valueCollection.stream()
+        .map(o -> o == null ? null : o instanceof ByteBuffer ? bytesOf((ByteBuffer) o) : (byte[]) o)
+        .toArray(byte[][]::new);
+  }
+
+  private static byte[] bytesOf(ByteBuffer buffer) {
+    ByteBuffer slice = buffer.slice();
+    byte[] bytes = new byte[slice.remaining()];
+    slice.get(bytes);
+    return bytes;
   }
 
   /**
@@ -1366,13 +1449,15 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   protected String valueTypeCast(TableDefinition tableDefn, ColumnId columnId) {
     if (tableDefn != null) {
       ColumnDefinition defn = tableDefn.definitionForColumn(columnId.name());
-      if (defn != null) {
-        String typeName = defn.typeName(); // database-specific
-        if (typeName != null) {
-          typeName = typeName.toLowerCase();
-          if (CAST_TYPES.contains(typeName)) {
-            return "::" + typeName;
-          }
+      if (defn != null && defn.typeName() != null) {
+        // database-specific, and schema-qualified when the type is off the search_path
+        String typeName = localTypeName(defn.typeName()).toLowerCase();
+        if (CAST_TYPES.contains(typeName)) {
+          return "::" + typeName;
+        }
+        // The array of a cast type needs the same cast, e.g. text[] bound into a uuid[] column.
+        if (typeName.startsWith("_") && CAST_TYPES.contains(typeName.substring(1))) {
+          return "::" + typeName.substring(1) + "[]";
         }
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -19,6 +19,7 @@ import io.confluent.connect.jdbc.data.Json;
 import io.confluent.connect.jdbc.data.VariableScaleDecimal;
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.TableAlterOrCreateException;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
@@ -135,23 +136,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           JSON_TYPE_NAME,
           JSONB_TYPE_NAME,
           UUID_TYPE_NAME
-      ))
-  );
-
-  /**
-   * Logical array element types that only {@link #arrayElementBinding(Schema)} can write. Their
-   * Connect values are {@code java.util.Date} or {@code BigDecimal}, neither of which matches the
-   * array the primitive fallback builds from the physical type; without the complex types they must
-   * fail rather than advertise an unwritable column. {@code Json} is excluded deliberately — it is
-   * STRING-based and degrades losslessly to {@code text[]} — as is {@code VariableScaleDecimal},
-   * which is STRUCT-typed and so already refused by both paths.
-   */
-  private static final Set<String> COMPLEX_ARRAY_ELEMENT_TYPES = Collections.unmodifiableSet(
-      new HashSet<>(Arrays.asList(
-          Decimal.LOGICAL_NAME,
-          Date.LOGICAL_NAME,
-          Time.LOGICAL_NAME,
-          Timestamp.LOGICAL_NAME
       ))
   );
 
@@ -877,7 +861,13 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * auto-create build a column every insert then fails on.
    */
   private boolean isUnbindableArrayElement(SinkRecordField field) {
-    if (field.schema().valueSchema().type() == Schema.Type.ARRAY) {
+    Schema element = field.schema().valueSchema();
+    if (element.type() == Schema.Type.ARRAY) {
+      return true;
+    }
+    // BYTES binds only through the complex-types path, so a named one no binding claims — a custom
+    // logical type, say — would otherwise advertise a bytea[] column every insert then fails on.
+    if (element.type() == Schema.Type.BYTES && arrayElementBinding(element) == null) {
       return true;
     }
     return config instanceof JdbcSinkConfig
@@ -886,11 +876,13 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Whether an element is written only by {@link #arrayElementBinding(Schema)}: a bytea-bound plain
-   * BYTES element, or one of the {@link #COMPLEX_ARRAY_ELEMENT_TYPES} logical types.
+   * element the complex-types path would bind, other than Json.
    */
-  private static boolean isComplexArrayElement(Schema element) {
-    return (element.type() == Schema.Type.BYTES && element.name() == null)
-        || COMPLEX_ARRAY_ELEMENT_TYPES.contains(element.name());
+  private boolean isComplexArrayElement(Schema element) {
+    // Derived from the binding rather than an enumerated name list, so any element the complex
+    // types would write is refused when they are off. Json is the deliberate exception: it is
+    // STRING-based and degrades losslessly to text[].
+    return !Json.LOGICAL_NAME.equals(element.name()) && arrayElementBinding(element) != null;
   }
 
   /**
@@ -898,8 +890,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * from both the DDL and the bind path so an operator sees the same actionable message either way,
    * rather than an unwritable column or a driver-level type error.
    */
-  private static ConnectException complexArrayElementDisabled(Schema element, String fieldName) {
-    return new ConnectException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
+  private static TableAlterOrCreateException complexArrayElementDisabled(
+      Schema element, String fieldName) {
+    return new TableAlterOrCreateException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
         element.name() == null ? element.type() : element.name(),
         fieldName, JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
   }
@@ -978,11 +971,13 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return "BYTEA";
       case ARRAY: {
         Schema element = field.schema().valueSchema();
-        if (!complexTypesEnabled() && isComplexArrayElement(element)) {
-          throw complexArrayElementDisabled(element, field.name());
-        }
+        // Unbindable first: enabling the feature cannot help an element nothing can write, so
+        // advising it would only lead to a second and less helpful failure.
         if (isUnbindableArrayElement(field)) {
           return super.getSqlType(field);
+        }
+        if (!complexTypesEnabled() && isComplexArrayElement(element)) {
+          throw complexArrayElementDisabled(element, field.name());
         }
         SinkRecordField childField = new SinkRecordField(
             element,

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -140,9 +140,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Logical array element types that only {@link #arrayElementBinding(Schema)} can write. Their
-   * Connect values are {@code java.util.Date}/{@code Struct}, so the primitive fallback cannot bind
-   * them; without the complex types they must fail rather than advertise an unwritable column.
-   * {@code Json} is excluded deliberately: it is STRING-based and degrades losslessly to text[].
+   * Connect values are {@code java.util.Date} or {@code BigDecimal}, neither of which matches the
+   * array the primitive fallback builds from the physical type; without the complex types they must
+   * fail rather than advertise an unwritable column. {@code Json} is excluded deliberately — it is
+   * STRING-based and degrades losslessly to {@code text[]} — as is {@code VariableScaleDecimal},
+   * which is STRUCT-typed and so already refused by both paths.
    */
   private static final Set<String> COMPLEX_ARRAY_ELEMENT_TYPES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList(
@@ -595,9 +597,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Read a PostgreSQL array column into a Connect list. The shared handling — SQL NULL, skipping
-   * multi-dimensional columns (see {@link #isMultiDimensional(Object[])}), and freeing the array —
-   * lives here. Temporal elements are decoded via the element {@link ResultSet} so each can honor
-   * the configured {@code db.timezone}; all other elements come straight from {@code getArray()}.
+   * multi-dimensional columns (see {@link #isMultiDimensional(Object[], String)}), and freeing the
+   * array — lives here. Temporal elements are decoded via the element {@link ResultSet} so each
+   * can honor the configured {@code db.timezone}; all other elements come straight from
+   * {@code getArray()}.
    */
   private List<Object> readArray(ResultSet rs, int col, ColumnId columnId, String elementType)
       throws SQLException {
@@ -638,7 +641,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Map elements the driver already returns as the target Java type into a Connect list (nulls
-   * preserved). Used for primitive, Json and VariableScaleDecimal elements.
+   * preserved). Used for primitive, bytea, uuid, Json and VariableScaleDecimal elements.
    */
   private static List<Object> readMappedElements(Object[] elements, String elementType) {
     List<Object> out = new ArrayList<>(elements.length);
@@ -650,7 +653,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Convert a single non-temporal array element to its Connect value: VariableScaleDecimal structs
-   * from the element BigDecimal, Json from the raw JSON text, and primitives passed through as-is.
+   * from the element BigDecimal, raw text for Json and uuid, and primitives — including bytea,
+   * already a {@code byte[]} — passed through as-is.
    */
   private static Object mapArrayElement(String elementType, Object element) {
     switch (elementType) {
@@ -660,10 +664,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
             VariableScaleDecimal.optionalSchema(), (BigDecimal) element);
       case JSON_TYPE_NAME:
       case JSONB_TYPE_NAME:
-        // Raw JSON text; toString() covers both String and PGobject.
-        return element.toString();
       case UUID_TYPE_NAME:
-        // The driver yields java.util.UUID; the scalar path emits the canonical text.
         return element.toString();
       default:
         // Primitives and bytea (already a byte[]) pass through.
@@ -744,10 +745,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * {@code Object[]} — {@code byte[][][]}, from a {@code bytea[][]} column — is multi-dimensional.
    */
   private static boolean isMultiDimensional(Object[] elements, String elementType) {
-    boolean elementIsBytes = BYTEA_TYPE_NAME.equals(elementType);
     for (Object element : elements) {
       if (element != null) {
-        return elementIsBytes ? element instanceof Object[] : element.getClass().isArray();
+        return BYTEA_TYPE_NAME.equals(elementType)
+            ? element instanceof Object[] : element.getClass().isArray();
       }
     }
     return false;
@@ -983,8 +984,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         if (isUnbindableArrayElement(field)) {
           return super.getSqlType(field);
         }
-        SinkRecordField childField =
-            new SinkRecordField(element, field.name(), field.isPrimaryKey());
+        SinkRecordField childField = new SinkRecordField(
+            element,
+            field.name(),
+            field.isPrimaryKey()
+        );
         return getSqlType(childField) + "[]";
       }
       case MAP:
@@ -1191,14 +1195,12 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   ) throws SQLException {
     Collection<?> values = arrayValueCollection(value);
     Schema elementSchema = schema.valueSchema();
-    if (!complexTypesEnabled()) {
-      if (isComplexArrayElement(elementSchema)) {
-        // The primitive fallback would fail on the element's Java type rather than say why.
-        throw complexArrayElementDisabled(elementSchema, fieldName);
-      }
-      return maybeBindPrimitiveArray(statement, index, elementSchema, values);
+    if (!complexTypesEnabled() && isComplexArrayElement(elementSchema)) {
+      // The primitive fallback would fail on the element's Java type rather than say why.
+      throw complexArrayElementDisabled(elementSchema, fieldName);
     }
-    ArrayElementBinding binding = arrayElementBinding(elementSchema);
+    ArrayElementBinding binding =
+        complexTypesEnabled() ? arrayElementBinding(elementSchema) : null;
     if (binding == null) {
       return maybeBindPrimitiveArray(statement, index, elementSchema, values);
     }
@@ -1440,7 +1442,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    *
    * <p>This method returns a blank string except for those column types that require casting
    * when set with literal values. For example, a column of type {@code uuid} must be cast when
-   * being bound with with a {@code varchar} literal, since a UUID value cannot be bound directly.
+   * being bound with a {@code varchar} literal, since a UUID value cannot be bound directly. The
+   * array of such a type needs the same cast, so a {@code uuid[]} column yields {@code ::uuid[]}.
    *
    * @param tableDefn the table definition; may be null if unknown
    * @param columnId  the column within the table; may not be null
@@ -1449,15 +1452,17 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   protected String valueTypeCast(TableDefinition tableDefn, ColumnId columnId) {
     if (tableDefn != null) {
       ColumnDefinition defn = tableDefn.definitionForColumn(columnId.name());
-      if (defn != null && defn.typeName() != null) {
-        // database-specific, and schema-qualified when the type is off the search_path
-        String typeName = localTypeName(defn.typeName()).toLowerCase();
-        if (CAST_TYPES.contains(typeName)) {
-          return "::" + typeName;
-        }
-        // The array of a cast type needs the same cast, e.g. text[] bound into a uuid[] column.
-        if (typeName.startsWith("_") && CAST_TYPES.contains(typeName.substring(1))) {
-          return "::" + typeName.substring(1) + "[]";
+      if (defn != null) {
+        String typeName = defn.typeName(); // database-specific
+        if (typeName != null) {
+          typeName = typeName.toLowerCase();
+          if (CAST_TYPES.contains(typeName)) {
+            return "::" + typeName;
+          }
+          // The array of a cast type needs the same cast, e.g. text[] into a uuid[] column.
+          if (typeName.startsWith("_") && CAST_TYPES.contains(typeName.substring(1))) {
+            return "::" + typeName.substring(1) + "[]";
+          }
         }
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -19,7 +19,6 @@ import io.confluent.connect.jdbc.data.Json;
 import io.confluent.connect.jdbc.data.VariableScaleDecimal;
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
-import io.confluent.connect.jdbc.sink.TableAlterOrCreateException;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
 import io.confluent.connect.jdbc.source.ColumnMapping;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
@@ -886,13 +885,13 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   }
 
   /**
-   * The failure for an array element the complex types would bind but the feature is off. Raised
-   * from both the DDL and the bind path so an operator sees the same actionable message either way,
-   * rather than an unwritable column or a driver-level type error.
+   * The failure for an array element the complex types would bind while the feature is off.
+   * Shared by the DDL and bind paths for one actionable message. Not a DDL failure: the flag is
+   * off for the whole connector, so no record can succeed and a batch split would find nothing.
    */
-  private static TableAlterOrCreateException complexArrayElementDisabled(
+  private static ConnectException complexArrayElementDisabled(
       Schema element, String fieldName) {
-    return new TableAlterOrCreateException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
+    return new ConnectException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
         element.name() == null ? element.type() : element.name(),
         fieldName, JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
   }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1655,7 +1655,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         Decimal.builder(2).optional().build());
 
     for (Schema element : elements) {
-      assertThrows("no column type for " + element.name(), ConnectException.class,
+      ConnectException fromDdl = assertThrows("no column type for " + element.name(),
+          ConnectException.class,
           () -> disabled.getSqlType(new SinkRecordField(arraySchema(element), "col", false)));
 
       ConnectException thrown = assertThrows(ConnectException.class,
@@ -1664,6 +1665,15 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
               mock(ColumnDefinition.class), "col"));
       assertTrue("message should name the config, but was: " + thrown.getMessage(),
           thrown.getMessage().contains(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
+
+      // The flag is off for the whole connector, so no record can succeed and there is nothing for
+      // a batch split to find: both paths fail the task rather than carrying the DDL exception's
+      // per-record handling. Asserted on the exact class, since TableAlterOrCreateException
+      // extends ConnectException and would satisfy the checks above unnoticed.
+      assertEquals("the DDL path must not carry a table-alter exception",
+          ConnectException.class, fromDdl.getClass());
+      assertEquals("the bind path must not carry a table-alter exception",
+          ConnectException.class, thrown.getClass());
     }
   }
 

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -365,8 +365,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   /**
    * The array of a cast type needs the same cast: a uuid[] source column becomes a Connect
-   * ARRAY&lt;STRING&gt; and binds as text[], which only reaches a uuid[] column through {@code
-   * ::uuid[]}. Off the search_path the type name arrives schema-qualified and must still match.
+   * ARRAY&lt;STRING&gt; and binds as text[], which only reaches a uuid[] column through
+   * {@code ::uuid[]}.
    */
   @Test
   public void shouldComputeValueTypeCastForArrayColumns() {
@@ -374,8 +374,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     builder.withColumn("uuidArray").type("_uuid", JDBCType.ARRAY, Object.class);
     builder.withColumn("jsonbArray").type("_jsonb", JDBCType.ARRAY, Object.class);
     builder.withColumn("textArray").type("_text", JDBCType.ARRAY, Object.class);
-    builder.withColumn("qualifiedUuidArray")
-        .type("\"ext\".\"_uuid\"", JDBCType.ARRAY, Object.class);
     TableDefinition tableDefn = builder.build();
 
     assertEquals("::uuid[]",
@@ -384,8 +382,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
     assertEquals("",
         dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("textArray").id()));
-    assertEquals("::uuid[]", dialect.valueTypeCast(
-        tableDefn, tableDefn.definitionForColumn("qualifiedUuidArray").id()));
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.JDBCType;
@@ -59,6 +60,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -359,6 +361,31 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertEquals("", dialect.valueTypeCast(tableDefn, dateColumn));
     // The cast that turns the bound JSON text into jsonb server-side.
     assertEquals("::jsonb", dialect.valueTypeCast(tableDefn, jsonbColumn));
+  }
+
+  /**
+   * The array of a cast type needs the same cast: a uuid[] source column becomes a Connect
+   * ARRAY&lt;STRING&gt; and binds as text[], which only reaches a uuid[] column through {@code
+   * ::uuid[]}. Off the search_path the type name arrives schema-qualified and must still match.
+   */
+  @Test
+  public void shouldComputeValueTypeCastForArrayColumns() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("uuidArray").type("_uuid", JDBCType.ARRAY, Object.class);
+    builder.withColumn("jsonbArray").type("_jsonb", JDBCType.ARRAY, Object.class);
+    builder.withColumn("textArray").type("_text", JDBCType.ARRAY, Object.class);
+    builder.withColumn("qualifiedUuidArray")
+        .type("\"ext\".\"_uuid\"", JDBCType.ARRAY, Object.class);
+    TableDefinition tableDefn = builder.build();
+
+    assertEquals("::uuid[]",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidArray").id()));
+    assertEquals("::jsonb[]",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
+    assertEquals("",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("textArray").id()));
+    assertEquals("::uuid[]", dialect.valueTypeCast(
+        tableDefn, tableDefn.definitionForColumn("qualifiedUuidArray").id()));
   }
 
   @Test
@@ -1254,6 +1281,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertArrayElement("_float4", Type.FLOAT32, null);
     assertArrayElement("_float8", Type.FLOAT64, null);
     assertArrayElement("_bool", Type.BOOLEAN, null);
+    assertArrayElement("_bytea", Type.BYTES, null);
+    assertArrayElement("_uuid", Type.STRING, null);
     assertArrayElement("_numeric", Type.STRUCT, VariableScaleDecimal.LOGICAL_NAME);
     assertArrayElement("_json", Type.STRING, Json.LOGICAL_NAME);
     assertArrayElement("_jsonb", Type.STRING, Json.LOGICAL_NAME);
@@ -1278,8 +1307,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void shouldSkipUnsupportedArrayElementTypes() {
-    // uuid[]/inet[]/money[] are not in the supported element set, so the column is skipped.
-    assertNull(sourceFieldSchema(complexTypesDialect(), Types.ARRAY, "_uuid"));
+    // inet[]/money[] are not in the supported element set, so the column is skipped.
     assertNull(sourceFieldSchema(complexTypesDialect(), Types.ARRAY, "_inet"));
     assertNull(sourceFieldSchema(complexTypesDialect(), Types.ARRAY, "_money"));
   }
@@ -1425,12 +1453,9 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldNotMapUnbindableArrayElementsToSqlType() {
     PostgreSqlDatabaseDialect sink = complexTypesSinkDialect();
     Schema nested = arraySchema(arraySchema(Schema.OPTIONAL_INT32_SCHEMA));
-    Schema bytes = arraySchema(Schema.OPTIONAL_BYTES_SCHEMA);
 
     assertThrows(ConnectException.class,
         () -> sink.getSqlType(new SinkRecordField(nested, "col", false)));
-    assertThrows(ConnectException.class,
-        () -> sink.getSqlType(new SinkRecordField(bytes, "col", false)));
     assertEquals("a named BYTES element that does bind is still mapped", "DECIMAL[]",
         sink.getSqlType(
             new SinkRecordField(arraySchema(Decimal.builder(2).optional().build()), "col", false)));
@@ -1541,6 +1566,108 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         mock(ColumnDefinition.class), "field");
 
     verify(statement).setObject(eq(1), any(Integer[].class), eq(Types.ARRAY));
+  }
+
+  /**
+   * A {@code bytea} element is itself a {@code byte[]}, so the multi-dimensional guard — which
+   * treats any array-valued element as nested — must not fire on it and null the whole column.
+   */
+  @Test
+  public void shouldReadByteaArrayElements() throws Exception {
+    byte[] first = new byte[]{1, 2};
+    byte[] second = new byte[]{3};
+    ResultSet rs = arrayResultSet(new byte[][]{first, null, second});
+
+    Object value = arrayColumnConverter("_bytea").convert(rs);
+
+    assertEquals(Arrays.asList(first, null, second), value);
+  }
+
+  /** Only a nested Object[] is multi-dimensional for bytea, i.e. a {@code bytea[][]} column. */
+  @Test
+  public void shouldSkipMultiDimensionalByteaArrayElements() throws Exception {
+    ResultSet rs = arrayResultSet(new byte[][][]{{{1, 2}}, {{3}}});
+
+    Object value = arrayColumnConverter("_bytea").convert(rs);
+
+    assertEquals(Arrays.asList(null, null), value);
+  }
+
+  /** pgjdbc yields java.util.UUID elements; the scalar path emits canonical text, so must this. */
+  @Test
+  public void shouldReadUuidArrayElementsAsText() throws Exception {
+    UUID uuid = UUID.fromString("0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f");
+    ResultSet rs = arrayResultSet(new UUID[]{uuid, null});
+
+    Object value = arrayColumnConverter("_uuid").convert(rs);
+
+    assertEquals(Arrays.asList(uuid.toString(), null), value);
+  }
+
+  @Test
+  public void shouldBindByteaArrayAsNativeByteaArray() throws Exception {
+    byte[] first = new byte[]{1, 2};
+    verifyArrayBind(Schema.OPTIONAL_BYTES_SCHEMA, Arrays.asList(first, null), "bytea",
+        new Object[]{first, null});
+  }
+
+  /** Connect BYTES permits a ByteBuffer, which must be unwrapped without consuming the caller's. */
+  @Test
+  public void shouldBindByteBufferArrayAsNativeByteaArray() throws Exception {
+    PreparedStatement statement = mock(PreparedStatement.class);
+    Connection connection = mock(Connection.class);
+    when(statement.getConnection()).thenReturn(connection);
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[]{7, 8});
+
+    complexTypesSinkDialect().bindField(statement, 7,
+        SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build(),
+        Collections.singletonList(buffer), mock(ColumnDefinition.class), "field");
+
+    ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
+    verify(connection).createArrayOf(eq("bytea"), captor.capture());
+    assertArrayEquals(new byte[]{7, 8}, (byte[]) captor.getValue()[0]);
+    assertEquals("the source buffer must not be drained", 2, buffer.remaining());
+  }
+
+  @Test
+  public void shouldMapByteaArrayToSqlType() {
+    Schema bytes = arraySchema(Schema.OPTIONAL_BYTES_SCHEMA);
+    assertEquals("BYTEA[]",
+        complexTypesSinkDialect().getSqlType(new SinkRecordField(bytes, "col", false)));
+
+    PostgreSqlDatabaseDialect disabled =
+        new PostgreSqlDatabaseDialect(sinkConfigWithUrl("jdbc:postgresql://something"));
+    assertThrows(ConnectException.class,
+        () -> disabled.getSqlType(new SinkRecordField(bytes, "col", false)));
+  }
+
+  /**
+   * A temporal element carries {@code java.util.Date} values, which the primitive fallback would
+   * try to store in a {@code Long[]}/{@code Integer[]} and fail with a bare ArrayStoreException.
+   * With the flag off the column must not be advertised at all, and a bind against a pre-existing
+   * column must name the config rather than surface the JVM error.
+   */
+  @Test
+  public void temporalArraysAreRejectedWhenComplexTypesDisabled() {
+    PostgreSqlDatabaseDialect disabled =
+        new PostgreSqlDatabaseDialect(sinkConfigWithUrl("jdbc:postgresql://something"));
+    List<Schema> elements = Arrays.asList(
+        Date.builder().optional().build(),
+        Time.builder().optional().build(),
+        Timestamp.builder().optional().build(),
+        Decimal.builder(2).optional().build());
+
+    for (Schema element : elements) {
+      assertThrows("no column type for " + element.name(), ConnectException.class,
+          () -> disabled.getSqlType(new SinkRecordField(arraySchema(element), "col", false)));
+
+      ConnectException thrown = assertThrows(ConnectException.class,
+          () -> disabled.bindField(mock(PreparedStatement.class), 1,
+              arraySchema(element), Collections.singletonList(new java.util.Date(0L)),
+              mock(ColumnDefinition.class), "col"));
+      assertTrue("message should name the config, but was: " + thrown.getMessage(),
+          thrown.getMessage().contains(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
+    }
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -370,18 +370,41 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
    */
   @Test
   public void shouldComputeValueTypeCastForArrayColumns() {
+    PostgreSqlDatabaseDialect enabled = complexTypesSinkDialect();
+    TableDefinition tableDefn = arrayCastColumns();
+
+    assertEquals("::uuid[]",
+        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidArray").id()));
+    assertEquals("::jsonb[]",
+        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
+    assertEquals("",
+        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("textArray").id()));
+  }
+
+  /**
+   * The array cast is behind the flag like the rest of the feature, so with it off a text[] reaches
+   * a uuid[] column uncast and PostgreSQL rejects it, exactly as before the feature. The scalar
+   * cast types are untouched, since those pre-date it.
+   */
+  @Test
+  public void shouldNotCastArrayColumnsWhenComplexTypesDisabled() {
+    TableDefinition tableDefn = arrayCastColumns();
+
+    assertEquals("",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidArray").id()));
+    assertEquals("",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
+    assertEquals("a pre-feature scalar cast type must still be cast with the flag off", "::uuid",
+        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidScalar").id()));
+  }
+
+  private TableDefinition arrayCastColumns() {
     TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
     builder.withColumn("uuidArray").type("_uuid", JDBCType.ARRAY, Object.class);
     builder.withColumn("jsonbArray").type("_jsonb", JDBCType.ARRAY, Object.class);
     builder.withColumn("textArray").type("_text", JDBCType.ARRAY, Object.class);
-    TableDefinition tableDefn = builder.build();
-
-    assertEquals("::uuid[]",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidArray").id()));
-    assertEquals("::jsonb[]",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
-    assertEquals("",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("textArray").id()));
+    builder.withColumn("uuidScalar").type("uuid", JDBCType.OTHER, Object.class);
+    return builder.build();
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -1621,6 +1621,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
     verify(connection).createArrayOf(eq("bytea"), captor.capture());
+    assertTrue("bytea[] must be bound as byte[][]", captor.getValue() instanceof byte[][]);
     assertArrayEquals(new byte[]{7, 8}, (byte[]) captor.getValue()[0]);
     assertEquals("the source buffer must not be drained", 2, buffer.remaining());
   }
@@ -2272,6 +2273,11 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
     verify(connection).createArrayOf(eq(expectedPgType), captor.capture());
+    if ("bytea".equals(expectedPgType)) {
+      // The component type is the whole correctness condition: pgjdbc rejects a byte[] nested
+      // in an Object[], so comparing elements alone would pass on a byte[][] and an Object[].
+      assertTrue("bytea[] must be bound as byte[][]", captor.getValue() instanceof byte[][]);
+    }
     assertEquals(Arrays.asList(expectedElements), Arrays.asList(captor.getValue()));
     verify(statement).setArray(7, boundArray);
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -71,6 +71,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -1831,8 +1832,9 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
    */
   @Test
   public void testMultiDimensionalArrayEmitsNullPerElement() throws Exception {
-    execute("CREATE TABLE " + tableName + "(id int, i int4[], t text[])",
-        "INSERT INTO " + tableName + " VALUES (1, '{{1,2},{3,4}}', '{{a,b},{c,d}}')");
+    execute("CREATE TABLE " + tableName + "(id int, i int4[], t text[], ba bytea[])",
+        "INSERT INTO " + tableName + " VALUES (1, '{{1,2},{3,4}}', '{{a,b},{c,d}}', "
+            + "ARRAY[ARRAY['\\x01'::bytea], ARRAY['\\x02'::bytea]])");
 
     Struct row = pollOneRow(complexTypesSourceProps("postgres"));
 
@@ -1840,22 +1842,70 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         Arrays.asList(null, null)).assertFor(row);
     new SchemaAndValueField("t", arrayOf(Schema.OPTIONAL_STRING_SCHEMA),
         Arrays.asList(null, null)).assertFor(row);
+    // bytea elements are byte[] themselves, so only this genuinely nested case must null out.
+    new SchemaAndValueField("ba", arrayOf(Schema.OPTIONAL_BYTES_SCHEMA),
+        Arrays.asList(null, null)).assertFor(row);
   }
 
   /** An unsupported element type drops its column and leaves neighbouring columns untouched. */
   @Test
   public void testUnsupportedArrayElementTypesAreSkipped() throws Exception {
-    execute("CREATE TABLE " + tableName + "(id int, u uuid[], ba bytea[], i int4[])",
-        "INSERT INTO " + tableName + " VALUES (1, "
-            + "ARRAY['0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f'::uuid], "
-            + "ARRAY['\\x0102'::bytea], '{7}')");
+    execute("CREATE TABLE " + tableName + "(id int, n inet[], m money[], i int4[])",
+        "INSERT INTO " + tableName + " VALUES (1, ARRAY['10.0.0.1'::inet], "
+            + "ARRAY[1.23::money], '{7}')");
 
     Struct row = pollOneRow(complexTypesSourceProps("postgres"));
 
-    assertFieldAbsent(row, "u");
-    assertFieldAbsent(row, "ba");
+    assertFieldAbsent(row, "n");
+    assertFieldAbsent(row, "m");
     new SchemaAndValueField("i", arrayOf(Schema.OPTIONAL_INT32_SCHEMA),
         Collections.singletonList(7)).assertFor(row);
+  }
+
+  /**
+   * {@code bytea[]} elements stay bytes and {@code uuid[]} elements become canonical text, matching
+   * the scalar mappings of the same types.
+   */
+  @Test
+  public void testByteaAndUuidArraysEmitTypedElements() throws Exception {
+    execute("CREATE TABLE " + tableName + "(id int, ba bytea[], u uuid[])",
+        "INSERT INTO " + tableName + " VALUES (1, "
+            + "ARRAY['\\x0102'::bytea, NULL, '\\x'::bytea], "
+            + "ARRAY['0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f'::uuid, NULL])");
+
+    Struct row = pollOneRow(complexTypesSourceProps("postgres"));
+
+    assertEquals(arrayOf(Schema.OPTIONAL_BYTES_SCHEMA), row.schema().field("ba").schema());
+    List<?> bytes = (List<?>) row.get("ba");
+    assertEquals(3, bytes.size());
+    assertArrayEquals(new byte[]{1, 2}, (byte[]) bytes.get(0));
+    assertNull(bytes.get(1));
+    assertArrayEquals(new byte[0], (byte[]) bytes.get(2));
+
+    new SchemaAndValueField("u", arrayOf(Schema.OPTIONAL_STRING_SCHEMA),
+        Arrays.asList("0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f", null)).assertFor(row);
+  }
+
+  /**
+   * Pin the driver contract the mocked unit tests assume: pgjdbc returns {@code byte[][]} for
+   * bytea[] — array-valued elements the multi-dimensional guard must not mistake for nesting —
+   * and {@code UUID[]} for uuid[].
+   */
+  @Test
+  public void testDriverArrayElementClasses() throws Exception {
+    execute("CREATE TABLE " + tableName + "(id int, ba bytea[], u uuid[])",
+        "INSERT INTO " + tableName + " VALUES (1, ARRAY['\\x01'::bytea], "
+            + "ARRAY['0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f'::uuid])");
+
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
+         Statement s = c.createStatement();
+         ResultSet rs = s.executeQuery("SELECT ba, u FROM " + tableName)) {
+      assertTrue(rs.next());
+      assertTrue("pgjdbc must return byte[][] for bytea[]",
+          rs.getArray(1).getArray() instanceof byte[][]);
+      assertTrue("pgjdbc must return UUID[] for uuid[]",
+          rs.getArray(2).getArray() instanceof UUID[]);
+    }
   }
 
   /** Backward compatibility: with the default flag an array column is dropped, as before. */
@@ -2003,6 +2053,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .field("a_time", arrayOf(Time.builder().optional().build()))
         .field("a_ts", arrayOf(Timestamp.builder().optional().build()))
         .field("a_hstore", arrayOf(hstoreMap))
+        .field("a_bytes", arrayOf(Schema.OPTIONAL_BYTES_SCHEMA))
         .build();
 
     java.util.Date epoch = new java.util.Date(0L);
@@ -2022,7 +2073,8 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .put("a_time", Collections.singletonList(epoch))
         .put("a_ts", Collections.singletonList(epoch))
         .put("a_hstore", Collections.singletonList(
-            Collections.singletonMap("env", "prod"))));
+            Collections.singletonMap("env", "prod")))
+        .put("a_bytes", Collections.singletonList(new byte[]{1, 2})));
 
     waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
         TimeUnit.MINUTES.toMillis(2));
@@ -2042,9 +2094,66 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     expectedUdtNames.put("a_time", "_time");
     expectedUdtNames.put("a_ts", "_timestamp");
     expectedUdtNames.put("a_hstore", "_jsonb");
+    expectedUdtNames.put("a_bytes", "_bytea");
     for (Map.Entry<String, String> entry : expectedUdtNames.entrySet()) {
       assertEquals("element type of " + entry.getKey(), entry.getValue(),
           columnUdtName(tableName, entry.getKey()));
+    }
+  }
+
+  /**
+   * With the flag off a temporal element must fail with a message naming the config, not blow up
+   * inside the driver. Before the gate, auto-create built a {@code timestamp[]} column and the bind
+   * then raised a bare ArrayStoreException storing {@code java.util.Date} values in a
+   * {@code Long[]}. The column must not be created either, since no insert could populate it.
+   */
+  @Test
+  public void testTemporalArrayFailsWhenComplexTypesDisabled() throws Exception {
+    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    final Schema schema = SchemaBuilder.struct().name("com.example.Timestamps")
+        .field("a_ts", arrayOf(Timestamp.builder().optional().build()))
+        .build();
+    produceRecord(schema, new Struct(schema)
+        .put("a_ts", Collections.singletonList(new java.util.Date(0L))));
+
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1,
+        JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE);
+    assertTableAbsent(tableName);
+  }
+
+  /**
+   * The bind half of the same gate, for a column the connector did not create: a pre-existing
+   * {@code timestamp[]} must be refused with the same message rather than an ArrayStoreException.
+   */
+  @Test
+  public void testTemporalArrayBindFailsIntoExistingColumnWhenComplexTypesDisabled()
+      throws Exception {
+    execute("CREATE TABLE " + tableName + "(a_ts timestamp[])");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    final Schema schema = SchemaBuilder.struct().name("com.example.Timestamps")
+        .field("a_ts", arrayOf(Timestamp.builder().optional().build()))
+        .build();
+    produceRecord(schema, new Struct(schema)
+        .put("a_ts", Collections.singletonList(new java.util.Date(0L))));
+
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1,
+        JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE);
+  }
+
+  /** Assert no table was auto-created, i.e. no unwritable column was advertised. */
+  private void assertTableAbsent(String table) throws SQLException {
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
+         Statement s = c.createStatement();
+         ResultSet rs = s.executeQuery("SELECT 1 FROM information_schema.tables "
+             + "WHERE table_name = '" + table + "'")) {
+      assertTrue("table " + table + " must not have been created", !rs.next());
     }
   }
 
@@ -2134,6 +2243,47 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         "{1,2}", "{1,2,42}", "{100,200}", "{1.5,2.5}", "{1.25,2.5}", "{t,f}", "{a,b}", "{ab,cd}",
         // char(10) padding survives; Postgres quotes array elements containing spaces.
         "{\"cone      \",\"ctwo      \"}");
+  }
+
+  /**
+   * {@code bytea[]} end to end, including an empty and a NULL element, into a native bytea[].
+   */
+  @Test
+  public void testByteaArrayRoundTrip() throws Exception {
+    execute("CREATE TABLE " + SRC_TABLE + "(id int PRIMARY KEY, ba bytea[])",
+        "INSERT INTO " + SRC_TABLE + " VALUES (1, "
+            + "ARRAY['\\x0102'::bytea, NULL, '\\x'::bytea])");
+
+    runRoundTrip(1,
+        Collections.singletonMap(
+            JdbcSourceConnectorConfig.SQL_COMPLEX_TYPES_ENABLE_CONFIG, "true"),
+        Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+
+    assertEquals("bytea[] must land in a native bytea[] column",
+        "_bytea", columnUdtName(DST_TABLE, "ba"));
+    assertDestArrayText("ba::text", "{\"\\\\x0102\",NULL,\"\\\\x\"}");
+  }
+
+  /**
+   * {@code uuid[]} has no Connect logical type, so it travels as ARRAY&lt;STRING&gt; and would
+   * auto-create text[]. Into a pre-existing uuid[] column it must still land as real uuids, which
+   * only the {@code ::uuid[]} cast makes possible.
+   */
+  @Test
+  public void testUuidArrayRoundTripIntoExistingUuidColumn() throws Exception {
+    String uuid = "0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f";
+    execute("CREATE TABLE " + SRC_TABLE + "(id int PRIMARY KEY, u uuid[])",
+        "INSERT INTO " + SRC_TABLE + " VALUES (1, ARRAY['" + uuid + "'::uuid, NULL])",
+        "CREATE TABLE " + DST_TABLE + "(id int PRIMARY KEY, u uuid[])");
+
+    runRoundTrip(1,
+        Collections.singletonMap(
+            JdbcSourceConnectorConfig.SQL_COMPLEX_TYPES_ENABLE_CONFIG, "true"),
+        Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
+
+    assertEquals("the pre-existing uuid[] column must be preserved",
+        "_uuid", columnUdtName(DST_TABLE, "u"));
+    assertDestArrayText("u::text", "{" + uuid + ",NULL}");
   }
 
   /**

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -2265,6 +2265,63 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
   }
 
   /**
+   * The array cast is behind {@code sql.complex.types.enable} like the rest of the feature, so with
+   * it off an ARRAY&lt;STRING&gt; is offered to a pre-existing {@code uuid[]} column uncast and
+   * PostgreSQL refuses it — the pre-feature behaviour. Paired with the flag-on case below, this is
+   * what keeps an upgrade from changing anything an existing pipeline can observe.
+   */
+  @Test
+  public void testStringArrayIntoUuidArrayColumnIsRefusedWhenComplexTypesDisabled()
+      throws Exception {
+    execute("CREATE TABLE " + tableName + "(name text, ids uuid[])");
+    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "false");
+    props.put(MAX_RETRIES, "0");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(TEXT_IDS_SCHEMA, new Struct(TEXT_IDS_SCHEMA)
+        .put("name", "web-1")
+        .put("ids", Collections.singletonList(CAST_UUID)));
+
+    // PostgreSQL's own rejection, because no cast was emitted.
+    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "is of type uuid[]");
+  }
+
+  /** With the feature on the same record is cast and lands as real uuids. */
+  @Test
+  public void testStringArrayIsCastIntoUuidArrayColumnWhenComplexTypesEnabled() throws Exception {
+    execute("CREATE TABLE " + tableName + "(name text, ids uuid[])");
+    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
+    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
+    connect.configureConnector("jdbc-sink-connector", props);
+    waitForConnectorToStart("jdbc-sink-connector", 1);
+
+    produceRecord(TEXT_IDS_SCHEMA, new Struct(TEXT_IDS_SCHEMA)
+        .put("name", "web-1")
+        .put("ids", Collections.singletonList(CAST_UUID)));
+
+    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
+        TimeUnit.MINUTES.toMillis(2));
+
+    assertEquals("_uuid", columnUdtName(tableName, "ids"));
+    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
+         Statement st = c.createStatement();
+         ResultSet rs = st.executeQuery("SELECT ids::text FROM " + tableName)) {
+      assertTrue("destination table has no rows", rs.next());
+      assertEquals("{" + CAST_UUID + "}", rs.getString(1));
+    }
+  }
+
+  private static final String CAST_UUID = "0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f";
+
+  private static final Schema TEXT_IDS_SCHEMA = SchemaBuilder.struct()
+      .name("com.example.CastArrays")
+      .field("name", Schema.STRING_SCHEMA)
+      .field("ids", arrayOf(Schema.OPTIONAL_STRING_SCHEMA))
+      .build();
+
+  /**
    * {@code uuid[]} has no Connect logical type, so it travels as ARRAY&lt;STRING&gt; and would
    * auto-create text[]. Into a pre-existing uuid[] column it must still land as real uuids, which
    * only the {@code ::uuid[]} cast makes possible.


### PR DESCRIPTION
## Problem

Two related gaps in the PostgreSQL native array support added by #1651.

**1. A gated array element failed opaquely instead of being refused.**

`logicalSqlType` gates `Json` and `VariableScaleDecimal` behind `sql.complex.types.enable`, but not `Decimal`, `Date`, `Time` or `Timestamp`. With the flag off, a `Timestamp` array therefore still advertised a `timestamp[]` column, which auto-create happily built and no insert could ever populate: the bind fell through to the primitive path, which tried to store `java.util.Date` values into a `Long[]` and raised a bare `java.lang.ArrayStoreException`.

So the operator saw a JVM error with no indication that a config was responsible, against a column the connector had itself just created. `Decimal` had the milder form of the same defect — the DDL succeeded and every insert then failed.

This is pre-existing behaviour on `master`, not a regression introduced by the complex-types stack.

**2. `bytea[]` and `uuid[]` were skipped entirely.**

Neither was in the supported element set, so the columns were dropped with a WARN even though the scalar `bytea` and `uuid` types are both mapped.

## Solution

**1.** A single gate, raised from both the DDL path and the bind path, so an operator gets the same actionable message either way:

> Cannot write an array of `org.apache.kafka.connect.data.Timestamp` into column `a_ts` while `sql.complex.types.enable` is false; set it to true to map complex column types.

`Json` deliberately keeps degrading to `text[]` — it is STRING-based, so the fallback is lossless and useful for a partially upgraded pipeline. Only the elements that genuinely cannot bind are refused.

**2.** `bytea` elements map to Connect `BYTES`, `uuid` elements to canonical text (matching the scalar `uuid` mapping, which has no Connect logical type).

Making `bytea[]` work required fixing the multi-dimensional guard first. `getArray()` returns `byte[][]` for a `bytea[]` column, and the guard asked `element.getClass().isArray()` — true for every `byte[]` — so every `bytea[]` would have been read as multi-dimensional and nulled out. It now asks `element instanceof Object[]` instead: `byte[]` has a primitive component so it is not an `Object[]`, while a real `bytea[][]` arrives as `byte[][][]` whose elements are. That one question is correct for every element type, because `bytea` is the only one whose 1-D value is itself an array — `org.postgresql.jdbc.ArrayDecoding` declares a reference-array decoder for every type with the single exception of `ArrayDecoder<byte[][]> BYTE_ARRAY_ARRAY` — so no element-type special case is needed.

On the sink, `bytea` elements bind through `createArrayOf`, accepting both `byte[]` and `ByteBuffer` since Connect permits either. `uuid` has no logical type and travels as `ARRAY<STRING>`, so `valueTypeCast` now also casts the array form of a cast type — letting a `text[]` parameter reach a pre-existing `uuid[]` column via `::uuid[]`.

That match deliberately does **not** normalise a schema-qualified type name. Only extension types are ever reported qualified, and `json`, `jsonb` and `uuid` are all built in, so the case cannot arise; an earlier revision handled it and the handling was removed as speculative.

### Changes from code review

Five corrections after review. The mapping itself is unchanged; all five are about refusing correctly and pinning what matters.

- **The gate is derived, not enumerated.** `isComplexArrayElement` now asks `arrayElementBinding(element) != null` instead of consulting a hand-maintained set of logical names, with `Json` as the one deliberate exception. That closes the gap where `VariableScaleDecimal` — which *does* have a binding — was refused by the DDL path but fell through the bind path to a generic *"Unsupported source data type: ARRAY"*, defeating the "same actionable message either way" goal above. The enumerated set is gone, so the two can no longer drift.
- **A BYTES element no binding claims is no longer advertised.** `isUnbindableArrayElement` now also refuses it, so a named logical BYTES type the dialect cannot write (`io.debezium.data.Bits`, or any custom one) is skipped with a WARN instead of auto-creating a `bytea[]` column every insert then fails on — the exact failure mode item (a) of this PR exists to remove. Pre-existing, but this PR re-homed that predicate, so it belongs here.
- **Unbindable is checked before the flag gate.** Previously a field in `timestamp.fields.list` with a temporal element was told to set `sql.complex.types.enable=true`, and doing so produced a second, less helpful failure. Enabling the feature cannot help an element nothing can write, so that advice is no longer given.
- **The array form of `valueTypeCast` is behind the flag.** It was ungated, which made a previously-rejected `ARRAY<STRING>` into a pre-existing `uuid[]`/`jsonb[]` column start succeeding on default config. Gated so a flag-off pipeline is byte-identical to `10.9.x`; the scalar cast above it is untouched.
- **`complexArrayElementDisabledError` raises `ConnectException`.** An earlier revision used `TableAlterOrCreateException` to gain the writer's rollback and the task's error-reporter routing. That was reverted on review: the refusal is not a DDL failure — one throw site is `bindArray` — and `sql.complex.types.enable=false` holds for the whole connector, so no record can succeed and splitting the batch to report each in turn finds nothing to salvage. It now fails the task, as `GenericDatabaseDialect` does for any value it cannot bind, matching #1676's refusals. The rollback and DLQ routing are given up deliberately, not overlooked.
- **The `bytea[]` bind tests now pin the runtime component type.** They compared elements but never the array's component type, which is the whole correctness condition — pgjdbc rejects a `byte[]` nested in an `Object[]`. Proven by mutation: changing `.toArray(byte[][]::new)` to `.toArray()` previously left all 120 unit tests green and now fails two.

Two further corrections after a later review pass:

- **The multi-dimensional guard drops its element-type parameter.** `isMultiDimensional(Object[], String)` becomes `isMultiDimensional(Object[])`, reverting a signature change this PR had introduced. See the guard's description above — the general form is correct for all element types, so the `bytea` branch was redundant rather than wrong. Confirmed by mutation: `shouldReadByteaArrayElements` and `shouldSkipMultiDimensionalByteaArrayElements` both stay green, while removing the check entirely fails the first with `expected:<[[B@…, null, [B@…]> but was:<[null, null, null]>`.
- **`complexArrayElementDisabled` renamed to `complexArrayElementDisabledError`.** It reads as a predicate but returns an exception; the file's own convention for that shape is `hstoreOffSearchPathError`.

### Second commit

`01f68672` is refinement only, no behaviour change:

- the `uuid` element folds into the existing `json`/`jsonb` case in `mapArrayElement`, since all three take the raw text
- `bindArray` keeps its original body and gains only a three-line guard, rather than restructuring the branch that resolves the element binding
- `isMultiDimensional` drops a hoisted local that bought nothing, as the loop returns on the first non-null element
- documentation corrections in the same code: the `@link` to `isMultiDimensional` names its current signature, the element-type set no longer claims its values are `Struct`s and says why `VariableScaleDecimal` is excluded, and `readMappedElements`, `mapArrayElement` and `valueTypeCast` describe the `bytea` and `uuid` elements they now handle

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?

PostgreSQL is the only dialect that maps native arrays, so both gaps are contained in `PostgreSqlDatabaseDialect`.

## Test Strategy

Unit tests cover the schema mapping for `_bytea`/`_uuid`, the multi-dimensional guard firing on `bytea[][]` but not `bytea[]`, the `bytea` bind for both `byte[]` and `ByteBuffer`, the array form of `valueTypeCast`, and the gate refusing each affected element type on both the DDL and bind paths.

Integration tests cover reading `bytea[]`/`uuid[]` including empty, NULL element and NULL column; a driver-contract test pinning that pgjdbc returns `byte[][]` and `UUID[]`, which the mocked unit tests assume; auto-create producing `_bytea`; the gated temporal array failing with the config named and no table created; and source-to-sink round trips for both `bytea[]` and `uuid[]`.

Run locally:

- `PostgreSqlDatabaseDialectTest` — 120/120 passing at `47aa28dc`
- `PostgresDatatypeIT` — 72/72 passing (full class, not just the new cases). Last full local run predates the two later review items above, both of which are covered by unit tests; Semaphore green on `47aa28dc`
- Full unit suite — 1567 tests, no failures attributable to this change. `JdbcSourceTaskLifecycleTest` is flaky in this repo independently of this PR — it has produced both a Derby `DirectoryNotEmptyException` teardown error and an EasyMock *"Unexpected method calls: CachedConnectionProvider.getConnection()"* on unmodified branches, and passes 10/10 in isolation. Neither involves a Postgres dialect.
- `mvn -o validate` checkstyle clean

**Not run:** the Docker-based Postgres IT classes, including `PostgreSqlSourceDialectIT` and `PostgresSinkDialectIT`, which cover the *scalar* `bytea` and `uuid` paths. They cannot start on a current Docker Engine: `testcontainers.version` is 1.17.3, whose docker-java speaks Engine API 1.32, while Docker 29 reports `MinAPIVersion 1.40` and rejects the client outright. That blocks 15 of the 17 Postgres IT classes for anyone on Docker 29 and is unrelated to this change — worth its own `testcontainers.version` bump. `PostgresDatatypeIT` is unaffected because it uses embedded Postgres rather than Testcontainers.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? -->

Targets `10.9.x`, to be forward-merged to `master` with the rest of the complex-types work. No new configuration. `bytea[]`/`uuid[]` support is only reachable with the flag on.

One change is visible with `sql.complex.types.enable` at its default, and nothing that previously worked stops working:

- A temporal or decimal array now fails with a clear message naming the config, instead of an `ArrayStoreException`, and no unwritable column is created. Where the column already exists the failure stays at bind time and only the message improves; with `auto.create` it moves to DDL, so the unwritable column is no longer created at all.

Everything else is behind the flag, including the cast. An earlier revision left the array form of `valueTypeCast` ungated, on the grounds that it completes cast logic that pre-dates the feature: an `ARRAY<STRING>` into a pre-existing `uuid[]` column previously failed with *column "u" is of type uuid[] but expression is of type character varying[]* and would have started succeeding via `?::uuid[]`. That was gated on review — a failure turning into a success is still a flag-off behaviour change, and an upgrade is easier to reason about when the default config behaves exactly as it did before. `uuid[]` writes into a pre-existing column therefore require the flag, which is consistent with the rest of the feature.

Verified by running the same cast over 52 column types on this branch with the flag off and on `10.9.x`, and diffing: identical. With the flag on, the only additions are `_json`, `_jsonb` and `_uuid`; the scalar `::json`, `::jsonb` and `::uuid` casts fire either way, since those pre-date the feature.

Reverting is safe and self-contained — no config, schema or offset format changes.

Note for whoever merges second: this PR and #1676 both touch `PostgreSqlDatabaseDialect.java` and `PostgresDatatypeIT.java`. I performed the merge locally to verify it — **four** conflicts, all union merges:

| Conflict | Resolution |
|---|---|
| `bindArray` javadoc | keep `bytea` in the element list **and** the `arrayElementBinding(Schema, String)` signature |
| `byteArrayFor`/`bytesOf` vs `hstoreArrayFor` | keep all three; `hstoreArrayFor` keeps its own javadoc |
| `valueTypeCast` | union on the local name — hstore first (returning the reported qualified name), then `CAST_TYPES`, then the `_`-prefixed array form |
| `testAutoCreateArrayColumnTypes` | keep both expectations: `a_hstore → _hstore` and `a_bytes → _bytea` |

That merge was verified when both branches were at their earlier heads; both have since moved, so treat the conflict list as a guide and re-run the merge before relying on it.

One trap worth naming: only `bindArray` gains `fieldName` in both PRs. `arrayElementBinding` does **not** — this PR keeps `arrayElementBinding(Schema)` while #1676 changes it to `arrayElementBinding(Schema, String)`. Resolving the `bindArray` javadoc hunk by "keeping both" can therefore preserve the 1-arg form and silently drop #1676's field naming from its missing-extension error, or leave two overloads. This PR also carries three `{@link #arrayElementBinding(Schema)}` references that become dangling signatures once #1676 lands, and need updating in the same pass.





