### PR TITLE
Revert "Fix gated array element failures and add bytea[]/uuid[] support for PostgreSQL (#1677)"

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -54,7 +54,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -154,7 +153,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   static final String TIME_TYPE_NAME = "time";
   static final String TIMESTAMP_TYPE_NAME = "timestamp";
   static final String TIMESTAMPTZ_TYPE_NAME = "timestamptz";
-  static final String BYTEA_TYPE_NAME = "bytea";
 
   /** pgjdbc reports an array type as its element name with this prefix: hstore[] is _hstore. */
   static final String ARRAY_TYPE_PREFIX = "_";
@@ -193,10 +191,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
           UUID_TYPE_NAME
       ))
   );
-
-  private static final String COMPLEX_ARRAY_ELEMENT_DISABLED =
-      "Cannot write an array of %s into column %s while %s is false; set it to true to map "
-          + "complex column types.";
 
   /**
    * Create a new dialect instance with the given connector configuration.
@@ -626,11 +620,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       case "bool":
       case "boolean":
         return Schema.OPTIONAL_BOOLEAN_SCHEMA;
-      case BYTEA_TYPE_NAME:
-        return Schema.OPTIONAL_BYTES_SCHEMA;
-      case UUID_TYPE_NAME:
-        // Rendered as text, matching the scalar uuid mapping.
-        return Schema.OPTIONAL_STRING_SCHEMA;
       case "numeric":
       case "decimal":
         // Per-value scale carried via VariableScaleDecimal (array typmod is -1 in JDBC metadata).
@@ -710,10 +699,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Read a PostgreSQL array column into a Connect list. The shared handling — SQL NULL, skipping
-   * multi-dimensional columns (see {@link #isMultiDimensional(Object[])}), and freeing the
-   * array — lives here. Temporal elements are decoded via the element {@link ResultSet} so each
-   * can honor the configured {@code db.timezone}; all other elements come straight from
-   * {@code getArray()}.
+   * multi-dimensional columns (see {@link #isMultiDimensional(Object[])}), and freeing the array —
+   * lives here. Temporal elements are decoded via the element {@link ResultSet} so each can honor
+   * the configured {@code db.timezone}; all other elements come straight from {@code getArray()}.
    */
   private List<Object> readArray(ResultSet rs, int col, ColumnId columnId, String elementType)
       throws SQLException {
@@ -754,7 +742,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Map elements the driver already returns as the target Java type into a Connect list (nulls
-   * preserved). Used for primitive, bytea, uuid, Json and VariableScaleDecimal elements.
+   * preserved). Used for primitive, Json and VariableScaleDecimal elements.
    */
   private static List<Object> readMappedElements(Object[] elements, String elementType) {
     List<Object> out = new ArrayList<>(elements.length);
@@ -766,8 +754,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Convert a single non-temporal array element to its Connect value: VariableScaleDecimal structs
-   * from the element BigDecimal, raw text for Json and uuid, and primitives — including bytea,
-   * already a {@code byte[]} — passed through as-is.
+   * from the element BigDecimal, Json from the raw JSON text, and primitives passed through as-is.
    */
   private static Object mapArrayElement(String elementType, Object element) {
     switch (elementType) {
@@ -777,10 +764,9 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
             VariableScaleDecimal.optionalSchema(), (BigDecimal) element);
       case JSON_TYPE_NAME:
       case JSONB_TYPE_NAME:
-      case UUID_TYPE_NAME:
+        // Raw JSON text; toString() covers both String and PGobject.
         return element.toString();
       default:
-        // Primitives and bytea (already a byte[]) pass through.
         return element;
     }
   }
@@ -864,16 +850,11 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    * Whether the elements are themselves arrays — a multi-dimensional column like {@code int[][]}.
    * Postgres allows these, but JDBC reports the same type name as 1-D, so they are only
    * detectable from values; with no 1-D Connect ARRAY schema, callers skip them, returning null.
