### PR TITLE
CC-43623: Correct VERSION_SELECTION.md for the last-released base

### DIFF
--- a/VERSION_SELECTION.md
+++ b/VERSION_SELECTION.md
@@ -15,12 +15,14 @@ The Kafka Connect JDBC connector has two main types of versions:
 - **Use Case**: **Production deployments and official releases**
 
 ### 2. **Incremental Versions**
-- **Format**: `X.Y.Z-N` (e.g., `10.9.7-1`, `10.9.7-2`, `10.9.7-3`)
+- **Format**: `X.Y.Z-N` (e.g., `10.9.6-1`, `10.9.6-2`, `10.9.6-3`)
+  - Read it as "the latest release, plus increment N".
 - **Characteristics**:
-  - Based on the **upcoming** version — the branch's current development version with `-SNAPSHOT` stripped. On `10.9.x` with a pom version of `10.9.7-SNAPSHOT`, incrementals are `10.9.7-1`, `10.9.7-2`, and so on.
+  - Based on the **latest released version on the same release line**. On `10.9.x`, with `10.9.6` the newest release, incrementals are `10.9.6-1`, `10.9.6-2`, and so on — regardless of what the pom's development version says.
   - **Released via Semaphore pipeline promotion** after merging to the release branch
-  - Version number is **automatically determined** from git tags by `ci-update-version`
-  - Each release also pushes a matching git tag (e.g. `v10.9.7-1`)
+  - Version number is **automatically determined** from git tags
+  - Each release also pushes a matching git tag (e.g. `v10.9.6-1`)
+  - The line must already have a release. On a freshly cut branch such as `10.10.x`, the promotion fails until `10.10.0` ships, because there is no release to increment on top of.
   - **Requires manual promotion trigger** (not part of the automated pipeline flow)
   - Published **only to internal CodeArtifact** — never to packages.confluent.io
 - **Purpose**: To unblock developers who need specific fixes or features in the framework without waiting for the next official CP release
@@ -47,7 +49,7 @@ The Kafka Connect JDBC connector has two main types of versions:
 <dependency>
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
-    <version>10.9.7-1</version> <!-- Latest incremental version -->
+    <version>10.9.6-1</version> <!-- Latest incremental version -->
 </dependency>
 ```
 Incremental versions are not on packages.confluent.io, so your build must also declare the internal repository:
@@ -62,7 +64,7 @@ Incremental versions are not on packages.confluent.io, so your build must also d
 **✅ Use**: Latest incremental version with a `-N` suffix
 **✅ Best for**: Teams that need latest features/fixes and cannot wait for CP releases
 **⚠️ Responsibility**: Developers must thoroughly test before triggering the pipeline promotion since kafka-connect-jdbc is a common dependency for many connectors
-**⚠️ Always pin an exact version.** Maven orders `10.9.7-1` *after* `10.9.7`, so a version range or "latest" resolution can select an incremental in preference to a newer official release.
+**⚠️ Pin an exact version.** Incrementals sort where you would expect — `10.9.6 < 10.9.6-1 < 10.9.6-2 < 10.9.7` — but they are untested-by-CP-release builds, so they should never be picked up implicitly by a range or "latest" resolution.
 
 ### For Local Development
 - **Build from source** using the current development version in `pom.xml`
@@ -79,10 +81,9 @@ When a developer needs to release an incremental version to unblock themselves o
 3. **Semaphore Pipeline Execution**: After the merge, the Semaphore pipeline will automatically run and complete
 
 4. **Trigger Pipeline Promotion**: In the Semaphore pipeline interface, use the "Release incremental f/w version" promotion to:
-   - Run `ci-tools ci-update-version`, which:
-     - Reads the current development version from `pom.xml` (e.g. `10.9.7-SNAPSHOT` → `10.9.7`)
-     - Lists git tags matching `v10.9.7-[0-9]*` and takes the highest build number
-     - Sets the pom to the next version (e.g. `10.9.7-3`) and creates tag `v10.9.7-3`
+   - Find the newest release tag on this branch's line (e.g. `v10.9.6` on `10.9.x`) — this is the base
+   - Take the highest existing `v10.9.6-<n>` tag and add one
+   - Run `ci-update-version --version 10.9.6-<n+1>`, which stamps the pom and creates tag `v10.9.6-<n+1>`
    - Run `ci-tools ci-push-tag` to push that tag
    - Deploy the release automatically to CodeArtifact
 
@@ -106,7 +107,7 @@ git tag -l 'v10.9.*' | sort -V
 ```
 
 ### Latest Incremental Version
