### PR TITLE
CC-43056: Upgrade org.postgresql:postgresql to 42.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <sqlite-jdbc.version>3.41.2.2</sqlite-jdbc.version>
         <oracle.jdbc.driver.version>19.7.0.0</oracle.jdbc.driver.version>
         <mssqlserver.jdbc.driver.version>12.8.2.jre8</mssqlserver.jdbc.driver.version>
-        <postgresql.version>42.7.11</postgresql.version>
+        <postgresql.version>42.7.12</postgresql.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>


### PR DESCRIPTION
## Summary

- Bumped `org.postgresql:postgresql` from `42.7.11` to `42.7.12` to fix `CVE-2026-54291`.


## Test Results

### Trivy CVE Scan - before and after, on the driver jar itself

This is the direct proof that the bump removes the advisory rather than merely hiding it.

**Command**:
```
trivy rootfs --scanners vuln --quiet ~/.m2/repository/org/postgresql/postgresql/42.7.11/postgresql-42.7.11.jar
trivy rootfs --scanners vuln --quiet ~/.m2/repository/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar
```

```
=== 42.7.11 (before) ===
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)
org.postgresql:postgresql (postgresql-42.7.11.jar)  CVE-2026-54291  HIGH  fixed  42.7.11  42.7.12
  org.postgresql/postgresql: com.ongres.scram/scram-client: pgjdbc:
  Man-in-the-middle protection bypass via SCRAM-SHA-256-PLUS downgrade

=== 42.7.12 (after) ===
(no findings)
```

**Result: the advisory is present at 42.7.11 and gone at 42.7.12.**

### Trivy CVE Scan - full built tree

**Command**: `trivy rootfs --scanners vuln .`

```
Java (jar)
==========
Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 6, CRITICAL: 0)

com.microsoft.sqlserver:mssql-jdbc (mssql-jdbc-12.8.2.jre8.jar)
  CVE-2025-59250  HIGH  fixed  12.8.2 / 12.8.2.jre8
  JDBC Driver for SQL Server has improper input validation issue
```

**Result: zero `org.postgresql` findings.** The remaining 6 HIGH findings are all the same `com.microsoft.sqlserver:mssql-jdbc` advisory, which is a different dependency and a different CVE, tracked separately and out of scope for CC-43056.

Dependency resolution confirmed after the bump:

**Command**: `mvn dependency:tree -Dincludes=org.postgresql:postgresql`
```
[INFO] \- org.postgresql:postgresql:jar:42.7.12:runtime
[INFO] BUILD SUCCESS
```

Packaged artifact confirmed:
```
target/components/packages/confluentinc-kafka-connect-jdbc-10.9.7-SNAPSHOT/
  confluentinc-kafka-connect-jdbc-10.9.7-SNAPSHOT/lib/postgresql-42.7.12.jar
```

### Unit Tests - 1559 tests, 0 failures, 0 errors

**Command**: `mvn test`

```
[INFO] Tests run: 98, Failures: 0, Errors: 0, Skipped: 0 - in io.confluent.connect.jdbc.validation.JdbcSourceConnectorValidationTest
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0 - in io.confluent.connect.jdbc.validation.JdbcSinkConnectorValidationTest
[WARNING] Tests run: 1559, Failures: 0, Errors: 0, Skipped: 2
[INFO] BUILD SUCCESS
```

### Integration Tests

**Command**: `mvn verify -DskipIntegrationTests=false`

Every PostgreSQL integration test class passes against a real PostgreSQL container running through the upgraded driver, which is the part of the suite that actually exercises this change:

```
Tests run: 66, Failures: 0, Errors: 0, Skipped: 0 - PostgresDatatypeIT
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0 - PostgresJdbcSinkConnectorIT
Tests run:  5, Failures: 0, Errors: 0, Skipped: 0 - PostgresSinkDialectIT
Tests run:  4, Failures: 0, Errors: 0, Skipped: 0 - PostgresJdbcSourceConnectorIT
Tests run:  4, Failures: 0, Errors: 0, Skipped: 0 - PostgresNumericMappingIT
Tests run:  3, Failures: 0, Errors: 0, Skipped: 0 - PostgresViewIT
Tests run:  2, Failures: 0, Errors: 0, Skipped: 0 - PostgresLiteralIncludeListIT
Tests run:  2, Failures: 0, Errors: 0, Skipped: 0 - PostgresQueryModeIT
Tests run:  2, Failures: 0, Errors: 0, Skipped: 0 - PostgresSchemaPatternIT
Tests run:  2, Failures: 0, Errors: 0, Skipped: 0 - PostgresOOMIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresDbTimezoneIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresMultiTaskIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresOffsetResumeIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgreSqlSourceDialectIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresQuotedIdentifierSourceIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresSchemaEvolutionIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresTableLifecycleIT
Tests run:  1, Failures: 0, Errors: 0, Skipped: 0 - PostgresPartitionedIT
```

