### PR TITLE
Guard stop() against a task whose start() never completed

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -178,7 +178,9 @@ public class JdbcSinkTask extends SinkTask {
   public void stop() {
     log.info("Stopping task");
     try {
-      writer.closeQuietly();
+      if (writer != null) {
+        writer.closeQuietly();
+      }
     } finally {
       try {
         if (dialect != null) {

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -246,6 +246,14 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
   }
 
   @Test
+  public void stopBeforeStartDoesNotThrow() {
+    // The framework can call stop() on a task whose start() never ran or never completed
+    // (e.g. a sibling task's startup failure aborts this one first), leaving writer unset.
+    JdbcSinkTask neverStarted = new JdbcSinkTask();
+    neverStarted.stop();
+  }
+
+  @Test
   public void retries() throws SQLException {
     final int maxRetries = 2;
     final int retryBackoffMs = 1000;

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcSinkTaskTest.java
@@ -247,8 +247,6 @@ public class JdbcSinkTaskTest extends EasyMockSupport {
 
   @Test
   public void stopBeforeStartDoesNotThrow() {
-    // The framework can call stop() on a task whose start() never ran or never completed
-    // (e.g. a sibling task's startup failure aborts this one first), leaving writer unset.
     JdbcSinkTask neverStarted = new JdbcSinkTask();
     neverStarted.stop();
   }


### PR DESCRIPTION
## Summary
- `JdbcSinkTask.stop()` called `writer.closeQuietly()` unconditionally, but `writer` is only assigned once `start()`'s `initWriter()` completes. The Connect framework can call `stop()` on a task whose `start()` never ran or never completed (e.g. a sibling task's startup failure aborts this one first), so this threw a `NullPointerException` instead of shutting down cleanly.
- Same shape of bug already found and fixed in `kafka-connect-azure-blob-storage` (confluentinc/kafka-connect-azure-blob-storage#531) and `kafka-connect-aws-dynamodb` (confluentinc/kafka-connect-aws-dynamodb#157) during a broader KIP-848 partial-revocation audit, which also swept every Confluent Cloud sink connector for this specific `stop()`-before-`start()` pattern and found this one.

## Test plan
- [x] Added `stopBeforeStartDoesNotThrow`, constructing a task via the no-arg constructor (never started) and calling `stop()` on it directly.
- [x] `mvn compile test-compile` passes cleanly.
- [ ] Could not execute the test suite locally in this environment — EasyMock's cglib-based proxy factory fails to initialize under the local JDK (JDK 25), a pre-existing issue unrelated to this change (confirmed the same failure occurs on unmodified `master`). Recommend running in CI before merge.