-   *
-   * <p>Tested as an object array rather than any array: {@code bytea} is the one element type whose
-   * value is itself a {@code byte[]}, and its primitive component keeps it out of {@code Object[]}
-   * while a real {@code bytea[][]} still nests. Every other decoder yields a reference array, so
-   * the same question is correct for all of them.
    */
   private static boolean isMultiDimensional(Object[] elements) {
     for (Object element : elements) {
       if (element != null) {
-        return element instanceof Object[];
+        return element.getClass().isArray();
       }
     }
     return false;
@@ -1046,46 +1027,20 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Whether an array field's elements are ones {@link #bindArray} cannot write, so no column type
-   * is advertised: a nested array, or any element under {@code timestamp.fields.list}, which
-   * selects TIMESTAMP by field name but has no binding for arrays. Advertising these would let
-   * auto-create build a column every insert then fails on.
+   * is advertised: a nested array, a plain BYTES element, or any element under
+   * {@code timestamp.fields.list}, which selects TIMESTAMP by field name but has no binding for
+   * arrays. Advertising these would let auto-create build a column every insert then fails on.
    */
   private boolean isUnbindableArrayElement(SinkRecordField field) {
     Schema element = field.schema().valueSchema();
     if (element.type() == Schema.Type.ARRAY) {
       return true;
     }
-    // BYTES binds only through the complex-types path, so a named one no binding claims — a custom
-    // logical type, say — would otherwise advertise a bytea[] column every insert then fails on.
-    if (element.type() == Schema.Type.BYTES && arrayElementBinding(element, field.name()) == null) {
+    if (element.type() == Schema.Type.BYTES && element.name() == null) {
       return true;
     }
     return config instanceof JdbcSinkConfig
         && config.getList(JdbcSinkConfig.TIMESTAMP_FIELDS_LIST).contains(field.name());
-  }
-
-  /**
-   * Whether an element is written only by {@link #arrayElementBinding(Schema, String)}: a
-   * bytea-bound plain element the complex-types path would bind, other than Json.
-   */
-  private boolean isComplexArrayElement(Schema element, String fieldName) {
-    // Derived from the binding rather than an enumerated name list, so any element the complex
-    // types would write is refused when they are off. Json is the deliberate exception: it is
-    // STRING-based and degrades losslessly to text[].
-    return !Json.LOGICAL_NAME.equals(element.name())
-        && arrayElementBinding(element, fieldName) != null;
-  }
-
-  /**
-   * The failure for an array element the complex types would bind while the feature is off.
-   * Shared by the DDL and bind paths for one actionable message. Not a DDL failure: the flag is
-   * off for the whole connector, so no record can succeed and a batch split would find nothing.
-   */
-  private static ConnectException complexArrayElementDisabledError(
-      Schema element, String fieldName) {
-    return new ConnectException(String.format(COMPLEX_ARRAY_ELEMENT_DISABLED,
-        element.name() == null ? element.type() : element.name(),
-        fieldName, JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
   }
 
   /**
@@ -1160,23 +1115,16 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return "TEXT";
       case BYTES:
         return "BYTEA";
-      case ARRAY: {
-        Schema element = field.schema().valueSchema();
-        // Unbindable first: enabling the feature cannot help an element nothing can write, so
-        // advising it would only lead to a second and less helpful failure.
+      case ARRAY:
         if (isUnbindableArrayElement(field)) {
           return super.getSqlType(field);
         }
-        if (!complexTypesEnabled() && isComplexArrayElement(element, field.name())) {
-          throw complexArrayElementDisabledError(element, field.name());
-        }
         SinkRecordField childField = new SinkRecordField(
-            element,
+            field.schema().valueSchema(),
             field.name(),
             field.isPrimaryKey()
         );
         return getSqlType(childField) + "[]";
-      }
       case MAP:
         if (isStringToStringMap(field.schema()) && complexTypesEnabled()) {
           return hstoreTypeNameOrFail(field.name());
@@ -1367,8 +1315,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   /**
    * Bind a Connect ARRAY value to a native PostgreSQL array parameter. When complex types are
-   * enabled, element types with a dedicated PostgreSQL array type (bytea, hstore, json, numeric and
-   * the temporals) are resolved by {@link #arrayElementBinding(Schema, String)} and bound via
+   * enabled, element types with a dedicated PostgreSQL array type (json, numeric and the
+   * temporals) are resolved by {@link #arrayElementBinding(Schema, String)} and bound via
    * {@code createArrayOf}; any other (primitive) element type falls back to the pre-existing
    * {@link #maybeBindPrimitiveArray}. Returns false if the element type is not handled here.
    */
@@ -1381,10 +1329,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
   ) throws SQLException {
     Collection<?> values = arrayValueCollection(value);
     Schema elementSchema = schema.valueSchema();
-    if (!complexTypesEnabled() && isComplexArrayElement(elementSchema, fieldName)) {
-      // The primitive fallback would fail on the element's Java type rather than say why.
-      throw complexArrayElementDisabledError(elementSchema, fieldName);
-    }
     ArrayElementBinding binding =
         complexTypesEnabled() ? arrayElementBinding(elementSchema, fieldName) : null;
     if (binding == null) {
@@ -1434,9 +1378,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     if (isStringToStringMap(elementSchema)) {
       return new ArrayElementBinding(
           hstoreTypeNameOrFail(fieldName), PostgreSqlDatabaseDialect::hstoreArrayFor);
-    }
-    if (elementSchema.type() == Schema.Type.BYTES && elementSchema.name() == null) {
-      return new ArrayElementBinding(BYTEA_TYPE_NAME, PostgreSqlDatabaseDialect::byteArrayFor);
     }
     String elementName = elementSchema.name();
     if (elementName != null) {
@@ -1507,23 +1448,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
             : VariableScaleDecimal.toLogical(
                 (Struct) o))
         .toArray(BigDecimal[]::new);
-  }
-
-  /**
-   * Decode a collection of Connect BYTES elements into a {@code byte[][]} for binding into a native
-   * {@code bytea[]} column. Connect permits either representation. Null elements are preserved.
-   */
-  private static Object[] byteArrayFor(Collection<?> valueCollection) {
-    return valueCollection.stream()
-        .map(o -> o == null ? null : o instanceof ByteBuffer ? bytesOf((ByteBuffer) o) : (byte[]) o)
-        .toArray(byte[][]::new);
-  }
-
-  private static byte[] bytesOf(ByteBuffer buffer) {
-    ByteBuffer slice = buffer.slice();
-    byte[] bytes = new byte[slice.remaining()];
-    slice.get(bytes);
-    return bytes;
   }
 
   /**
@@ -1628,8 +1552,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
    *
    * <p>This method returns a blank string except for those column types that require casting
    * when set with literal values. For example, a column of type {@code uuid} must be cast when
-   * being bound with a {@code varchar} literal, since a UUID value cannot be bound directly. The
-   * array of such a type needs the same cast, so a {@code uuid[]} column yields {@code ::uuid[]}.
+   * being bound with with a {@code varchar} literal, since a UUID value cannot be bound directly.
    *
    * @param tableDefn the table definition; may be null if unknown
    * @param columnId  the column within the table; may not be null
@@ -1641,8 +1564,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
       if (defn != null && defn.typeName() != null) {
         String typeName = defn.typeName(); // database-specific
         if (!complexTypesEnabled()) {
-          // Both gates off: the hstore cast, the array cast, and the local-name match are all new,
-          // so this is the pre-feature form — scalar cast types matched on the raw name only.
+          // The hstore cast and the local-name match are both new, so off is the pre-feature form.
           String rawName = typeName.toLowerCase();
           return CAST_TYPES.contains(rawName) ? "::" + rawName : "";
         }
@@ -1653,11 +1575,6 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         }
         if (CAST_TYPES.contains(localName)) {
           return "::" + localName;
-        }
-        // The array of a cast type needs the same cast, e.g. text[] into a uuid[] column.
-        if (localName.startsWith(ARRAY_TYPE_PREFIX)
-            && CAST_TYPES.contains(localName.substring(ARRAY_TYPE_PREFIX.length()))) {
-          return "::" + localName.substring(ARRAY_TYPE_PREFIX.length()) + "[]";
         }
       }
     }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -41,7 +41,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.JDBCType;
@@ -61,7 +60,6 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -364,50 +362,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertEquals("", dialect.valueTypeCast(tableDefn, dateColumn));
     // The cast that turns the bound JSON text into jsonb server-side.
     assertEquals("::jsonb", dialect.valueTypeCast(tableDefn, jsonbColumn));
-  }
-
-  /**
-   * The array of a cast type needs the same cast: a uuid[] source column becomes a Connect
-   * ARRAY&lt;STRING&gt; and binds as text[], which only reaches a uuid[] column through
-   * {@code ::uuid[]}.
-   */
-  @Test
-  public void shouldComputeValueTypeCastForArrayColumns() {
-    PostgreSqlDatabaseDialect enabled = complexTypesSinkDialect();
-    TableDefinition tableDefn = arrayCastColumns();
-
-    assertEquals("::uuid[]",
-        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidArray").id()));
-    assertEquals("::jsonb[]",
-        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
-    assertEquals("",
-        enabled.valueTypeCast(tableDefn, tableDefn.definitionForColumn("textArray").id()));
-  }
-
-  /**
-   * The array cast is behind the flag like the rest of the feature, so with it off a text[] reaches
-   * a uuid[] column uncast and PostgreSQL rejects it, exactly as before the feature. The scalar
-   * cast types are untouched, since those pre-date it.
-   */
-  @Test
-  public void shouldNotCastArrayColumnsWhenComplexTypesDisabled() {
-    TableDefinition tableDefn = arrayCastColumns();
-
-    assertEquals("",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidArray").id()));
-    assertEquals("",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("jsonbArray").id()));
-    assertEquals("a pre-feature scalar cast type must still be cast with the flag off", "::uuid",
-        dialect.valueTypeCast(tableDefn, tableDefn.definitionForColumn("uuidScalar").id()));
-  }
-
-  private TableDefinition arrayCastColumns() {
-    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
-    builder.withColumn("uuidArray").type("_uuid", JDBCType.ARRAY, Object.class);
-    builder.withColumn("jsonbArray").type("_jsonb", JDBCType.ARRAY, Object.class);
-    builder.withColumn("textArray").type("_text", JDBCType.ARRAY, Object.class);
-    builder.withColumn("uuidScalar").type("uuid", JDBCType.OTHER, Object.class);
-    return builder.build();
   }
 
   @Test
@@ -1628,8 +1582,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
     assertArrayElement("_float4", Type.FLOAT32, null);
     assertArrayElement("_float8", Type.FLOAT64, null);
     assertArrayElement("_bool", Type.BOOLEAN, null);
-    assertArrayElement("_bytea", Type.BYTES, null);
-    assertArrayElement("_uuid", Type.STRING, null);
     assertArrayElement("_numeric", Type.STRUCT, VariableScaleDecimal.LOGICAL_NAME);
     assertArrayElement("_json", Type.STRING, Json.LOGICAL_NAME);
     assertArrayElement("_jsonb", Type.STRING, Json.LOGICAL_NAME);
@@ -1654,7 +1606,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void shouldSkipUnsupportedArrayElementTypes() {
-    // inet[]/money[] are not in the supported element set, so the column is skipped.
+    // uuid[]/inet[]/money[] are not in the supported element set, so the column is skipped.
+    assertNull(sourceFieldSchema(complexTypesDialect(), Types.ARRAY, "_uuid"));
     assertNull(sourceFieldSchema(complexTypesDialect(), Types.ARRAY, "_inet"));
     assertNull(sourceFieldSchema(complexTypesDialect(), Types.ARRAY, "_money"));
   }
@@ -1800,9 +1753,12 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void shouldNotMapUnbindableArrayElementsToSqlType() {
     PostgreSqlDatabaseDialect sink = complexTypesSinkDialect();
     Schema nested = arraySchema(arraySchema(Schema.OPTIONAL_INT32_SCHEMA));
+    Schema bytes = arraySchema(Schema.OPTIONAL_BYTES_SCHEMA);
 
     assertThrows(ConnectException.class,
         () -> sink.getSqlType(new SinkRecordField(nested, "col", false)));
+    assertThrows(ConnectException.class,
+        () -> sink.getSqlType(new SinkRecordField(bytes, "col", false)));
     assertEquals("a named BYTES element that does bind is still mapped", "DECIMAL[]",
         sink.getSqlType(
             new SinkRecordField(arraySchema(Decimal.builder(2).optional().build()), "col", false)));
@@ -1913,119 +1869,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         mock(ColumnDefinition.class), "field");
 
     verify(statement).setObject(eq(1), any(Integer[].class), eq(Types.ARRAY));
-  }
-
-  /**
-   * A {@code bytea} element is itself a {@code byte[]}, so the multi-dimensional guard — which
-   * treats any array-valued element as nested — must not fire on it and null the whole column.
-   */
-  @Test
-  public void shouldReadByteaArrayElements() throws Exception {
-    byte[] first = new byte[]{1, 2};
-    byte[] second = new byte[]{3};
-    ResultSet rs = arrayResultSet(new byte[][]{first, null, second});
-
-    Object value = arrayColumnConverter("_bytea").convert(rs);
-
-    assertEquals(Arrays.asList(first, null, second), value);
-  }
-
-  /** Only a nested Object[] is multi-dimensional for bytea, i.e. a {@code bytea[][]} column. */
-  @Test
-  public void shouldSkipMultiDimensionalByteaArrayElements() throws Exception {
-    ResultSet rs = arrayResultSet(new byte[][][]{{{1, 2}}, {{3}}});
-
-    Object value = arrayColumnConverter("_bytea").convert(rs);
-
-    assertEquals(Arrays.asList(null, null), value);
-  }
-
-  /** pgjdbc yields java.util.UUID elements; the scalar path emits canonical text, so must this. */
-  @Test
-  public void shouldReadUuidArrayElementsAsText() throws Exception {
-    UUID uuid = UUID.fromString("0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f");
-    ResultSet rs = arrayResultSet(new UUID[]{uuid, null});
-
-    Object value = arrayColumnConverter("_uuid").convert(rs);
-
-    assertEquals(Arrays.asList(uuid.toString(), null), value);
-  }
-
-  @Test
-  public void shouldBindByteaArrayAsNativeByteaArray() throws Exception {
-    byte[] first = new byte[]{1, 2};
-    verifyArrayBind(Schema.OPTIONAL_BYTES_SCHEMA, Arrays.asList(first, null), "bytea",
-        new Object[]{first, null});
-  }
-
-  /** Connect BYTES permits a ByteBuffer, which must be unwrapped without consuming the caller's. */
-  @Test
-  public void shouldBindByteBufferArrayAsNativeByteaArray() throws Exception {
-    PreparedStatement statement = mock(PreparedStatement.class);
-    Connection connection = mock(Connection.class);
-    when(statement.getConnection()).thenReturn(connection);
-    ByteBuffer buffer = ByteBuffer.wrap(new byte[]{7, 8});
-
-    complexTypesSinkDialect().bindField(statement, 7,
-        SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build(),
-        Collections.singletonList(buffer), mock(ColumnDefinition.class), "field");
-
-    ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
-    verify(connection).createArrayOf(eq("bytea"), captor.capture());
-    assertTrue("bytea[] must be bound as byte[][]", captor.getValue() instanceof byte[][]);
-    assertArrayEquals(new byte[]{7, 8}, (byte[]) captor.getValue()[0]);
-    assertEquals("the source buffer must not be drained", 2, buffer.remaining());
-  }
-
-  @Test
-  public void shouldMapByteaArrayToSqlType() {
-    Schema bytes = arraySchema(Schema.OPTIONAL_BYTES_SCHEMA);
-    assertEquals("BYTEA[]",
-        complexTypesSinkDialect().getSqlType(new SinkRecordField(bytes, "col", false)));
-
-    PostgreSqlDatabaseDialect disabled =
-        new PostgreSqlDatabaseDialect(sinkConfigWithUrl("jdbc:postgresql://something"));
-    assertThrows(ConnectException.class,
-        () -> disabled.getSqlType(new SinkRecordField(bytes, "col", false)));
-  }
-
-  /**
-   * A temporal element carries {@code java.util.Date} values, which the primitive fallback would
-   * try to store in a {@code Long[]}/{@code Integer[]} and fail with a bare ArrayStoreException.
-   * With the flag off the column must not be advertised at all, and a bind against a pre-existing
-   * column must name the config rather than surface the JVM error.
-   */
-  @Test
-  public void temporalArraysAreRejectedWhenComplexTypesDisabled() {
-    PostgreSqlDatabaseDialect disabled =
-        new PostgreSqlDatabaseDialect(sinkConfigWithUrl("jdbc:postgresql://something"));
-    List<Schema> elements = Arrays.asList(
-        Date.builder().optional().build(),
-        Time.builder().optional().build(),
-        Timestamp.builder().optional().build(),
-        Decimal.builder(2).optional().build());
-
-    for (Schema element : elements) {
-      ConnectException fromDdl = assertThrows("no column type for " + element.name(),
-          ConnectException.class,
-          () -> disabled.getSqlType(new SinkRecordField(arraySchema(element), "col", false)));
-
-      ConnectException thrown = assertThrows(ConnectException.class,
-          () -> disabled.bindField(mock(PreparedStatement.class), 1,
-              arraySchema(element), Collections.singletonList(new java.util.Date(0L)),
-              mock(ColumnDefinition.class), "col"));
-      assertTrue("message should name the config, but was: " + thrown.getMessage(),
-          thrown.getMessage().contains(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE));
-
-      // The flag is off for the whole connector, so no record can succeed and there is nothing for
-      // a batch split to find: both paths fail the task rather than carrying the DDL exception's
-      // per-record handling. Asserted on the exact class, since TableAlterOrCreateException
-      // extends ConnectException and would satisfy the checks above unnoticed.
-      assertEquals("the DDL path must not carry a table-alter exception",
-          ConnectException.class, fromDdl.getClass());
-      assertEquals("the bind path must not carry a table-alter exception",
-          ConnectException.class, thrown.getClass());
-    }
   }
 
   /**
@@ -2637,11 +2480,6 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
     ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
     verify(connection).createArrayOf(eq(expectedPgType), captor.capture());
-    if ("bytea".equals(expectedPgType)) {
-      // The component type is the whole correctness condition: pgjdbc rejects a byte[] nested
-      // in an Object[], so comparing elements alone would pass on a byte[][] and an Object[].
-      assertTrue("bytea[] must be bound as byte[][]", captor.getValue() instanceof byte[][]);
-    }
     assertEquals(Arrays.asList(expectedElements), Arrays.asList(captor.getValue()));
     verify(statement).setArray(7, boundArray);
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -76,7 +76,6 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -2250,9 +2249,8 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
    */
   @Test
   public void testMultiDimensionalArrayEmitsNullPerElement() throws Exception {
-    execute("CREATE TABLE " + tableName + "(id int, i int4[], t text[], ba bytea[])",
-        "INSERT INTO " + tableName + " VALUES (1, '{{1,2},{3,4}}', '{{a,b},{c,d}}', "
-            + "ARRAY[ARRAY['\\x01'::bytea], ARRAY['\\x02'::bytea]])");
+    execute("CREATE TABLE " + tableName + "(id int, i int4[], t text[])",
+        "INSERT INTO " + tableName + " VALUES (1, '{{1,2},{3,4}}', '{{a,b},{c,d}}')");
 
     Struct row = pollOneRow(complexTypesSourceProps("postgres"));
 
@@ -2260,70 +2258,22 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         Arrays.asList(null, null)).assertFor(row);
     new SchemaAndValueField("t", arrayOf(Schema.OPTIONAL_STRING_SCHEMA),
         Arrays.asList(null, null)).assertFor(row);
-    // bytea elements are byte[] themselves, so only this genuinely nested case must null out.
-    new SchemaAndValueField("ba", arrayOf(Schema.OPTIONAL_BYTES_SCHEMA),
-        Arrays.asList(null, null)).assertFor(row);
   }
 
   /** An unsupported element type drops its column and leaves neighbouring columns untouched. */
   @Test
   public void testUnsupportedArrayElementTypesAreSkipped() throws Exception {
-    execute("CREATE TABLE " + tableName + "(id int, n inet[], m money[], i int4[])",
-        "INSERT INTO " + tableName + " VALUES (1, ARRAY['10.0.0.1'::inet], "
-            + "ARRAY[1.23::money], '{7}')");
+    execute("CREATE TABLE " + tableName + "(id int, u uuid[], ba bytea[], i int4[])",
+        "INSERT INTO " + tableName + " VALUES (1, "
+            + "ARRAY['0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f'::uuid], "
+            + "ARRAY['\\x0102'::bytea], '{7}')");
 
     Struct row = pollOneRow(complexTypesSourceProps("postgres"));
 
-    assertFieldAbsent(row, "n");
-    assertFieldAbsent(row, "m");
+    assertFieldAbsent(row, "u");
+    assertFieldAbsent(row, "ba");
     new SchemaAndValueField("i", arrayOf(Schema.OPTIONAL_INT32_SCHEMA),
         Collections.singletonList(7)).assertFor(row);
-  }
-
-  /**
-   * {@code bytea[]} elements stay bytes and {@code uuid[]} elements become canonical text, matching
-   * the scalar mappings of the same types.
-   */
-  @Test
-  public void testByteaAndUuidArraysEmitTypedElements() throws Exception {
-    execute("CREATE TABLE " + tableName + "(id int, ba bytea[], u uuid[])",
-        "INSERT INTO " + tableName + " VALUES (1, "
-            + "ARRAY['\\x0102'::bytea, NULL, '\\x'::bytea], "
-            + "ARRAY['0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f'::uuid, NULL])");
-
-    Struct row = pollOneRow(complexTypesSourceProps("postgres"));
-
-    assertEquals(arrayOf(Schema.OPTIONAL_BYTES_SCHEMA), row.schema().field("ba").schema());
-    List<?> bytes = (List<?>) row.get("ba");
-    assertEquals(3, bytes.size());
-    assertArrayEquals(new byte[]{1, 2}, (byte[]) bytes.get(0));
-    assertNull(bytes.get(1));
-    assertArrayEquals(new byte[0], (byte[]) bytes.get(2));
-
-    new SchemaAndValueField("u", arrayOf(Schema.OPTIONAL_STRING_SCHEMA),
-        Arrays.asList("0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f", null)).assertFor(row);
-  }
-
-  /**
-   * Pin the driver contract the mocked unit tests assume: pgjdbc returns {@code byte[][]} for
-   * bytea[] — array-valued elements the multi-dimensional guard must not mistake for nesting —
-   * and {@code UUID[]} for uuid[].
-   */
-  @Test
-  public void testDriverArrayElementClasses() throws Exception {
-    execute("CREATE TABLE " + tableName + "(id int, ba bytea[], u uuid[])",
-        "INSERT INTO " + tableName + " VALUES (1, ARRAY['\\x01'::bytea], "
-            + "ARRAY['0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f'::uuid])");
-
-    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
-         Statement s = c.createStatement();
-         ResultSet rs = s.executeQuery("SELECT ba, u FROM " + tableName)) {
-      assertTrue(rs.next());
-      assertTrue("pgjdbc must return byte[][] for bytea[]",
-          rs.getArray(1).getArray() instanceof byte[][]);
-      assertTrue("pgjdbc must return UUID[] for uuid[]",
-          rs.getArray(2).getArray() instanceof UUID[]);
-    }
   }
 
   /** Backward compatibility: with the default flag an array column is dropped, as before. */
@@ -2472,7 +2422,6 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .field("a_time", arrayOf(Time.builder().optional().build()))
         .field("a_ts", arrayOf(Timestamp.builder().optional().build()))
         .field("a_hstore", arrayOf(hstoreMap))
-        .field("a_bytes", arrayOf(Schema.OPTIONAL_BYTES_SCHEMA))
         .build();
 
     java.util.Date epoch = new java.util.Date(0L);
@@ -2492,8 +2441,7 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         .put("a_time", Collections.singletonList(epoch))
         .put("a_ts", Collections.singletonList(epoch))
         .put("a_hstore", Collections.singletonList(
-            Collections.singletonMap("env", "prod")))
-        .put("a_bytes", Collections.singletonList(new byte[]{1, 2})));
+            Collections.singletonMap("env", "prod"))));
 
     waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
         TimeUnit.MINUTES.toMillis(2));