-Incremental versions live only in internal CodeArtifact. Identify the branch's development version from `pom.xml`, then look for the highest `-N` suffix on it.
+Incremental versions live only in internal CodeArtifact. Identify the newest release on the line (`git tag -l 'v10.9.*' | sort -V | tail -1`), then look for the highest `-N` suffix on it.
 
 ### Using AWS CLI (Internal)
 ```bash
@@ -120,7 +121,7 @@ aws codeartifact list-package-versions \
   --package kafka-connect-jdbc \
   --region us-west-2
 
-# Filter for incremental versions of a given base (e.g. 10.9.7)
+# Filter for incremental versions of a given base (e.g. 10.9.6)
 aws codeartifact list-package-versions \
   --domain confluent \
   --domain-owner 519856050701 \
@@ -129,45 +130,47 @@ aws codeartifact list-package-versions \
   --namespace io.confluent \
   --package kafka-connect-jdbc \
   --region us-west-2 \
-  --query "versions[?starts_with(version, '10.9.7-')].version" \
-  --output text | tr '\t' '\n' | grep -E '^10\.9\.7-[0-9]+$' | sort -V
+  --query "versions[?starts_with(version, '10.9.6-')].version" \
+  --output text | tr '\t' '\n' | grep -E '^10\.9\.6-[0-9]+$' | sort -V
 ```
 
-**Why the `grep` is needed**: this repository also contains timestamped snapshot builds such as `10.9.7-20260807.053902-8`, produced by the ordinary per-merge pipeline. They also start with `10.9.7-` and do not contain the string `SNAPSHOT`, so no CodeArtifact-side filter separates them. Incremental releases are the ones whose suffix is a plain integer.
+**Why the `grep` is needed**: this repository also contains timestamped snapshot builds such as `10.9.7-20260807.053902-8`, produced by the ordinary per-merge pipeline. They share the `X.Y.Z-` shape and do not contain the string `SNAPSHOT`, so no CodeArtifact-side filter separates them. Incremental releases are the ones whose suffix is a plain integer.
 
 ## Version Lifecycle
 
 ### Overview
-Incremental versions are based on the version currently under development on the branch, so the base advances when a CP release ships:
+Incremental versions hang off the latest release, so the base advances when the next CP release ships:
 
 ```
 10.9.x branch
 
-  v10.9.6 released  ──►  pom becomes 10.9.7-SNAPSHOT
-                              │
-                              ├─ 10.9.7-1   (promotion)
-                              ├─ 10.9.7-2   (promotion)
-                              └─ 10.9.7-3   (promotion)
-
-  v10.9.7 released  ──►  pom becomes 10.9.8-SNAPSHOT
-                              │
-                              ├─ 10.9.8-1   (promotion)
-                              └─ ...
+  v10.9.6 released
+        │
+        ├─ 10.9.6-1   (promotion)
+        ├─ 10.9.6-2   (promotion)
+        └─ 10.9.6-3   (promotion)
+        │
+  v10.9.7 released
+        │
+        ├─ 10.9.7-1   (promotion)
+        └─ ...
 ```
+
+Everything sorts in release order: `10.9.6 < 10.9.6-1 < 10.9.6-2 < 10.9.7 < 10.9.7-1`.
 
 **Note**: Incremental versions are released through Semaphore pipeline promotion. The version number is calculated automatically from git tags.
 
 ### Example Workflow:
-If the **latest CP release is 10.9.6** and the branch pom is `10.9.7-SNAPSHOT`:
+If the **latest CP release on the branch is 10.9.6**:
 
 1. Developer works locally by building from source
 2. Developer needs to unblock their team with a critical fix
 3. Developer thoroughly tests their changes
 4. Developer merges to the release branch
 5. Semaphore pipeline runs and completes successfully
-6. Developer triggers the "Release incremental f/w version" promotion → `10.9.7-1` is created, tagged `v10.9.7-1`, and deployed to internal CodeArtifact
+6. Developer triggers the "Release incremental f/w version" promotion → `10.9.6-1` is created, tagged `v10.9.6-1`, and deployed to internal CodeArtifact
 7. Other teams can now use:
    - `10.9.6` (latest CP version, from packages.confluent.io)
-   - `10.9.7-1` (with the critical fix, from internal CodeArtifact)
+   - `10.9.6-1` (with the critical fix, from internal CodeArtifact)
 8. Next official CP release will be `10.9.7`
 9. Once `10.9.7` is released the pom moves to `10.9.8-SNAPSHOT`, and future incremental versions will be `10.9.8-1`, `10.9.8-2`, etc.


### PR DESCRIPTION
#1680 changed the incremental base from the pom's development version to the latest release on the branch's line. The doc still described the old behaviour.

| | doc said | actual |
|---|---|---|
| base | pom's upcoming version → `10.9.7-N` | latest release on the line → `10.9.6-N` |
| ordering | `10.9.7-1` sorts *after* `10.9.7` | `10.9.6 < 10.9.6-1 < 10.9.7` |
| no release on line | not mentioned | promotion fails, and says which version must ship first |

Updated the format examples, the promotion steps, the lifecycle diagram, the worked example and the CodeArtifact listing command to match. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