The Oracle and SQL Server integration tests also pass (`OracleJdbcSourceConnectorIT` 4, `OracleDatatypeIT` 9, `MsSqlJdbcSourceConnectorIT` 4, `OracleTableIT` 1, `PauseResumeIT` 1).

**Pre-existing local failures, not caused by this change**: three MySQL classes (`MySqlJdbcSourceConnectorIT`, `MySqlJdbcSinkConnectorIT`, `MySQLOOMIT`) fail identically on this machine because the embedded MariaDB used by the test fixture cannot install:

```
ch.vorburger.exec.ManagedProcessException: An error occurred while installing the database
    at ch.vorburger.mariadb4j.DB.install(DB.java:134)
    at ch.vorburger.mariadb4j.DB.newEmbeddedDB(DB.java:81)
Caused by: ... Program [.../MariaDB4j/base/bin/mysql_install_db, ...] failed, exitValue=1
```

This was confirmed pre-existing by reverting `pom.xml` to `42.7.11` and re-running `MySQLOOMIT`, which fails with the identical error. The failure happens in fixture setup while installing an embedded MariaDB server, before any JDBC driver is loaded, and it is on the MySQL path, which does not involve the PostgreSQL driver at all.

### KDP Source Test

Note on how this was run: the connector was installed with `--connector-zip` rather than `--connector-jar`. This matters for a driver CVE. The `--connector-jar` option replaces only the connector's own jar inside the hub-installed directory and leaves the bundled PostgreSQL driver untouched, so it would have tested the old driver. `--connector-zip` runs `confluent-hub install` on the component package built from this branch, which brings the upgraded driver with it.

**Command**:
```
playground run -f ./postgres.sh \
  --connector-zip .../target/components/packages/confluentinc-kafka-connect-jdbc-10.9.7-SNAPSHOT.zip \
  --environment plaintext
```

The worker under test was confirmed to be running the upgraded driver, not a hub download:

```
$ docker exec connect ls /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/ | grep postgresql
postgresql-42.7.12.jar

$ jq -r .version confluent-hub/confluentinc-kafka-connect-jdbc/manifest.json
10.9.7-SNAPSHOT
```

```
11:23:26 ✅ 🌎onprem connector postgres-source was successfully created
postgres-source                ✅ RUNNING  0:🟢 RUNNING
11:23:39 Verifying topic postgres-customers
11:23:49 ✅ RESULT: SUCCESS for postgres.sh (took: 2min 7sec)
```

**Result: SUCCESS.** Rows were read out of PostgreSQL through the upgraded driver and verified on the `postgres-customers` topic.

### KDP Sink Test

**Command**:
```
playground run -f ./postgres-sink.sh \
  --connector-zip .../target/components/packages/confluentinc-kafka-connect-jdbc-10.9.7-SNAPSHOT.zip \
  --environment plaintext
```

```
11:24:56 ✅ 🌎onprem connector postgres-sink was successfully created
postgres-sink                  ✅ RUNNING  0:🟢 RUNNING
11:25:43 📤 producing 1 records to topic orders
11:25:45 📤 produced 1 records to topic orders, took: 0min 2sec
11:25:51 ✅ RESULT: SUCCESS for postgres-sink.sh (took: 1min 26sec)
```

The worker was again confirmed to be running the upgraded driver:

```
$ docker exec connect ls /usr/share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/ | grep postgresql
postgresql-42.7.12.jar
```

**Result: SUCCESS.** Records produced to the `orders` topic were written into PostgreSQL through the upgraded driver and read back.

### KDP Source Test over TLS

Run as an extra check that the driver upgrade does not regress the TLS path.

**Command**:
```
playground run -f ./postgres-ssl.sh \
  --connector-zip .../target/components/packages/confluentinc-kafka-connect-jdbc-10.9.7-SNAPSHOT.zip \
  --environment plaintext
```

```
11:27:06 ✅ 🌎onprem connector postgres-source-ssl was successfully created
postgres-source-ssl            ✅ RUNNING  0:🟢 RUNNING
11:27:25 ✅ RESULT: SUCCESS for postgres-ssl.sh (took: 1min 5sec)
```

**Result: SUCCESS** with `sslmode=verify-full` against a generated CA.

To be precise about what this does and does not show: this fixture authenticates with md5 over TLS (`FROM postgres:10`, `pg_hba.conf` line `hostssl all all all md5`), so it does not negotiate SCRAM and therefore does not exercise channel binding. It demonstrates that the upgraded driver still works correctly over a verified TLS connection. The evidence that the advisory itself is remediated is the version bump plus the before and after trivy scans above, which is the same standard applied to any dependency CVE of this kind.


[CC-43056]: https://confluentinc.atlassian.net/browse/CC-43056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CVE-23473]: https://confluentinc.atlassian.net/browse/CVE-23473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