@@ -2513,66 +2461,9 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
     expectedUdtNames.put("a_time", "_time");
     expectedUdtNames.put("a_ts", "_timestamp");
     expectedUdtNames.put("a_hstore", "_hstore");
-    expectedUdtNames.put("a_bytes", "_bytea");
     for (Map.Entry<String, String> entry : expectedUdtNames.entrySet()) {
       assertEquals("element type of " + entry.getKey(), entry.getValue(),
           columnUdtName(tableName, entry.getKey()));
-    }
-  }
-
-  /**
-   * With the flag off a temporal element must fail with a message naming the config, not blow up
-   * inside the driver. Before the gate, auto-create built a {@code timestamp[]} column and the bind
-   * then raised a bare ArrayStoreException storing {@code java.util.Date} values in a
-   * {@code Long[]}. The column must not be created either, since no insert could populate it.
-   */
-  @Test
-  public void testTemporalArrayFailsWhenComplexTypesDisabled() throws Exception {
-    props.put(JdbcSinkConfig.AUTO_CREATE, "true");
-    props.put(MAX_RETRIES, "0");
-    connect.configureConnector("jdbc-sink-connector", props);
-    waitForConnectorToStart("jdbc-sink-connector", 1);
-
-    final Schema schema = SchemaBuilder.struct().name("com.example.Timestamps")
-        .field("a_ts", arrayOf(Timestamp.builder().optional().build()))
-        .build();
-    produceRecord(schema, new Struct(schema)
-        .put("a_ts", Collections.singletonList(new java.util.Date(0L))));
-
-    assertTasksFailedWithTrace("jdbc-sink-connector", 1,
-        JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE);
-    assertTableAbsent(tableName);
-  }
-
-  /**
-   * The bind half of the same gate, for a column the connector did not create: a pre-existing
-   * {@code timestamp[]} must be refused with the same message rather than an ArrayStoreException.
-   */
-  @Test
-  public void testTemporalArrayBindFailsIntoExistingColumnWhenComplexTypesDisabled()
-      throws Exception {
-    execute("CREATE TABLE " + tableName + "(a_ts timestamp[])");
-    props.put(MAX_RETRIES, "0");
-    connect.configureConnector("jdbc-sink-connector", props);
-    waitForConnectorToStart("jdbc-sink-connector", 1);
-
-    final Schema schema = SchemaBuilder.struct().name("com.example.Timestamps")
-        .field("a_ts", arrayOf(Timestamp.builder().optional().build()))
-        .build();
-    produceRecord(schema, new Struct(schema)
-        .put("a_ts", Collections.singletonList(new java.util.Date(0L))));
-
-    assertTasksFailedWithTrace("jdbc-sink-connector", 1,
-        JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE);
-  }
-
-  /** Assert no table was auto-created, i.e. no unwritable column was advertised. */
-  private void assertTableAbsent(String table) throws SQLException {
-    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
-         Statement s = c.createStatement();
-         ResultSet rs = s.executeQuery("SELECT 1 FROM information_schema.tables "
-             + "WHERE table_name = '" + table + "'")) {
-      assertTrue("table " + table + " must not have been created", !rs.next());
     }
   }
 
