### PR TITLE
CC-43623: Base the incremental version on the last released version

### DIFF
--- a/.semaphore/release-internal-version.yml
+++ b/.semaphore/release-internal-version.yml
@@ -20,7 +20,21 @@ blocks:
       jobs:
         - name: Release
           commands:
-            - ci-tools ci-update-version
+            - git fetch --tags -q || true
+            - |
+              # An incremental builds on the latest release of this branch's own line. The
+              # pom holds the next, unreleased version, so the base must come from tags.
+              LINE="${SEMAPHORE_GIT_BRANCH%.x}"
+              BASE=$(git tag -l --merged HEAD | grep -E "^v${LINE//./\\.}\.[0-9]+$" | sed 's/^v//' | sort -V | tail -1)
+              if [ -z "$BASE" ]; then
+                echo "No ${LINE}.x release found; ${LINE}.0 must be released before an incremental can be cut"
+                exit 1
+              fi
+              # Incremental tags sit on dangling commits, so they are never --merged.
+              LAST=$(git tag -l | grep -E "^v${BASE//./\\.}-[0-9]+$" | sed "s|^v${BASE}-||" | sort -n | tail -1)
+              NEXT="${BASE}-$(( ${LAST:-0} + 1 ))"
+              echo "Latest ${LINE}.x release: v${BASE}; releasing ${NEXT}"
+              ci-tools ci-update-version --version "${NEXT}"
             - ci-tools ci-push-tag
             - mvn -Dcloud -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 -Ddependency.check.skip=true --batch-mode --no-transfer-progress 
               -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/ 

--- a/.semaphore/release-internal-version.yml
+++ b/.semaphore/release-internal-version.yml
@@ -20,7 +20,9 @@ blocks:
       jobs:
         - name: Release
           commands:
-            - git fetch --tags -q || true
+            # checkout is a shallow clone and incremental tags sit on dangling commits,
+            # so this fetch is the only source of the tags the version is computed from.
+            - git fetch --tags -q
             - |
               # An incremental builds on the latest release of this branch's own line. The
               # pom holds the next, unreleased version, so the base must come from tags.


### PR DESCRIPTION
Follow-up to #1674.

`ci-update-version` takes the version from the pom, which on a release branch is the *next, unreleased* version. On `10.9.x` (pom `10.9.7-SNAPSHOT`) it published `10.9.7-1`, though `10.9.6` is the latest release.

It also breaks ordering — verified with `maven-artifact` 3.9.8:

```
10.9.6 < 10.9.7-1 > 10.9.7      non-monotonic
10.9.6 < 10.9.6-1 < 10.9.7      monotonic
```

An incremental cut before a release sorted as *newer* than that release.

## Fix

Take the base from the highest release tag on the branch's **own line** and pass it via `--version`.

Scoping to the line is the part that matters: release tags are merged forward into master, so `v10.9.6` is reachable from a freshly cut `10.10.x` branch and the job would otherwise publish `10.9.6-1` from 10.10 content. With no release on the line it now fails and names the version that must ship first.

The counter deliberately omits `--merged` — `ci-update-version` tags a dangling commit, so incremental tags are never reachable from the branch.

## Verified

```
10.9.x    Latest 10.9.x release: v10.9.6; releasing 10.9.6-1
10.10.x   No 10.10.x release found; 10.10.0 must be released before an incremental can be cut   (exit 1)
```

Counter and filtering against real tags: `v10.9.7-1` → next `10.9.7-2`; `v10.8.3-rc-4e6a1dd5` ignored.

The earlier run left `10.9.7-1` in CodeArtifact and tag `v10.9.7-1`; both are now misnamed but inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