@@ -2662,104 +2553,6 @@ public class PostgresDatatypeIT extends BaseConnectorIT {
         "{1,2}", "{1,2,42}", "{100,200}", "{1.5,2.5}", "{1.25,2.5}", "{t,f}", "{a,b}", "{ab,cd}",
         // char(10) padding survives; Postgres quotes array elements containing spaces.
         "{\"cone      \",\"ctwo      \"}");
-  }
-
-  /**
-   * {@code bytea[]} end to end, including an empty and a NULL element, into a native bytea[].
-   */
-  @Test
-  public void testByteaArrayRoundTrip() throws Exception {
-    execute("CREATE TABLE " + SRC_TABLE + "(id int PRIMARY KEY, ba bytea[])",
-        "INSERT INTO " + SRC_TABLE + " VALUES (1, "
-            + "ARRAY['\\x0102'::bytea, NULL, '\\x'::bytea])");
-
-    runRoundTrip(1,
-        Collections.singletonMap(
-            JdbcSourceConnectorConfig.SQL_COMPLEX_TYPES_ENABLE_CONFIG, "true"),
-        Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-
-    assertEquals("bytea[] must land in a native bytea[] column",
-        "_bytea", columnUdtName(DST_TABLE, "ba"));
-    assertDestArrayText("ba::text", "{\"\\\\x0102\",NULL,\"\\\\x\"}");
-  }
-
-  /**
-   * The array cast is behind {@code sql.complex.types.enable} like the rest of the feature, so with
-   * it off an ARRAY&lt;STRING&gt; is offered to a pre-existing {@code uuid[]} column uncast and
-   * PostgreSQL refuses it — the pre-feature behaviour. Paired with the flag-on case below, this is
-   * what keeps an upgrade from changing anything an existing pipeline can observe.
-   */
-  @Test
-  public void testStringArrayIntoUuidArrayColumnIsRefusedWhenComplexTypesDisabled()
-      throws Exception {
-    execute("CREATE TABLE " + tableName + "(name text, ids uuid[])");
-    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
-    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "false");
-    props.put(MAX_RETRIES, "0");
-    connect.configureConnector("jdbc-sink-connector", props);
-    waitForConnectorToStart("jdbc-sink-connector", 1);
-
-    produceRecord(TEXT_IDS_SCHEMA, new Struct(TEXT_IDS_SCHEMA)
-        .put("name", "web-1")
-        .put("ids", Collections.singletonList(CAST_UUID)));
-
-    // PostgreSQL's own rejection, because no cast was emitted.
-    assertTasksFailedWithTrace("jdbc-sink-connector", 1, "is of type uuid[]");
-  }
-
-  /** With the feature on the same record is cast and lands as real uuids. */
-  @Test
-  public void testStringArrayIsCastIntoUuidArrayColumnWhenComplexTypesEnabled() throws Exception {
-    execute("CREATE TABLE " + tableName + "(name text, ids uuid[])");
-    props.put(JdbcSinkConfig.AUTO_CREATE, "false");
-    props.put(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true");
-    connect.configureConnector("jdbc-sink-connector", props);
-    waitForConnectorToStart("jdbc-sink-connector", 1);
-
-    produceRecord(TEXT_IDS_SCHEMA, new Struct(TEXT_IDS_SCHEMA)
-        .put("name", "web-1")
-        .put("ids", Collections.singletonList(CAST_UUID)));
-
-    waitForCommittedRecords("jdbc-sink-connector", Collections.singleton(tableName), 1, 1,
-        TimeUnit.MINUTES.toMillis(2));
-
-    assertEquals("_uuid", columnUdtName(tableName, "ids"));
-    try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection();
-         Statement st = c.createStatement();
-         ResultSet rs = st.executeQuery("SELECT ids::text FROM " + tableName)) {
-      assertTrue("destination table has no rows", rs.next());
-      assertEquals("{" + CAST_UUID + "}", rs.getString(1));
-    }
-  }
-
-  private static final String CAST_UUID = "0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f";
-
-  private static final Schema TEXT_IDS_SCHEMA = SchemaBuilder.struct()
-      .name("com.example.CastArrays")
-      .field("name", Schema.STRING_SCHEMA)
-      .field("ids", arrayOf(Schema.OPTIONAL_STRING_SCHEMA))
-      .build();
-
-  /**
-   * {@code uuid[]} has no Connect logical type, so it travels as ARRAY&lt;STRING&gt; and would
-   * auto-create text[]. Into a pre-existing uuid[] column it must still land as real uuids, which
-   * only the {@code ::uuid[]} cast makes possible.
-   */
-  @Test
-  public void testUuidArrayRoundTripIntoExistingUuidColumn() throws Exception {
-    String uuid = "0d3ec2e0-9c6a-4b1e-9f1a-7c3a2b5d6e7f";
-    execute("CREATE TABLE " + SRC_TABLE + "(id int PRIMARY KEY, u uuid[])",
-        "INSERT INTO " + SRC_TABLE + " VALUES (1, ARRAY['" + uuid + "'::uuid, NULL])",
-        "CREATE TABLE " + DST_TABLE + "(id int PRIMARY KEY, u uuid[])");
-
-    runRoundTrip(1,
-        Collections.singletonMap(
-            JdbcSourceConnectorConfig.SQL_COMPLEX_TYPES_ENABLE_CONFIG, "true"),
-        Collections.singletonMap(JdbcSinkConfig.SQL_COMPLEX_TYPES_ENABLE, "true"));
-
-    assertEquals("the pre-existing uuid[] column must be preserved",
-        "_uuid", columnUdtName(DST_TABLE, "u"));
-    assertDestArrayText("u::text", "{" + uuid + ",NULL}");
   }
 
   /**


### PR DESCRIPTION
## Problem
The "Additional Data Types for Postgres JDBC" feature (#1651 + #1676 + #1677) is being removed from the `10.9.x` maintenance line. It is a larger minor feature enhancement and will instead land on the upcoming `10.10` branch. `master` is intentionally left unchanged.

## Solution
Reverts **#1677 — "Fix gated array element failures and add bytea[]/uuid[] support for PostgreSQL"** (commit `3ac40d24de6c6764f9041a7ca440d3a0d5c2bd07`).

This is the **first** revert in a stack of three that together remove the whole feature from `10.9.x`:

| Merge order | PR | Reverts | Base |
| --- | --- | --- | --- |
| 1 (this PR) | #1684 | #1677 | `10.9.x` |
| 2 | #1683 | #1676 | `revert-1677-10.9.x` |
| 3 | #1682 | #1651 | `revert-1676-10.9.x` |

Single revert commit — 3 files changed, +31/−483 (exact inverse of #1677). Merge **#1684 → #1683 → #1682**; GitHub auto-retargets each next PR's base to `10.9.x` as the one below merges.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
Only `10.9.x`. `master` deliberately keeps the feature; it will be carried onto `10.10`.

## Test Strategy
Pure revert — restores the pre-#1677 state exactly; covered by the existing unit + integration suite.

##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Safe revert on `10.9.x`. The feature (#1651 + #1676 + #1677) will be re-introduced on `10.10`. To re-apply later: `git revert` this revert commit, or cherry-pick the original `3ac40d24`.
